### PR TITLE
fix: add coin type to init cmd

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -115,6 +115,8 @@ const (
 	Name          = "inscription"
 	EIP155ChainID = "9000"
 	Epoch         = "1"
+
+	CoinType = 60
 )
 
 // this line is used by starport scaffolding # stargate/wasm/app/enabledProposals

--- a/cmd/bfsd/cmd/config.go
+++ b/cmd/bfsd/cmd/config.go
@@ -1,0 +1,14 @@
+package cmd
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/bnb-chain/bfs/app"
+)
+
+func initSDKConfig() {
+	// Set and seal config
+	config := sdk.GetConfig()
+	config.SetCoinType(app.CoinType)
+	config.Seal()
+}

--- a/cmd/bfsd/cmd/root.go
+++ b/cmd/bfsd/cmd/root.go
@@ -103,8 +103,7 @@ func initRootCmd(
 	encodingConfig appparams.EncodingConfig,
 ) {
 	// Set config
-	cfg := sdk.GetConfig()
-	cfg.Seal()
+	initSDKConfig()
 
 	rootCmd.AddCommand(
 		genutilcli.InitCmd(app.ModuleBasics, app.DefaultNodeHome),


### PR DESCRIPTION
### Description

Add coin type  of ETH to the config when init the app cmd

### Rationale

In order to be consistent with BSC when generating address from mnemonic.

### Example

N/A

### Changes

Notable changes: 

* add coin type of ETH to init config
