### PR TITLE
release: prepare for v0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,16 @@
 # Changelog
 
+## v0.0.2 
+FEATURES
+* [\#11](https://github.com/bnb-chain/inscription/pull/11) feat: customize staking module for inscription 
+* [\#10](https://github.com/bnb-chain/inscription/pull/10) deployment: local setup scripts
+* [\#2](https://github.com/bnb-chain/inscription/pull/2) feat: add support for EIP712 and eth address standard r4r
+
+DEP
+* [\#3](https://github.com/bnb-chain/inscription/pull/3) dep: replace cosmos-sdk to inscription-cosmos-sdk v0.0.1(v0.46.4)
+
+BUG FIX
+* [\#9](https://github.com/bnb-chain/inscription/pull/9) fix: add coin type to init cmd
+
+DOCS
+* [\#1](https://github.com/bnb-chain/inscription/pull/1) docs: refine the readme with detailed introduction documentation

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@
 VERSION=$(shell git describe --tags)
 GIT_COMMIT=$(shell git rev-parse HEAD)
 GIT_COMMIT_DATE=$(shell git log -n1 --pretty='format:%cd' --date=format:'%Y%m%d')
-REPO=github.com/bnb-chain/bfs
-IMAGE_NAME=ghcr.io/bnb-chain/bfs
-REPO=github.com/bnb-chain/bfs
+REPO=github.com/bnb-chain/inscription
+IMAGE_NAME=ghcr.io/bnb-chain/inscription
+REPO=github.com/bnb-chain/inscription
 
 ldflags = -X $(REPO)/version.AppVersion=$(VERSION) \
           -X $(REPO)/version.GitCommit=$(GIT_COMMIT) \

--- a/go.mod
+++ b/go.mod
@@ -244,6 +244,6 @@ require (
 
 replace (
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk v0.46.4 => github.com/bnb-chain/inscription-cosmos-sdk v0.0.2-0.20221223062300-e235b25ee7e4
+	github.com/cosmos/cosmos-sdk v0.46.4 => github.com/bnb-chain/inscription-cosmos-sdk v0.0.2
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 )

--- a/go.sum
+++ b/go.sum
@@ -234,8 +234,8 @@ github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdn
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
-github.com/bnb-chain/inscription-cosmos-sdk v0.0.2-0.20221223062300-e235b25ee7e4 h1:F9avu+nmHhWatImWG0ur8crWlKg0ef4MXBn7vHFfYi0=
-github.com/bnb-chain/inscription-cosmos-sdk v0.0.2-0.20221223062300-e235b25ee7e4/go.mod h1:weE9S2ElFu9NlLz04FULp9w5lJSP//Eg04VMrrLMxQY=
+github.com/bnb-chain/inscription-cosmos-sdk v0.0.2 h1:0wnLTxUonaOt01jTittdw2jTJjIrR6oPEOtNj/7MqAU=
+github.com/bnb-chain/inscription-cosmos-sdk v0.0.2/go.mod h1:weE9S2ElFu9NlLz04FULp9w5lJSP//Eg04VMrrLMxQY=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/bradfitz/gomemcache v0.0.0-20170208213004-1952afaa557d/go.mod h1:PmM6Mmwb0LSuEubjR8N7PtNe1KxZLtOUHtbeikc5h60=


### PR DESCRIPTION
### Description
This is the first release of the inscription.

It includes two key features:
1. EIP721 signing schema support;
2. New staking mechanism;

### Rationale
Change Log

FEATURES
* [\#11](https://github.com/bnb-chain/inscription/pull/11) feat: customize staking module for inscription 
* [\#10](https://github.com/bnb-chain/inscription/pull/10) deployment: local setup scripts
* [\#2](https://github.com/bnb-chain/inscription/pull/2) feat: add support for EIP712 and eth address standard r4r

DEP
* [\#3](https://github.com/bnb-chain/inscription/pull/3) dep: replace cosmos-sdk to inscription-cosmos-sdk v0.0.1(v0.46.4)

BUG FIX
* [\#9](https://github.com/bnb-chain/inscription/pull/9) fix: add coin type to init cmd

DOCS
* [\#1](https://github.com/bnb-chain/inscription/pull/1) docs: refine the readme with detailed introduction documentation


### Example
No

### Changes
No
