### PR TITLE
feat: remove ValAddress and update EIP712 related functions

### DIFF
--- a/app/ante/ante_test.go
+++ b/app/ante/ante_test.go
@@ -47,8 +47,7 @@ func (suite *AnteTestSuite) TestAnteHandler() {
 		reCheckTx bool
 		expPass   bool
 	}{
-		// Based on EVMBackend.SendTransaction, for cosmos tx, forcing null for some fields except ExtensionOptions, Fee, MsgEthereumTx
-		// should be part of consensus
+		// ensure all msg type could pass test
 		{
 			"success - DeliverTx EIP712 signed Cosmos Tx with MsgSend",
 			func() sdk.Tx {
@@ -60,7 +59,7 @@ func (suite *AnteTestSuite) TestAnteHandler() {
 			}, false, false, true,
 		},
 		{
-			"success - DeliverTx EIP712 signed Cosmos Tx with DelegateMsg",
+			"success - DeliverTx EIP712 signed Cosmos Tx with MsgDelegate",
 			func() sdk.Tx {
 				from := acc.GetAddress()
 				gas := uint64(200000)
@@ -141,6 +140,28 @@ func (suite *AnteTestSuite) TestAnteHandler() {
 				amount := sdk.NewCoins(coinAmount)
 				gas := uint64(200000)
 				txBuilder := suite.CreateTestEIP712MsgEditValidator(from, privKey, "inscription_9000-1", gas, amount)
+				return txBuilder.GetTx()
+			}, false, false, true,
+		},
+		{
+			"success- DeliverTx EIP712 MsgSubmitProposalV1",
+			func() sdk.Tx {
+				from := acc.GetAddress()
+				coinAmount := sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20))
+				amount := sdk.NewCoins(coinAmount)
+				gas := uint64(200000)
+				txBuilder := suite.CreateTestEIP712TxBuilderMsgSubmitProposalV1(from, privKey, "inscription_9000-1", gas, amount)
+				return txBuilder.GetTx()
+			}, false, false, true,
+		},
+		{
+			"success- DeliverTx EIP712 MsgGrant",
+			func() sdk.Tx {
+				from := acc.GetAddress()
+				coinAmount := sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20))
+				amount := sdk.NewCoins(coinAmount)
+				gas := uint64(200000)
+				txBuilder := suite.CreateTestEIP712TxBuilderMsgGrant(from, privKey, "inscription_9000-1", gas, amount)
 				return txBuilder.GetTx()
 			}, false, false, true,
 		},
@@ -229,14 +250,10 @@ func (suite *AnteTestSuite) TestAnteHandler() {
 
 			suite.ctx = suite.ctx.WithIsCheckTx(tc.checkTx).WithIsReCheckTx(tc.reCheckTx)
 
-			// expConsumed := params.TxGasContractCreation + params.TxGas
 			_, err := suite.anteHandler(suite.ctx, tc.txFn(), false)
-
-			// suite.Require().Equal(consumed, ctx.GasMeter().GasConsumed())
 
 			if tc.expPass {
 				suite.Require().NoError(err)
-				// suite.Require().Equal(int(expConsumed), int(suite.ctx.GasMeter().GasConsumed()))
 			} else {
 				suite.Require().Error(err)
 			}

--- a/app/ante/utils_test.go
+++ b/app/ante/utils_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	sdkmath "cosmossdk.io/math"
-	"github.com/bnb-chain/bfs/app/params"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -23,17 +22,19 @@ import (
 	signingtypes "github.com/cosmos/cosmos-sdk/types/tx/signing"
 	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
 	sdkante "github.com/cosmos/cosmos-sdk/x/auth/ante"
+	"github.com/cosmos/cosmos-sdk/x/auth/signing"
+	"github.com/cosmos/cosmos-sdk/x/auth/tx"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	types2 "github.com/cosmos/cosmos-sdk/x/bank/types"
 	evtypes "github.com/cosmos/cosmos-sdk/x/evidence/types"
 	"github.com/cosmos/cosmos-sdk/x/feegrant"
-	types5 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
+	govtypesv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	types3 "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/evmos/ethermint/crypto/ethsecp256k1"
 	"github.com/evmos/ethermint/tests"
 	evmtypes "github.com/evmos/ethermint/x/evm/types"
-	"github.com/prysmaticlabs/prysm/crypto/bls"
 	"github.com/stretchr/testify/suite"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
@@ -43,10 +44,8 @@ import (
 
 	"github.com/bnb-chain/bfs/app"
 	"github.com/bnb-chain/bfs/app/ante"
-	"github.com/cosmos/cosmos-sdk/x/auth/signing"
-	"github.com/cosmos/cosmos-sdk/x/auth/tx"
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/evmos/ethermint/crypto/ethsecp256k1"
+	"github.com/bnb-chain/bfs/app/params"
+	"github.com/cosmos/cosmos-sdk/x/authz"
 )
 
 const genesisAccountPrivateKeyForTest = "02DCA3F2C6CDF541934FA043A0ADBD891968EC7B948691ABA0C3CACA59A5DAC753"
@@ -99,45 +98,38 @@ func (suite *AnteTestSuite) SetupTest() {
 func (suite *AnteTestSuite) CreateTestEIP712TxBuilderMsgSend(from sdk.AccAddress, priv cryptotypes.PrivKey, chainId string, gas uint64, gasAmount sdk.Coins) client.TxBuilder {
 	// Build MsgSend
 	recipient := tests.GenerateAddress().Bytes()
-	msgSend := types2.NewMsgSend(from, recipient, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdkmath.NewInt(1))))
+	msgSend := banktypes.NewMsgSend(from, recipient, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdkmath.NewInt(1))))
 	return suite.CreateTestEIP712CosmosTxBuilder(from, priv, chainId, gas, gasAmount, msgSend)
 }
 
 func (suite *AnteTestSuite) CreateTestEIP712TxBuilderMsgDelegate(from sdk.AccAddress, priv cryptotypes.PrivKey, chainId string, gas uint64, gasAmount sdk.Coins) client.TxBuilder {
 	// Build MsgSend
 	valEthAddr := tests.GenerateAddress()
-	valAddr := sdk.ValAddress(valEthAddr.Bytes())
-	msgSend := types3.NewMsgDelegate(from, valAddr, sdk.NewCoin(sdk.DefaultBondDenom, sdkmath.NewInt(20)))
+	valAddr := sdk.AccAddress(valEthAddr.Bytes())
+	msgSend := stakingtypes.NewMsgDelegate(from, valAddr, sdk.NewCoin(sdk.DefaultBondDenom, sdkmath.NewInt(20)))
 	return suite.CreateTestEIP712CosmosTxBuilder(from, priv, chainId, gas, gasAmount, msgSend)
 }
 
 func (suite *AnteTestSuite) CreateTestEIP712MsgCreateValidator(from sdk.AccAddress, priv cryptotypes.PrivKey, chainId string, gas uint64, gasAmount sdk.Coins) client.TxBuilder {
 	// Build MsgCreateValidator
-	valAddr := sdk.ValAddress(from.Bytes())
+	valAddr := sdk.AccAddress(from.Bytes())
 	privEd := ed25519.GenPrivKey()
-	addr1 := sdk.AccAddress(from.Bytes())
-	blsSecretKey, _ := bls.RandKey()
-	blsPk := hex.EncodeToString(blsSecretKey.PublicKey().Marshal())
-	msgCreate, err := types3.NewMsgCreateValidator(
+	msgCreate, err := stakingtypes.NewMsgCreateValidator(
 		valAddr,
 		privEd.PubKey(),
 		sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20)),
-		types3.NewDescription("moniker", "indentity", "website", "security_contract", "details"),
-		types3.NewCommissionRates(sdk.OneDec(), sdk.OneDec(), sdk.OneDec()),
-		sdk.OneInt(),
-		addr1,
-		addr1,
-		addr1,
-		blsPk,
+		stakingtypes.NewDescription("moniker", "indentity", "website", "security_contract", "details"),
+		stakingtypes.NewCommissionRates(sdk.OneDec(), sdk.OneDec(), sdk.OneDec()),
+		sdk.OneInt(), valAddr, valAddr, valAddr, "test",
 	)
 	suite.Require().NoError(err)
 	return suite.CreateTestEIP712CosmosTxBuilder(from, priv, chainId, gas, gasAmount, msgCreate)
 }
 
 func (suite *AnteTestSuite) CreateTestEIP712SubmitProposal(from sdk.AccAddress, priv cryptotypes.PrivKey, chainId string, gas uint64, gasAmount sdk.Coins, deposit sdk.Coins) client.TxBuilder {
-	proposal, ok := types5.ContentFromProposalType("My proposal", "My description", types5.ProposalTypeText)
+	proposal, ok := govtypes.ContentFromProposalType("My proposal", "My description", govtypes.ProposalTypeText)
 	suite.Require().True(ok)
-	msgSubmit, err := types5.NewMsgSubmitProposal(proposal, deposit, from)
+	msgSubmit, err := govtypes.NewMsgSubmitProposal(proposal, deposit, from)
 	suite.Require().NoError(err)
 	return suite.CreateTestEIP712CosmosTxBuilder(from, priv, chainId, gas, gasAmount, msgSubmit)
 }
@@ -157,15 +149,14 @@ func (suite *AnteTestSuite) CreateTestEIP712GrantAllowance(from sdk.AccAddress, 
 }
 
 func (suite *AnteTestSuite) CreateTestEIP712MsgEditValidator(from sdk.AccAddress, priv cryptotypes.PrivKey, chainId string, gas uint64, gasAmount sdk.Coins) client.TxBuilder {
-	valAddr := sdk.ValAddress(from.Bytes())
-	blsSecretKey, _ := bls.RandKey()
-	blsPk := hex.EncodeToString(blsSecretKey.PublicKey().Marshal())
-	msgEdit := types3.NewMsgEditValidator(
+	valAddr := sdk.AccAddress(from.Bytes())
+	msgEdit := stakingtypes.NewMsgEditValidator(
 		valAddr,
-		types3.NewDescription("moniker", "identity", "website", "security_contract", "details"),
+		stakingtypes.NewDescription("moniker", "identity", "website", "security_contract", "details"),
 		nil,
 		nil,
-		sdk.AccAddress(priv.PubKey().Address()), blsPk,
+		valAddr,
+		"test",
 	)
 	return suite.CreateTestEIP712CosmosTxBuilder(from, priv, chainId, gas, gasAmount, msgEdit)
 }
@@ -183,6 +174,42 @@ func (suite *AnteTestSuite) CreateTestEIP712MsgSubmitEvidence(from sdk.AccAddres
 	return suite.CreateTestEIP712CosmosTxBuilder(from, priv, chainId, gas, gasAmount, msgEvidence)
 }
 
+func (suite *AnteTestSuite) CreateTestEIP712TxBuilderMsgSubmitProposalV1(from sdk.AccAddress, priv cryptotypes.PrivKey, chainId string, gas uint64, gasAmount sdk.Coins) client.TxBuilder {
+	valAddr := sdk.AccAddress(tests.GenerateAddress().Bytes())
+	privEd := ed25519.GenPrivKey()
+	msgCreate, err := stakingtypes.NewMsgCreateValidator(
+		valAddr,
+		privEd.PubKey(),
+		sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20)),
+		stakingtypes.NewDescription("moniker", "indentity", "website", "security_contract", "details"),
+		stakingtypes.NewCommissionRates(sdk.OneDec(), sdk.OneDec(), sdk.OneDec()),
+		sdk.OneInt(), valAddr, valAddr, valAddr, "test",
+	)
+	suite.Require().NoError(err)
+	msgSubmitProposal, err := govtypesv1.NewMsgSubmitProposal(
+		[]sdk.Msg{msgCreate},
+		sdk.Coins{sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(20))},
+		sdk.ValAddress(from.Bytes()).String(),
+		"test",
+	)
+	suite.Require().NoError(err)
+	return suite.CreateTestEIP712CosmosTxBuilder(from, priv, chainId, gas, gasAmount, msgSubmitProposal)
+}
+
+func (suite *AnteTestSuite) CreateTestEIP712TxBuilderMsgGrant(from sdk.AccAddress, priv cryptotypes.PrivKey, chainId string, gas uint64, gasAmount sdk.Coins) client.TxBuilder {
+	allowed := tests.GenerateAddress().Bytes()
+	stakeAuthorization, err := stakingtypes.NewStakeAuthorization(
+		[]sdk.AccAddress{allowed},
+		nil,
+		1,
+		nil,
+	)
+	suite.Require().NoError(err)
+	msgGrant, err := authz.NewMsgGrant(from, allowed, stakeAuthorization, nil)
+	suite.Require().NoError(err)
+	return suite.CreateTestEIP712CosmosTxBuilder(from, priv, chainId, gas, gasAmount, msgGrant)
+}
+
 func (suite *AnteTestSuite) CreateTestEIP712CosmosTxBuilder(
 	from sdk.AccAddress, priv cryptotypes.PrivKey, chainId string, gas uint64, gasAmount sdk.Coins, msg sdk.Msg,
 ) client.TxBuilder {
@@ -195,7 +222,7 @@ func (suite *AnteTestSuite) CreateTestEIP712CosmosTxBuilder(
 
 	txBuilder := suite.clientCtx.TxConfig.NewTxBuilder()
 
-	txBuilder.SetFeeAmount(gasAmount)
+	// txBuilder.SetFeeAmount(gasAmount)
 	txBuilder.SetGasLimit(gas)
 
 	err = txBuilder.SetMsgs(msg)
@@ -341,7 +368,7 @@ func NewApp(options ...func(baseApp *baseapp.BaseApp)) (*app.App, params.Encodin
 	encCfg := app.MakeEncodingConfig()
 
 	nApp := app.New(
-		logger, db, nil, true, app.DefaultNodeHome, 0, encCfg, app.NewDefaultAppConfig(), simapp.EmptyAppOptions{}, options...)
+		logger, db, nil, true, app.DefaultNodeHome, 0, encCfg, nil, simapp.EmptyAppOptions{}, options...)
 
 	genesisState := app.NewDefaultGenesisState(encCfg.Marshaler)
 	genesisState, _ = genesisStateWithValSet(nApp, genesisState, valSet, []authtypes.GenesisAccount{acc}, balance)

--- a/app/app.go
+++ b/app/app.go
@@ -89,6 +89,8 @@ const (
 	EIP155ChainID = "9000"
 	Epoch         = "1"
 
+	// CoinType is the ETH coin type as defined in SLIP44 (https://github.com/satoshilabs/slips/blob/master/slip-0044.md)
+	// In order to keep consistent with bnb smart chain
 	CoinType = 60
 )
 
@@ -263,7 +265,6 @@ func New(
 		app.GetSubspace(authtypes.ModuleName),
 		authtypes.ProtoBaseAccount,
 		maccPerms,
-		sdk.Bech32PrefixAccAddr,
 	)
 
 	app.AuthzKeeper = authzkeeper.NewKeeper(

--- a/app/encoding.go
+++ b/app/encoding.go
@@ -34,5 +34,6 @@ func MakeEncodingConfig() params.EncodingConfig {
 	std.RegisterInterfaces(encodingConfig.InterfaceRegistry)
 	ModuleBasics.RegisterLegacyAminoCodec(encodingConfig.Amino)
 	ModuleBasics.RegisterInterfaces(encodingConfig.InterfaceRegistry)
+	tx.MsgCodec = codec.NewProtoCodec(encodingConfig.InterfaceRegistry)
 	return encodingConfig
 }

--- a/app/export.go
+++ b/app/export.go
@@ -154,7 +154,7 @@ func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []str
 	counter := int16(0)
 
 	for ; iter.Valid(); iter.Next() {
-		addr := sdk.ValAddress(iter.Key()[1:])
+		addr := sdk.AccAddress(iter.Key()[1:])
 		validator, found := app.StakingKeeper.GetValidator(ctx, addr)
 		if !found {
 			panic("expected validator, not found")

--- a/go.mod
+++ b/go.mod
@@ -26,10 +26,7 @@ require (
 
 require golang.org/x/text v0.5.0 // indirect
 
-require (
-	github.com/prysmaticlabs/prysm v0.0.0-20220124113610-e26cde5e091b
-	github.com/spf13/viper v1.13.0
-)
+require github.com/spf13/viper v1.13.0
 
 require (
 	filippo.io/edwards25519 v1.0.0-rc.1 // indirect
@@ -171,6 +168,7 @@ require (
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/prometheus/tsdb v0.10.0 // indirect
 	github.com/prysmaticlabs/eth2-types v0.0.0-20210303084904-c9735a06829d // indirect
+	github.com/prysmaticlabs/prysm v0.0.0-20220124113610-e26cde5e091b // indirect
 	github.com/radovskyb/watcher v1.0.7 // indirect
 	github.com/rakyll/statik v0.1.7 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
@@ -226,7 +224,7 @@ require (
 
 replace (
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/inscription-cosmos-sdk v0.0.3
+	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/inscription-cosmos-sdk v0.0.2-0.20230112115134-495785e45050
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/tendermint/tendermint => github.com/bnb-chain/inscription-tendermint v0.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -218,8 +218,8 @@ github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdn
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
-github.com/bnb-chain/inscription-cosmos-sdk v0.0.3 h1:MwwT5oUTqHdDnRuimnOKsGXwxuhV9fhb5OvfduF49pI=
-github.com/bnb-chain/inscription-cosmos-sdk v0.0.3/go.mod h1:yH9AsD2F8VoeAmTfdNqxxjfmt29AxQKfifAVfYCJUHU=
+github.com/bnb-chain/inscription-cosmos-sdk v0.0.2-0.20230112115134-495785e45050 h1:ic6NM2b/6u/RZlTaLxVXlSQ80Z8eDL7vGTO95txFchw=
+github.com/bnb-chain/inscription-cosmos-sdk v0.0.2-0.20230112115134-495785e45050/go.mod h1:yH9AsD2F8VoeAmTfdNqxxjfmt29AxQKfifAVfYCJUHU=
 github.com/bnb-chain/inscription-tendermint v0.0.1 h1:E2/QFh9gILGaW5bHNBrZcUvcaUL1SLxeP5WJ3SGQU8c=
 github.com/bnb-chain/inscription-tendermint v0.0.1/go.mod h1:/v9z9F6cq0+f7EGG92lYSLBcPYQDILoK91X8YM28hWo=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=


### PR DESCRIPTION
### Description

Adopt a new solution for EIP712 sign mode. Previously, we use amino codec to marshal the msg in txn and there're a lot of problems. Now we adopt proto codec. Besides that, all *Any types in msg will be treated as bytes rather than unpack it.

### Rationale

N/A

### Example

N/A

### Changes

Notable changes:
* remove bech32 codec from account keeper and grpc query
* update EIP712 related funcionts