### PR TITLE
docs: add the key management docs and keyring module tutorial

### DIFF
--- a/docs/architecture/02-key_management.md
+++ b/docs/architecture/02-key_management.md
@@ -1,6 +1,6 @@
 # Key Management
 
-The gnfd-cosmos-sdk provides a flexible and secure way to manage private keys for blockchain applications. The `Keyring` interface is used to define the methods that a type needs to implement to be used as a key storage backend. This document provides an overview of the different backend options available and the supported sign algorithms.
+The [greenfield-cosmos-sdk](https://github.com/bnb-chain/greenfield-cosmos-sdk) provides a flexible and secure way to manage private keys for blockchain applications. The `Keyring` interface is used to define the methods that a type needs to implement to be used as a key storage backend. This document provides an overview of the different backend options available and the supported sign algorithms.
 
 And to interact with BSC(BNB-smart-chain) more convinent and user-friendly, we add [EIP-712](https://eips.ethereum.org/EIPS/eip-712) support. Any Etherrum wallet could connect to a greenfield node and sign a EIP-712 transaction directly.
 
@@ -11,11 +11,11 @@ The greenfield chain supports and only supports EIP-712 structured transaction. 
 1. An Ethereum-compatible RPC backend. Be noted that we only support necessacry methods to connect a wallet(`eth_chainId`, `eth_networkId`, `eth_blockNumber`, `eth_getBlockByNumber` and `eth_getBalance`). Other RPC methods are not implemented.
 2. Same signing algorithm(`eth_scep256k1`) as Ethereum.
 
-For developers, they can refer to gnfd-go-sdk and gnfd-js-sdk for more infos.
+For developers, they can refer to [greenfield-go-sdk](https://github.com/bnb-chain/greenfield-go-sdk) and [greenfield-js-sdk](https://github.com/bnb-chain/greenfield-js-sdk) for more infos.
 
 ## Keyring Interface
 
-The `Keyring` interface is the primary interface for key management in the gnfd-cosmos-sdk. It defines the methods that a type needs to implement to be used as a key storage backend. These methods include:
+The `Keyring` interface is the primary interface for key management in the greenfield-cosmos-sdk. It defines the methods that a type needs to implement to be used as a key storage backend. These methods include:
 
 -   `Get`: retrieves a key by name.
 -   `List`: lists all keys stored in the keyring.
@@ -26,7 +26,7 @@ By implementing these methods, you can create a custom key storage backend that 
 
 ## Backend Options
 
-The gnfd-cosmos-sdk provides several backend options for key storage. Each backend has its own strengths and weaknesses, and the choice of backend will depend on your specific use case. Here are the available options:
+The greenfield-cosmos-sdk provides several backend options for key storage. Each backend has its own strengths and weaknesses, and the choice of backend will depend on your specific use case. Here are the available options:
 
 1. **os**: The os backend uses the operating system's default credentials store to handle key storage operations securely. The keyring may be kept unlocked for the whole duration of the user session.
 
@@ -42,8 +42,8 @@ The gnfd-cosmos-sdk provides several backend options for key storage. Each backe
 
 ## Supported Sign Algorithms
 
-The gnfd-cosmos-sdk supports as many sign algorithms as users want, but in Greenfield's context, we only support `eth_secp256k1` and `ed25519`. These algorithms were chosen for their security and compatibility with the Ethereum and Tendermint ecosystems.
+The greenfield-cosmos-sdk supports as many sign algorithms as users want, but in Greenfield's context, we only support `eth_secp256k1` and `ed25519`. These algorithms were chosen for their security and compatibility with the Ethereum and Tendermint ecosystems.
 
 ## Conclusion
 
-In conclusion, key management is a critical aspect of building secure blockchain applications. By understanding the available backend options and supported sign algorithms in the gnfd-cosmos-sdk, you can build applications that are both secure and user-friendly. The `Keyring` interface provides a flexible way to manage private keys, and by implementing the required methods, you can create a custom key storage backend that meets the specific needs of your application.
+In conclusion, key management is a critical aspect of building secure blockchain applications. By understanding the available backend options and supported sign algorithms in the greenfield-cosmos-sdk, you can build applications that are both secure and user-friendly. The `Keyring` interface provides a flexible way to manage private keys, and by implementing the required methods, you can create a custom key storage backend that meets the specific needs of your application.

--- a/docs/tutorial/04-key-management.md
+++ b/docs/tutorial/04-key-management.md
@@ -2,7 +2,7 @@
 
 ## Abstract
 
-The gnfd-cosmos-sdk comes with a built-in keyring module that helps manage private and public keypairs for secure interactions with a node. In this tutorial, we'll explore how to use the gnfd command to manage keys in the gnfd-cosmos-sdk.
+The greenfield-cosmos-sdk comes with a built-in keyring module that helps manage private and public keypairs for secure interactions with a node. In this tutorial, we'll explore how to use the gnfd command to manage keys in the greenfield-cosmos-sdk.
 
 ## Quick Start
 


### PR DESCRIPTION
### Description
The PR updates docs about key management.

### Rationale
This PR finishes the `02-key_manangement.md` of architecture part and `04-key_manangement.md` of tutorials part.

### Example
No

### Changes
No
