### PR TITLE
fix: list bucket object

### DIFF
--- a/x/storage/keeper/keeper.go
+++ b/x/storage/keeper/keeper.go
@@ -157,7 +157,7 @@ func (k Keeper) DeleteBucket(ctx sdk.Context, operator sdk.AccAddress, bucketNam
 	}
 
 	// check if the bucket empty
-	if k.isEmptyBucket(ctx, bucketName) {
+	if k.isNonEmptyBucket(ctx, bucketName) {
 		return types.ErrBucketNotEmpty
 	}
 
@@ -893,7 +893,7 @@ func (k Keeper) GenNextGroupId(ctx sdk.Context) math.Uint {
 	return seq
 }
 
-func (k Keeper) isEmptyBucket(ctx sdk.Context, bucketName string) bool {
+func (k Keeper) isNonEmptyBucket(ctx sdk.Context, bucketName string) bool {
 	store := ctx.KVStore(k.storeKey)
 	objectStore := prefix.NewStore(store, types.GetObjectKeyOnlyBucketPrefix(bucketName))
 


### PR DESCRIPTION
### Description

ListBucket and ListObject are not compatible with the IndexByID indexing format.

### Example

```shell
./build/bin/gnfd query storage list-buckets --node http://localhost:26750
./build/bin/gnfd query storage list-objects 4oszi --node http://localhost:26750
````


### Changes

Notable changes: 
* add e2e test for listbucket/listobject
