### PR TITLE
fix: add missing swagger doc for storage bucket, object and group related query apis.

### DIFF
--- a/docs/static/swagger.yaml
+++ b/docs/static/swagger.yaml
@@ -1564,10 +1564,10 @@ paths:
           type: boolean
       tags:
         - Query
-  /greenfield/storage/bucket/{bucket_name}:
+  /greenfield/storage/head_bucket/{bucket_name}:
     get:
-      summary: Queries a list of Bucket items.
-      operationId: Bucket
+      summary: Queries a bucket with specify name.
+      operationId: HeadBucket
       responses:
         '200':
           description: A successful response.
@@ -1594,6 +1594,7 @@ paths:
                     type: string
                     description: id is the unique identification for bucket.
                   source_type:
+                    title: source_type define the source of the bucket
                     type: string
                     enum:
                       - SOURCE_TYPE_ORIGIN
@@ -1672,10 +1673,10 @@ paths:
           type: string
       tags:
         - Query
-  /greenfield/storage/object/{bucket_name}/{object_name}:
+  /greenfield/storage/head_object/{bucket_name}/{object_name}:
     get:
-      summary: Queries a list of Object items.
-      operationId: Object
+      summary: Queries a object with specify name.
+      operationId: HeadObject
       responses:
         '200':
           description: A successful response.
@@ -1732,12 +1733,12 @@ paths:
                       - REDUNDANCY_INLINE_TYPE
                     default: REDUNDANCY_REPLICA_TYPE
                   source_type:
+                    description: source_type define the source of the object.
                     type: string
                     enum:
                       - SOURCE_TYPE_ORIGIN
                       - SOURCE_TYPE_BSC_CROSS_CHAIN
                     default: SOURCE_TYPE_ORIGIN
-                    description: source_type define the source of the object.
                   checksums:
                     type: array
                     items:
@@ -1787,6 +1788,401 @@ paths:
           in: path
           required: true
           type: string
+      tags:
+        - Query
+  /greenfield/storage/list_buckets:
+    get:
+      summary: Queries a list of bucket items.
+      operationId: ListBuckets
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              bucket_infos:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    owner:
+                      type: string
+                      description: >-
+                        owner is the account address of bucket creator, it is
+                        also the bucket owner.
+                    bucket_name:
+                      type: string
+                      title: bucket_name is a globally unique name of bucket
+                    is_public:
+                      type: boolean
+                      description: >-
+                        is_public define the highest permissions for bucket.
+                        When the bucket is public, everyone can get the object
+                        in it.
+                    id:
+                      type: string
+                      description: id is the unique identification for bucket.
+                    source_type:
+                      title: source_type define the source of the bucket
+                      type: string
+                      enum:
+                        - SOURCE_TYPE_ORIGIN
+                        - SOURCE_TYPE_BSC_CROSS_CHAIN
+                      default: SOURCE_TYPE_ORIGIN
+                    create_at:
+                      type: string
+                      format: int64
+                      description: >-
+                        create_at define the block number when the bucket
+                        created.
+                    payment_address:
+                      type: string
+                      title: payment_address is the address of the payment account
+                    primary_sp_address:
+                      type: string
+                      description: >-
+                        primary_sp_address is the address of the primary sp.
+                        Objects belongs to this bucket will never
+
+                        leave this SP, unless you explicitly shift them to
+                        another SP.
+                    read_quota:
+                      title: read_quota defines the traffic quota for read
+                      type: string
+                      enum:
+                        - READ_QUOTA_FREE
+                        - READ_QUOTA_1G
+                        - READ_QUOTA_10G
+                      default: READ_QUOTA_FREE
+                    payment_price_time:
+                      type: string
+                      format: int64
+                      title: 'payment_price_time TODO(Owen): refine the comments'
+                    payment_out_flows:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          sp_address:
+                            type: string
+                            title: SP(service provider) stream account address
+                          rate:
+                            type: string
+                            title: flow rate in USD
+                        title: >-
+                          OutFlowInUSD defines the accumulative outflow stream
+                          rate in USD
+
+                          from a stream account or a bucket to a SP
+                      title: payment_out_flows
+              pagination:
+                type: object
+                properties:
+                  next_key:
+                    type: string
+                    format: byte
+                    description: |-
+                      next_key is the key to be passed to PageRequest.key to
+                      query the next page most efficiently. It will be empty if
+                      there are no more results.
+                  total:
+                    type: string
+                    format: uint64
+                    title: >-
+                      total is total number of results available if
+                      PageRequest.count_total
+
+                      was set, its value is undefined otherwise
+                description: >-
+                  PageResponse is to be embedded in gRPC response messages where
+                  the
+
+                  corresponding request message has used PageRequest.
+
+                   message SomeResponse {
+                           repeated Bar results = 1;
+                           PageResponse page = 2;
+                   }
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                    value:
+                      type: string
+                      format: byte
+      parameters:
+        - name: pagination.key
+          description: |-
+            key is a value returned in PageResponse.next_key to begin
+            querying the next page most efficiently. Only one of offset or key
+            should be set.
+          in: query
+          required: false
+          type: string
+          format: byte
+        - name: pagination.offset
+          description: >-
+            offset is a numeric offset that can be used when key is unavailable.
+
+            It is less efficient than using key. Only one of offset or key
+            should
+
+            be set.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.limit
+          description: >-
+            limit is the total number of results to be returned in the result
+            page.
+
+            If left empty it will default to a value to be set by each app.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.count_total
+          description: >-
+            count_total is set to true  to indicate that the result set should
+            include
+
+            a count of the total number of items available for pagination in
+            UIs.
+
+            count_total is only respected when offset is used. It is ignored
+            when key
+
+            is set.
+          in: query
+          required: false
+          type: boolean
+        - name: pagination.reverse
+          description: >-
+            reverse is set to true if results are to be returned in the
+            descending order.
+
+
+            Since: cosmos-sdk 0.43
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - Query
+  /greenfield/storage/list_objects/{bucketName}:
+    get:
+      summary: Queries a list of object items under the bucket.
+      operationId: ListObjects
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              object_infos:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    owner:
+                      type: string
+                    bucket_name:
+                      type: string
+                      title: bucket_name is the name of the bucket
+                    object_name:
+                      type: string
+                      title: object_name is the name of object
+                    id:
+                      type: string
+                      title: id is the unique identifier of object
+                    payload_size:
+                      type: string
+                      format: uint64
+                      title: payloadSize is the total size of the object payload
+                    is_public:
+                      type: boolean
+                      description: >-
+                        is_public define the highest permissions for object.
+                        When the object is public, everyone can access it.
+                    content_type:
+                      type: string
+                      description: >-
+                        content_type define the format of the object which
+                        should be a standard MIME type.
+                    create_at:
+                      type: string
+                      format: int64
+                      title: >-
+                        create_at define the block number when the object
+                        created
+                    object_status:
+                      description: object_status define the upload status of the object.
+                      type: string
+                      enum:
+                        - OBJECT_STATUS_INIT
+                        - OBJECT_STATUS_IN_SERVICE
+                      default: OBJECT_STATUS_INIT
+                    redundancy_type:
+                      description: >-
+                        redundancy_type define the type of the redundancy which
+                        can be multi-replication or EC.
+                      type: string
+                      enum:
+                        - REDUNDANCY_REPLICA_TYPE
+                        - REDUNDANCY_EC_TYPE
+                        - REDUNDANCY_INLINE_TYPE
+                      default: REDUNDANCY_REPLICA_TYPE
+                    source_type:
+                      description: source_type define the source of the object.
+                      type: string
+                      enum:
+                        - SOURCE_TYPE_ORIGIN
+                        - SOURCE_TYPE_BSC_CROSS_CHAIN
+                      default: SOURCE_TYPE_ORIGIN
+                    checksums:
+                      type: array
+                      items:
+                        type: string
+                        format: byte
+                      description: >-
+                        checksums define the root hash of the pieces which
+                        stored in a SP.
+                    secondary_sp_addresses:
+                      type: array
+                      items:
+                        type: string
+                      title: >-
+                        secondary_sp_addresses define the addresses of
+                        secondary_sps
+                    lockedBalance:
+                      type: string
+                      title: lockedBalance
+              pagination:
+                type: object
+                properties:
+                  next_key:
+                    type: string
+                    format: byte
+                    description: |-
+                      next_key is the key to be passed to PageRequest.key to
+                      query the next page most efficiently. It will be empty if
+                      there are no more results.
+                  total:
+                    type: string
+                    format: uint64
+                    title: >-
+                      total is total number of results available if
+                      PageRequest.count_total
+
+                      was set, its value is undefined otherwise
+                description: >-
+                  PageResponse is to be embedded in gRPC response messages where
+                  the
+
+                  corresponding request message has used PageRequest.
+
+                   message SomeResponse {
+                           repeated Bar results = 1;
+                           PageResponse page = 2;
+                   }
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                    value:
+                      type: string
+                      format: byte
+      parameters:
+        - name: bucketName
+          in: path
+          required: true
+          type: string
+        - name: pagination.key
+          description: |-
+            key is a value returned in PageResponse.next_key to begin
+            querying the next page most efficiently. Only one of offset or key
+            should be set.
+          in: query
+          required: false
+          type: string
+          format: byte
+        - name: pagination.offset
+          description: >-
+            offset is a numeric offset that can be used when key is unavailable.
+
+            It is less efficient than using key. Only one of offset or key
+            should
+
+            be set.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.limit
+          description: >-
+            limit is the total number of results to be returned in the result
+            page.
+
+            If left empty it will default to a value to be set by each app.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.count_total
+          description: >-
+            count_total is set to true  to indicate that the result set should
+            include
+
+            a count of the total number of items available for pagination in
+            UIs.
+
+            count_total is only respected when offset is used. It is ignored
+            when key
+
+            is set.
+          in: query
+          required: false
+          type: boolean
+        - name: pagination.reverse
+          description: >-
+            reverse is set to true if results are to be returned in the
+            descending order.
+
+
+            Since: cosmos-sdk 0.43
+          in: query
+          required: false
+          type: boolean
       tags:
         - Query
   /greenfield/storage/params:
@@ -23108,6 +23504,9 @@ paths:
                     type: string
                     format: uint64
                     description: GasUsed is the amount of gas actually consumed.
+                  min_gas_price:
+                    type: string
+                    description: MinGasPrice are the min gas price.
               result:
                 description: result is the result of the simulation.
                 type: object
@@ -26494,6 +26893,7 @@ definitions:
         type: string
         description: id is the unique identification for bucket.
       source_type:
+        title: source_type define the source of the bucket
         type: string
         enum:
           - SOURCE_TYPE_ORIGIN
@@ -26590,12 +26990,12 @@ definitions:
           - REDUNDANCY_INLINE_TYPE
         default: REDUNDANCY_REPLICA_TYPE
       source_type:
+        description: source_type define the source of the object.
         type: string
         enum:
           - SOURCE_TYPE_ORIGIN
           - SOURCE_TYPE_BSC_CROSS_CHAIN
         default: SOURCE_TYPE_ORIGIN
-        description: source_type define the source of the object.
       checksums:
         type: array
         items:
@@ -26640,7 +27040,7 @@ definitions:
         format: uint64
         title: 'max_payload_size is the maximum size of the payload, default: 2G'
     description: Params defines the parameters for the module.
-  bnbchain.greenfield.storage.QueryBucketResponse:
+  bnbchain.greenfield.storage.QueryHeadBucketResponse:
     type: object
     properties:
       bucket_info:
@@ -26663,6 +27063,7 @@ definitions:
             type: string
             description: id is the unique identification for bucket.
           source_type:
+            title: source_type define the source of the bucket
             type: string
             enum:
               - SOURCE_TYPE_ORIGIN
@@ -26709,7 +27110,7 @@ definitions:
                 OutFlowInUSD defines the accumulative outflow stream rate in USD
                 from a stream account or a bucket to a SP
             title: payment_out_flows
-  bnbchain.greenfield.storage.QueryObjectResponse:
+  bnbchain.greenfield.storage.QueryHeadObjectResponse:
     type: object
     properties:
       object_info:
@@ -26762,12 +27163,12 @@ definitions:
               - REDUNDANCY_INLINE_TYPE
             default: REDUNDANCY_REPLICA_TYPE
           source_type:
+            description: source_type define the source of the object.
             type: string
             enum:
               - SOURCE_TYPE_ORIGIN
               - SOURCE_TYPE_BSC_CROSS_CHAIN
             default: SOURCE_TYPE_ORIGIN
-            description: source_type define the source of the object.
           checksums:
             type: array
             items:
@@ -26782,6 +27183,209 @@ definitions:
           lockedBalance:
             type: string
             title: lockedBalance
+  bnbchain.greenfield.storage.QueryListBucketsResponse:
+    type: object
+    properties:
+      bucket_infos:
+        type: array
+        items:
+          type: object
+          properties:
+            owner:
+              type: string
+              description: >-
+                owner is the account address of bucket creator, it is also the
+                bucket owner.
+            bucket_name:
+              type: string
+              title: bucket_name is a globally unique name of bucket
+            is_public:
+              type: boolean
+              description: >-
+                is_public define the highest permissions for bucket. When the
+                bucket is public, everyone can get the object in it.
+            id:
+              type: string
+              description: id is the unique identification for bucket.
+            source_type:
+              title: source_type define the source of the bucket
+              type: string
+              enum:
+                - SOURCE_TYPE_ORIGIN
+                - SOURCE_TYPE_BSC_CROSS_CHAIN
+              default: SOURCE_TYPE_ORIGIN
+            create_at:
+              type: string
+              format: int64
+              description: create_at define the block number when the bucket created.
+            payment_address:
+              type: string
+              title: payment_address is the address of the payment account
+            primary_sp_address:
+              type: string
+              description: >-
+                primary_sp_address is the address of the primary sp. Objects
+                belongs to this bucket will never
+
+                leave this SP, unless you explicitly shift them to another SP.
+            read_quota:
+              title: read_quota defines the traffic quota for read
+              type: string
+              enum:
+                - READ_QUOTA_FREE
+                - READ_QUOTA_1G
+                - READ_QUOTA_10G
+              default: READ_QUOTA_FREE
+            payment_price_time:
+              type: string
+              format: int64
+              title: 'payment_price_time TODO(Owen): refine the comments'
+            payment_out_flows:
+              type: array
+              items:
+                type: object
+                properties:
+                  sp_address:
+                    type: string
+                    title: SP(service provider) stream account address
+                  rate:
+                    type: string
+                    title: flow rate in USD
+                title: >-
+                  OutFlowInUSD defines the accumulative outflow stream rate in
+                  USD
+
+                  from a stream account or a bucket to a SP
+              title: payment_out_flows
+      pagination:
+        type: object
+        properties:
+          next_key:
+            type: string
+            format: byte
+            description: |-
+              next_key is the key to be passed to PageRequest.key to
+              query the next page most efficiently. It will be empty if
+              there are no more results.
+          total:
+            type: string
+            format: uint64
+            title: >-
+              total is total number of results available if
+              PageRequest.count_total
+
+              was set, its value is undefined otherwise
+        description: |-
+          PageResponse is to be embedded in gRPC response messages where the
+          corresponding request message has used PageRequest.
+
+           message SomeResponse {
+                   repeated Bar results = 1;
+                   PageResponse page = 2;
+           }
+  bnbchain.greenfield.storage.QueryListObjectsResponse:
+    type: object
+    properties:
+      object_infos:
+        type: array
+        items:
+          type: object
+          properties:
+            owner:
+              type: string
+            bucket_name:
+              type: string
+              title: bucket_name is the name of the bucket
+            object_name:
+              type: string
+              title: object_name is the name of object
+            id:
+              type: string
+              title: id is the unique identifier of object
+            payload_size:
+              type: string
+              format: uint64
+              title: payloadSize is the total size of the object payload
+            is_public:
+              type: boolean
+              description: >-
+                is_public define the highest permissions for object. When the
+                object is public, everyone can access it.
+            content_type:
+              type: string
+              description: >-
+                content_type define the format of the object which should be a
+                standard MIME type.
+            create_at:
+              type: string
+              format: int64
+              title: create_at define the block number when the object created
+            object_status:
+              description: object_status define the upload status of the object.
+              type: string
+              enum:
+                - OBJECT_STATUS_INIT
+                - OBJECT_STATUS_IN_SERVICE
+              default: OBJECT_STATUS_INIT
+            redundancy_type:
+              description: >-
+                redundancy_type define the type of the redundancy which can be
+                multi-replication or EC.
+              type: string
+              enum:
+                - REDUNDANCY_REPLICA_TYPE
+                - REDUNDANCY_EC_TYPE
+                - REDUNDANCY_INLINE_TYPE
+              default: REDUNDANCY_REPLICA_TYPE
+            source_type:
+              description: source_type define the source of the object.
+              type: string
+              enum:
+                - SOURCE_TYPE_ORIGIN
+                - SOURCE_TYPE_BSC_CROSS_CHAIN
+              default: SOURCE_TYPE_ORIGIN
+            checksums:
+              type: array
+              items:
+                type: string
+                format: byte
+              description: >-
+                checksums define the root hash of the pieces which stored in a
+                SP.
+            secondary_sp_addresses:
+              type: array
+              items:
+                type: string
+              title: secondary_sp_addresses define the addresses of secondary_sps
+            lockedBalance:
+              type: string
+              title: lockedBalance
+      pagination:
+        type: object
+        properties:
+          next_key:
+            type: string
+            format: byte
+            description: |-
+              next_key is the key to be passed to PageRequest.key to
+              query the next page most efficiently. It will be empty if
+              there are no more results.
+          total:
+            type: string
+            format: uint64
+            title: >-
+              total is total number of results available if
+              PageRequest.count_total
+
+              was set, its value is undefined otherwise
+        description: |-
+          PageResponse is to be embedded in gRPC response messages where the
+          corresponding request message has used PageRequest.
+
+           message SomeResponse {
+                   repeated Bar results = 1;
+                   PageResponse page = 2;
+           }
   bnbchain.greenfield.storage.QueryParamsResponse:
     type: object
     properties:
@@ -41588,6 +42192,9 @@ definitions:
         type: string
         format: uint64
         description: GasUsed is the amount of gas actually consumed.
+      min_gas_price:
+        type: string
+        description: MinGasPrice are the min gas price.
     description: GasInfo defines tx execution gas context.
   cosmos.base.abci.v1beta1.Result:
     type: object
@@ -44391,6 +44998,9 @@ definitions:
             type: string
             format: uint64
             description: GasUsed is the amount of gas actually consumed.
+          min_gas_price:
+            type: string
+            description: MinGasPrice are the min gas price.
       result:
         description: result is the result of the simulation.
         type: object


### PR DESCRIPTION
### Description

fix swagger doc by generating storage bucket, object and group related query apis.

### Rationale

user can track and query storage status by swagger.

### Example

NA

### Changes

Notable changes: 
*  generating swagger doc for storage query apis