### PR TITLE
fix: wrong operation number of object channel

### DIFF
--- a/x/storage/types/crosschain.go
+++ b/x/storage/types/crosschain.go
@@ -27,7 +27,8 @@ const (
 	// object operation types
 
 	OperationMirrorObject uint8 = 1
-	OperationDeleteObject uint8 = 2
+	// OperationCreateObject uint8 = 2 // not used
+	OperationDeleteObject uint8 = 3
 
 	// group operation types
 


### PR DESCRIPTION
### Description

This pr aims to fix the wrong operation type number of object channel.

### Rationale

Fix operation number of object channel to keep aligned with BSC smart contracts

### Changes

Notable changes: 
* change `OperationDeleteObject` from 2 to 3