### PR TITLE
fix: check status of object before mirroring

### DIFF
--- a/x/storage/keeper/msg_server.go
+++ b/x/storage/keeper/msg_server.go
@@ -329,6 +329,10 @@ func (k msgServer) MirrorObject(goCtx context.Context, msg *types.MsgMirrorObjec
 		return nil, types.ErrAlreadyMirrored
 	}
 
+	if objectInfo.ObjectStatus != types.OBJECT_STATUS_SEALED {
+		return nil, types.ErrObjectNotSealed
+	}
+
 	if operator.String() != objectInfo.Owner {
 		return nil, types.ErrAccessDenied
 	}


### PR DESCRIPTION
### Description

This pr fixes the bug that the user can mirror an object when the object is not sealed.

### Rationale

Fix the bug when mirroring object

### Example

N/A

### Changes

Notable changes: 
* check status of object before mirroring
