### PR TITLE
feat: support delete bucket with non-zero charged read quota

### DIFF
--- a/x/storage/keeper/keeper.go
+++ b/x/storage/keeper/keeper.go
@@ -169,13 +169,10 @@ func (k Keeper) DeleteBucket(ctx sdk.Context, operator sdk.AccAddress, bucketNam
 		return types.ErrBucketNotEmpty
 	}
 
-	// check bill is empty
-	bill, err := k.GetBucketBill(ctx, bucketInfo)
+	// change the bill
+	err := k.ChargeDeleteBucket(ctx, bucketInfo)
 	if err != nil {
-		return errors.Wrapf(err, "Get bucket bill failed.")
-	}
-	if len(bill.Flows) != 0 {
-		return types.ErrBucketBillNotEmpty
+		return types.ErrCharge.Wrapf("ChargeDeleteBucket error: %s", err)
 	}
 
 	store.Delete(bucketKey)

--- a/x/storage/types/errors.go
+++ b/x/storage/types/errors.go
@@ -23,7 +23,7 @@ var (
 	ErrSourceTypeMismatch       = errors.Register(ModuleName, 1114, "Object source type mismatch")
 	ErrTooLargeObject           = errors.Register(ModuleName, 1115, "Object payload size is too large")
 	ErrInvalidApproval          = errors.Register(ModuleName, 1116, "Invalid approval of sp")
-	ErrBucketBillNotEmpty       = errors.Register(ModuleName, 1117, "bucket bill is not empty")
+	ErrCharge                   = errors.Register(ModuleName, 1117, "charge error")
 
 	ErrNoSuchPolicy          = errors.Register(ModuleName, 1120, "No such Policy")
 	ErrInvalidParameter      = errors.Register(ModuleName, 1121, "Invalid parameter")


### PR DESCRIPTION
### Description

Previously a bucket with a non-zero charged read quota cannot be deleted.
This PR supports that by changing the billing info in that transaction.

### Rationale

Make it easier for users to delete a bucket. They don't need to update the charged read quota to zero first before deleting it.

### Example

NA

### Changes

Notable changes: 
* Change the billing info in `DeleteBucket`
