### PR TITLE
fix: forbid a stream account with negative static balance to pay

### DIFF
--- a/e2e/core/basesuite.go
+++ b/e2e/core/basesuite.go
@@ -77,6 +77,16 @@ func (s *BaseSuite) SendTxBlock(msg sdk.Msg, from keys.KeyManager) (txRes *sdk.T
 	return response.TxResponse
 }
 
+func (s *BaseSuite) SendTxBlockWithoutCheck(msg sdk.Msg, from keys.KeyManager) (*tx.BroadcastTxResponse, error) {
+	mode := tx.BroadcastMode_BROADCAST_MODE_BLOCK
+	txOpt := &types.TxOption{
+		Mode: &mode,
+		Memo: "",
+	}
+	s.Client.SetKeyManager(from)
+	return s.Client.BroadcastTx([]sdk.Msg{msg}, txOpt)
+}
+
 func (s *BaseSuite) SendTxBlockWithExpectErrorString(msg sdk.Msg, from keys.KeyManager, expectErrorString string) {
 	mode := tx.BroadcastMode_BROADCAST_MODE_BLOCK
 	txOpt := &types.TxOption{

--- a/x/storage/keeper/keeper.go
+++ b/x/storage/keeper/keeper.go
@@ -172,7 +172,7 @@ func (k Keeper) DeleteBucket(ctx sdk.Context, operator sdk.AccAddress, bucketNam
 	// change the bill
 	err := k.ChargeDeleteBucket(ctx, bucketInfo)
 	if err != nil {
-		return types.ErrCharge.Wrapf("ChargeDeleteBucket error: %s", err)
+		return types.ErrChargeFailed.Wrapf("ChargeDeleteBucket error: %s", err)
 	}
 
 	store.Delete(bucketKey)

--- a/x/storage/keeper/payment.go
+++ b/x/storage/keeper/payment.go
@@ -34,7 +34,7 @@ func (k Keeper) ChargeDeleteBucket(ctx sdk.Context, bucketInfo *storagetypes.Buc
 	}
 	// should only remain at most 2 flows: charged_read_quota fee and tax
 	if len(bill.Flows) > 2 {
-		return fmt.Errorf("unexpected left flow number: %d", len(bill.Flows))
+		panic(fmt.Sprintf("unexpected left flow number: %d", len(bill.Flows)))
 	}
 	bill.Flows = GetNegFlows(bill.Flows)
 	err = k.paymentKeeper.ApplyUserFlowsList(ctx, []types.UserFlows{bill})

--- a/x/storage/types/errors.go
+++ b/x/storage/types/errors.go
@@ -23,7 +23,7 @@ var (
 	ErrSourceTypeMismatch       = errors.Register(ModuleName, 1114, "Object source type mismatch")
 	ErrTooLargeObject           = errors.Register(ModuleName, 1115, "Object payload size is too large")
 	ErrInvalidApproval          = errors.Register(ModuleName, 1116, "Invalid approval of sp")
-	ErrCharge                   = errors.Register(ModuleName, 1117, "charge error")
+	ErrChargeFailed             = errors.Register(ModuleName, 1117, "charge failed error")
 
 	ErrNoSuchPolicy          = errors.Register(ModuleName, 1120, "No such Policy")
 	ErrInvalidParameter      = errors.Register(ModuleName, 1121, "Invalid parameter")


### PR DESCRIPTION
### Description

Forbid a stream account with negative static balance to pay.

### Rationale

Currently, a stream account with negative static balance can still pay, as long as it has enough buffer.
It might reduce the reserved time to settle for the account, which is not expected.

### Example

NA

### Changes

Notable changes: 
* Add a new check in stream account change function
