### PR TITLE
fix: `Visibility` type in `CreateBucketSynPackage`

### DIFF
--- a/x/storage/keeper/cross_app_bucket.go
+++ b/x/storage/keeper/cross_app_bucket.go
@@ -227,7 +227,7 @@ func (app *BucketApp) handleCreateBucketSynPackage(ctx sdk.Context, appCtx *sdk.
 		createBucketPackage.BucketName,
 		createBucketPackage.PrimarySpAddress,
 		&CreateBucketOptions{
-			Visibility:       createBucketPackage.Visibility,
+			Visibility:       types.VisibilityType(createBucketPackage.Visibility),
 			SourceType:       types.SOURCE_TYPE_BSC_CROSS_CHAIN,
 			ChargedReadQuota: createBucketPackage.ChargedReadQuota,
 			PaymentAddress:   createBucketPackage.PaymentAddress.String(),

--- a/x/storage/types/crosschain.go
+++ b/x/storage/types/crosschain.go
@@ -225,7 +225,7 @@ func DeserializeMirrorGroupAckPackage(serializedPackage []byte) (interface{}, er
 type CreateBucketSynPackage struct {
 	Creator                        sdk.AccAddress
 	BucketName                     string
-	Visibility                     VisibilityType
+	Visibility                     uint32
 	PaymentAddress                 sdk.AccAddress
 	PrimarySpAddress               sdk.AccAddress
 	PrimarySpApprovalExpiredHeight uint64
@@ -238,7 +238,7 @@ func (p CreateBucketSynPackage) ValidateBasic() error {
 	msg := MsgCreateBucket{
 		Creator:          p.Creator.String(),
 		BucketName:       p.BucketName,
-		Visibility:       p.Visibility,
+		Visibility:       VisibilityType(p.Visibility),
 		PaymentAddress:   p.PaymentAddress.String(),
 		PrimarySpAddress: p.PrimarySpAddress.String(),
 		PrimarySpApproval: &Approval{
@@ -255,7 +255,7 @@ func (p CreateBucketSynPackage) GetApprovalBytes() []byte {
 	msg := MsgCreateBucket{
 		Creator:          p.Creator.String(),
 		BucketName:       p.BucketName,
-		Visibility:       p.Visibility,
+		Visibility:       VisibilityType(p.Visibility),
 		PaymentAddress:   p.PaymentAddress.String(),
 		PrimarySpAddress: p.PrimarySpAddress.String(),
 		PrimarySpApproval: &Approval{


### PR DESCRIPTION
### Description

This pr aims to fix the rlp error of `CreateBucketSynPackage`

### Rationale

Int32 is not supported by rlp decode.

### Changes

Notable changes: 
* change the `Visibility` type in `CreateBucketSynPackage` from int32 to uint32
