### PR TITLE
fix: occasional timeout in auto-settle e2e test

### DIFF
--- a/e2e/tests/storage_test.go
+++ b/e2e/tests/storage_test.go
@@ -696,7 +696,7 @@ func (s *StorageTestSuite) TestPayment_AutoSettle() {
 		}
 		time.Sleep(time.Second)
 		retryCount++
-		if retryCount > 31 {
+		if retryCount > 60 {
 			s.T().Fatalf("wait for settle time timeout")
 		}
 	}


### PR DESCRIPTION
### Description

Fix occasional timeout in auto-settle e2e test.

### Rationale

The number of retry times is not big enough.
It may occasionally timeout for waiting for auto settlement.
Adjust it to avoid the timeout.

### Example

NA

### Changes

NA
