### PR TITLE
fix: addr is missing in EventPaymentAccountUpdate

### DIFF
--- a/x/payment/keeper/payment_account.go
+++ b/x/payment/keeper/payment_account.go
@@ -14,11 +14,12 @@ import (
 func (k Keeper) SetPaymentAccount(ctx sdk.Context, paymentAccount *types.PaymentAccount) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.PaymentAccountKeyPrefix)
 	key := types.PaymentAccountKey(sdk.MustAccAddressFromHex(paymentAccount.Addr))
+	addr := paymentAccount.Addr
 	paymentAccount.Addr = ""
 	b := k.cdc.MustMarshal(paymentAccount)
 	store.Set(key, b)
 	_ = ctx.EventManager().EmitTypedEvents(&types.EventPaymentAccountUpdate{
-		Addr:       paymentAccount.Addr,
+		Addr:       addr,
 		Owner:      paymentAccount.Owner,
 		Refundable: paymentAccount.Refundable,
 	})


### PR DESCRIPTION
### Description

Fixed the bug that the address is missing in `EventPaymentAccountUpdate`.

### Rationale

NA

### Example

NA

### Changes

NA