### PR TITLE
fix: gashub causes state sync to fail to synchronize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## v0.1.1
+* [\#166](https://github.com/bnb-chain/greenfield/pull/166) fix: gashub causes state sync to fail to synchronize
+
 ## v0.1.0
 * [\#141](https://github.com/bnb-chain/greenfield/pull/141) fix wrong comments for events.proto in storage (created_at field shows block timestamp instead of block number)
 * [\#149](https://github.com/bnb-chain/greenfield/pull/149) fix: get price boundary logic, remove useless query, enhance ci

--- a/app/app.go
+++ b/app/app.go
@@ -736,6 +736,8 @@ func (app *App) Name() string { return app.BaseApp.Name() }
 
 // BeginBlocker application updates every begin block
 func (app *App) BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock) abci.ResponseBeginBlock {
+	// TODO: remove this after we have a better way to handle this
+	app.initGashub(ctx)
 	return app.mm.BeginBlock(ctx, req)
 }
 


### PR DESCRIPTION
### Description

gashub causes state sync to fail to synchronize.

### Rationale

After state sync state synchronization, there is no init `gashub`, resulting in inconsistent execution state

### Example

n/a

### Changes

Notable changes: 
* app
