### PR TITLE
chore: rename the name of buf.yaml

### DIFF
--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -1,6 +1,6 @@
 # This module represents buf.build/cosmos/cosmos-sdk
 version: v1
-name: buf.build/bnb-chain/bfs
+name: buf.build/bnb-chain/greenfield
 deps:
   - buf.build/cosmos/cosmos-proto
   - buf.build/cosmos/gogo-proto


### PR DESCRIPTION
### Description

rename `buf.build/bnb-chain/bfs` to `buf.build/bnb-chain/greenfield`

### Rationale

n/a

### Example

n/a

### Changes

Notable changes: 
* proto/buf.yaml
