### PR TITLE
fix: add `ErrInvalidApproval` errorcode for sp's approval invalid

### DIFF
--- a/x/storage/keeper/keeper.go
+++ b/x/storage/keeper/keeper.go
@@ -946,12 +946,9 @@ func (k Keeper) VerifySPAndSignature(ctx sdk.Context, spAcc sdk.AccAddress, sigD
 		return sptypes.ErrStorageProviderNotInService
 	}
 
-	approvalAccAddress, err := sdk.AccAddressFromHexUnsafe(sp.ApprovalAddress)
-	if err != nil {
-		return err
-	}
+	approvalAccAddress := sdk.MustAccAddressFromHex(sp.ApprovalAddress)
 
-	err = types.VerifySignature(approvalAccAddress, sdk.Keccak256(sigData), signature)
+	err := types.VerifySignature(approvalAccAddress, sdk.Keccak256(sigData), signature)
 	if err != nil {
 		return errors.Wrapf(types.ErrInvalidApproval, "verify signature error: %s", err)
 	}

--- a/x/storage/keeper/keeper.go
+++ b/x/storage/keeper/keeper.go
@@ -953,7 +953,7 @@ func (k Keeper) VerifySPAndSignature(ctx sdk.Context, spAcc sdk.AccAddress, sigD
 
 	err = types.VerifySignature(approvalAccAddress, sdk.Keccak256(sigData), signature)
 	if err != nil {
-		return err
+		return errors.Wrapf(types.ErrInvalidApproval, "verify signature error: %s", err)
 	}
 	return nil
 }


### PR DESCRIPTION
### Description

If the user creates a bucket on sp1 and then creates an object on sp2, the error message will be more accurate. Use the ErrInvalidApproval error code to indicate an invalid approval from sp.

### Changes

Notable changes: 
* AccAddressFromHexUnsafe to MustAccAddressFromHex, to get sp's ApprovalAddress.
* ...
