### PR TITLE
feat: make sp receive storage fee with funding addr

### DIFF
--- a/x/storage/keeper/keeper_test.go
+++ b/x/storage/keeper/keeper_test.go
@@ -1,9 +1,10 @@
 package keeper_test
 
 import (
-	"github.com/samber/lo"
 	"testing"
 	"time"
+
+	"github.com/samber/lo"
 
 	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"

--- a/x/storage/keeper/payment.go
+++ b/x/storage/keeper/payment.go
@@ -12,6 +12,14 @@ import (
 	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
 )
 
+func (k Keeper) GetFundingAddressBySpAddr(ctx sdk.Context, spAddr sdk.AccAddress) (string, error) {
+	sp, found := k.spKeeper.GetStorageProvider(ctx, spAddr)
+	if !found {
+		return "", fmt.Errorf("storage provider %s not found", spAddr)
+	}
+	return sp.FundingAddress, nil
+}
+
 func (k Keeper) ChargeInitialReadFee(ctx sdk.Context, bucketInfo *storagetypes.BucketInfo) error {
 	if bucketInfo.ChargedReadQuota == 0 {
 		return nil
@@ -154,13 +162,17 @@ func (k Keeper) GetBucketBill(ctx sdk.Context, bucketInfo *storagetypes.BucketIn
 	if err != nil {
 		return userFlows, fmt.Errorf("get storage price failed: %w", err)
 	}
+	primarySpFundingAddr, err := k.GetFundingAddressBySpAddr(ctx, sdk.MustAccAddressFromHex(bucketInfo.PrimarySpAddress))
+	if err != nil {
+		return userFlows, fmt.Errorf("get funding address by sp address failed: %w, sp: %s", err, bucketInfo.PrimarySpAddress)
+	}
 	totalUserOutRate := sdkmath.ZeroInt()
 	readFlowRate := price.ReadPrice.MulInt(sdkmath.NewIntFromUint64(bucketInfo.ChargedReadQuota)).TruncateInt()
 	primaryStoreFlowRate := price.PrimaryStorePrice.MulInt(sdkmath.NewIntFromUint64(bucketInfo.BillingInfo.TotalChargeSize)).TruncateInt()
 	primarySpRate := readFlowRate.Add(primaryStoreFlowRate)
 	if primarySpRate.IsPositive() {
 		userFlows.Flows = append(userFlows.Flows, types.OutFlow{
-			ToAddress: bucketInfo.PrimarySpAddress,
+			ToAddress: primarySpFundingAddr,
 			Rate:      primarySpRate,
 		})
 		totalUserOutRate = totalUserOutRate.Add(primarySpRate)
@@ -170,8 +182,12 @@ func (k Keeper) GetBucketBill(ctx sdk.Context, bucketInfo *storagetypes.BucketIn
 		if rate.IsZero() {
 			continue
 		}
+		spFundingAddr, err := k.GetFundingAddressBySpAddr(ctx, sdk.MustAccAddressFromHex(spObjectsSize.SpAddress))
+		if err != nil {
+			return userFlows, fmt.Errorf("get funding address by sp address failed: %w, sp: %s", err, spObjectsSize.SpAddress)
+		}
 		userFlows.Flows = append(userFlows.Flows, types.OutFlow{
-			ToAddress: spObjectsSize.SpAddress,
+			ToAddress: spFundingAddr,
 			Rate:      rate,
 		})
 		totalUserOutRate = totalUserOutRate.Add(rate)


### PR DESCRIPTION
### Description

Make SP receive storage fee with funding address.

### Rationale

Currently, the storage fee goes to the SP operator address. Change it to the funding address.

### Example

NA

### Changes

Notable changes: 
* NA
