### PR TITLE
feat: remove amino dependencies for GetSignBytes

### DIFF
--- a/x/bridge/types/codec.go
+++ b/x/bridge/types/codec.go
@@ -22,10 +22,5 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 }
 
 var (
-	Amino     = codec.NewLegacyAmino()
-	ModuleCdc = codec.NewAminoCodec(Amino)
+	ModuleCdc = codec.NewProtoCodec(cdctypes.NewInterfaceRegistry())
 )
-
-func init() {
-	RegisterCodec(Amino)
-}

--- a/x/payment/types/codec.go
+++ b/x/payment/types/codec.go
@@ -3,10 +3,8 @@ package types
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
-	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
-	authzcodec "github.com/cosmos/cosmos-sdk/x/authz/codec"
 )
 
 func RegisterCodec(cdc *codec.LegacyAmino) {
@@ -36,16 +34,5 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 }
 
 var (
-	Amino     = codec.NewLegacyAmino()
-	ModuleCdc = codec.NewAminoCodec(Amino)
+	ModuleCdc = codec.NewProtoCodec(cdctypes.NewInterfaceRegistry())
 )
-
-func init() {
-	RegisterCodec(Amino)
-	cryptocodec.RegisterCrypto(Amino)
-	sdk.RegisterLegacyAminoCodec(Amino)
-
-	// Register all Amino interfaces and concrete types on the authz Amino codec so that this can later be
-	// used to properly serialize MsgGrant and MsgExec instances
-	RegisterCodec(authzcodec.Amino)
-}

--- a/x/sp/types/codec.go
+++ b/x/sp/types/codec.go
@@ -3,11 +3,9 @@ package types
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
-	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 	"github.com/cosmos/cosmos-sdk/x/authz"
-	authzcodec "github.com/cosmos/cosmos-sdk/x/authz/codec"
 )
 
 func RegisterCodec(cdc *codec.LegacyAmino) {
@@ -42,16 +40,5 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 }
 
 var (
-	Amino     = codec.NewLegacyAmino()
-	ModuleCdc = codec.NewAminoCodec(Amino)
+	ModuleCdc = codec.NewProtoCodec(cdctypes.NewInterfaceRegistry())
 )
-
-func init() {
-	RegisterCodec(Amino)
-	cryptocodec.RegisterCrypto(Amino)
-	sdk.RegisterLegacyAminoCodec(Amino)
-
-	// Register all Amino interfaces and concrete types on the authz Amino codec so that this can later be
-	// used to properly serialize MsgGrant and MsgExec instances
-	RegisterCodec(authzcodec.Amino)
-}

--- a/x/storage/types/codec.go
+++ b/x/storage/types/codec.go
@@ -3,10 +3,8 @@ package types
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
-	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
-	authzcodec "github.com/cosmos/cosmos-sdk/x/authz/codec"
 )
 
 func RegisterCodec(cdc *codec.LegacyAmino) {
@@ -76,16 +74,5 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 }
 
 var (
-	Amino     = codec.NewLegacyAmino()
-	ModuleCdc = codec.NewAminoCodec(Amino)
+	ModuleCdc = codec.NewProtoCodec(cdctypes.NewInterfaceRegistry())
 )
-
-func init() {
-	RegisterCodec(Amino)
-	cryptocodec.RegisterCrypto(Amino)
-	sdk.RegisterLegacyAminoCodec(Amino)
-
-	// Register all Amino interfaces and concrete types on the authz Amino codec so that this can later be
-	// used to properly serialize MsgGrant and MsgExec instances
-	RegisterCodec(authzcodec.Amino)
-}


### PR DESCRIPTION
### Description

This pr removes the amino dependencies for GetSignBytes and cherries pick the pr:

https://github.com/bnb-chain/greenfield/pull/178

### Rationale

Remove amino dependencies for GetSignBytes

### Example

N/A

### Changes

Notable changes: 
* remove amino dependencies for GetSignBytes
