### PR TITLE
fix: update group operation code

### DIFF
--- a/x/storage/types/crosschain.go
+++ b/x/storage/types/crosschain.go
@@ -493,8 +493,8 @@ func (p DeleteGroupAckPackage) MustSerialize() []byte {
 }
 
 const (
-	OperationAddGroupMember    uint8 = 1
-	OperationDeleteGroupMember uint8 = 2
+	OperationAddGroupMember    uint8 = 0
+	OperationDeleteGroupMember uint8 = 1
 )
 
 type UpdateGroupMemberSynPackage struct {


### PR DESCRIPTION
### Description

This pr is to fix the mis-align between greenfield and bsc's definition of update group operation code 

### Changes

Notable changes: 
* modify update group operation code
