### PR TITLE
fix: bring back the swagger server

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -81,9 +81,11 @@ import (
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
+	docs "github.com/bnb-chain/greenfield/swagger"
+	"github.com/bnb-chain/greenfield/types/openapiutil"
+
 	"github.com/bnb-chain/greenfield/app/ante"
 	appparams "github.com/bnb-chain/greenfield/app/params"
-	docs "github.com/bnb-chain/greenfield/swagger"
 	"github.com/bnb-chain/greenfield/version"
 	bridgemodule "github.com/bnb-chain/greenfield/x/bridge"
 	bridgemodulekeeper "github.com/bnb-chain/greenfield/x/bridge/keeper"
@@ -816,6 +818,7 @@ func (app *App) RegisterAPIRoutes(apiSvr *api.Server, apiConfig config.APIConfig
 
 	// register app's OpenAPI routes.
 	apiSvr.Router.Handle("/static/swagger.yaml", http.FileServer(http.FS(docs.Docs)))
+	apiSvr.Router.HandleFunc("/", openapiutil.Handler(Name, "/static/swagger.yaml"))
 }
 
 // RegisterTxService implements the Application.RegisterTxService method.

--- a/app/app.go
+++ b/app/app.go
@@ -81,11 +81,10 @@ import (
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
-	docs "github.com/bnb-chain/greenfield/swagger"
-	"github.com/bnb-chain/greenfield/types/openapiutil"
-
 	"github.com/bnb-chain/greenfield/app/ante"
 	appparams "github.com/bnb-chain/greenfield/app/params"
+	docs "github.com/bnb-chain/greenfield/swagger"
+	"github.com/bnb-chain/greenfield/types/openapiutil"
 	"github.com/bnb-chain/greenfield/version"
 	bridgemodule "github.com/bnb-chain/greenfield/x/bridge"
 	bridgemodulekeeper "github.com/bnb-chain/greenfield/x/bridge/keeper"

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 ![banner](./docs/asset/gnfd-banner.png)
 
-Official Golang implementation of the Greenfield Blockchain. It uses [tendermint](https://github.com/cometbft/cometbft/)
+Official Golang implementation of the Greenfield Blockchain. It uses [cometbft](https://github.com/cometbft/cometbft/)
 for consensus and build on [cosmos-sdk](https://github.com/cosmos/cosmos-sdk).
 
 BNB Greenfield aims to facilitate the decentralized data economy by simplifying the process of storing and managing data

--- a/swagger/static/swagger.yaml
+++ b/swagger/static/swagger.yaml
@@ -207,7 +207,11 @@ paths:
             properties:
               dynamic_balance:
                 type: string
+                title: dynamic balance is static balance + flowDelta
               stream_record:
+                title: >-
+                  the stream record of the given account, if it does not exist,
+                  it will be default values
                 type: object
                 properties:
                   account:
@@ -281,10 +285,22 @@ paths:
 
                         from a stream account to a Storage Provider
                     title: the accumulated outflow rates of the stream account
-                title: Stream Payment Record of a stream account
               current_timestamp:
                 type: string
                 format: int64
+                title: the timestamp of the current block
+              bank_balance:
+                type: string
+                title: bank_balance is the BNB balance of the bank module
+              available_balance:
+                type: string
+                title: available_balance is bank balance + static balance
+              locked_fee:
+                type: string
+                title: locked_fee is buffer balance + locked balance
+              change_rate:
+                type: string
+                title: change_rate is the netflow rate of the given account
         default:
           description: An unexpected error response.
           schema:
@@ -3845,10 +3861,420 @@ paths:
             - ACTION_TYPE_ALL
       tags:
         - Query
+  /cosmos/auth/v1beta1/account_info/{address}:
+    get:
+      summary: AccountInfo queries account info which is common to all account types.
+      description: 'Since: cosmos-sdk 0.47'
+      operationId: AccountInfo
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              info:
+                description: info is the account info which is represented by BaseAccount.
+                type: object
+                properties:
+                  address:
+                    type: string
+                  pub_key:
+                    type: object
+                    properties:
+                      type_url:
+                        type: string
+                        description: >-
+                          A URL/resource name that uniquely identifies the type
+                          of the serialized
+
+                          protocol buffer message. This string must contain at
+                          least
+
+                          one "/" character. The last segment of the URL's path
+                          must represent
+
+                          the fully qualified name of the type (as in
+
+                          `path/google.protobuf.Duration`). The name should be
+                          in a canonical form
+
+                          (e.g., leading "." is not accepted).
+
+
+                          In practice, teams usually precompile into the binary
+                          all types that they
+
+                          expect it to use in the context of Any. However, for
+                          URLs which use the
+
+                          scheme `http`, `https`, or no scheme, one can
+                          optionally set up a type
+
+                          server that maps type URLs to message definitions as
+                          follows:
+
+
+                          * If no scheme is provided, `https` is assumed.
+
+                          * An HTTP GET on the URL must yield a
+                          [google.protobuf.Type][]
+                            value in binary format, or produce an error.
+                          * Applications are allowed to cache lookup results
+                          based on the
+                            URL, or have them precompiled into a binary to avoid any
+                            lookup. Therefore, binary compatibility needs to be preserved
+                            on changes to types. (Use versioned type names to manage
+                            breaking changes.)
+
+                          Note: this functionality is not currently available in
+                          the official
+
+                          protobuf release, and it is not used for type URLs
+                          beginning with
+
+                          type.googleapis.com.
+
+
+                          Schemes other than `http`, `https` (or the empty
+                          scheme) might be
+
+                          used with implementation specific semantics.
+                      value:
+                        type: string
+                        format: byte
+                        description: >-
+                          Must be a valid serialized protocol buffer of the
+                          above specified type.
+                    description: >-
+                      `Any` contains an arbitrary serialized protocol buffer
+                      message along with a
+
+                      URL that describes the type of the serialized message.
+
+
+                      Protobuf library provides support to pack/unpack Any
+                      values in the form
+
+                      of utility functions or additional generated methods of
+                      the Any type.
+
+
+                      Example 1: Pack and unpack a message in C++.
+
+                          Foo foo = ...;
+                          Any any;
+                          any.PackFrom(foo);
+                          ...
+                          if (any.UnpackTo(&foo)) {
+                            ...
+                          }
+
+                      Example 2: Pack and unpack a message in Java.
+
+                          Foo foo = ...;
+                          Any any = Any.pack(foo);
+                          ...
+                          if (any.is(Foo.class)) {
+                            foo = any.unpack(Foo.class);
+                          }
+
+                      Example 3: Pack and unpack a message in Python.
+
+                          foo = Foo(...)
+                          any = Any()
+                          any.Pack(foo)
+                          ...
+                          if any.Is(Foo.DESCRIPTOR):
+                            any.Unpack(foo)
+                            ...
+
+                      Example 4: Pack and unpack a message in Go
+
+                           foo := &pb.Foo{...}
+                           any, err := anypb.New(foo)
+                           if err != nil {
+                             ...
+                           }
+                           ...
+                           foo := &pb.Foo{}
+                           if err := any.UnmarshalTo(foo); err != nil {
+                             ...
+                           }
+
+                      The pack methods provided by protobuf library will by
+                      default use
+
+                      'type.googleapis.com/full.type.name' as the type URL and
+                      the unpack
+
+                      methods only use the fully qualified type name after the
+                      last '/'
+
+                      in the type URL, for example "foo.bar.com/x/y.z" will
+                      yield type
+
+                      name "y.z".
+
+
+
+                      JSON
+
+
+                      The JSON representation of an `Any` value uses the regular
+
+                      representation of the deserialized, embedded message, with
+                      an
+
+                      additional field `@type` which contains the type URL.
+                      Example:
+
+                          package google.profile;
+                          message Person {
+                            string first_name = 1;
+                            string last_name = 2;
+                          }
+
+                          {
+                            "@type": "type.googleapis.com/google.profile.Person",
+                            "firstName": <string>,
+                            "lastName": <string>
+                          }
+
+                      If the embedded message type is well-known and has a
+                      custom JSON
+
+                      representation, that representation will be embedded
+                      adding a field
+
+                      `value` which holds the custom JSON in addition to the
+                      `@type`
+
+                      field. Example (for message [google.protobuf.Duration][]):
+
+                          {
+                            "@type": "type.googleapis.com/google.protobuf.Duration",
+                            "value": "1.212s"
+                          }
+                  account_number:
+                    type: string
+                    format: uint64
+                  sequence:
+                    type: string
+                    format: uint64
+            description: |-
+              QueryAccountInfoResponse is the Query/AccountInfo response type.
+
+              Since: cosmos-sdk 0.47
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                      description: >-
+                        A URL/resource name that uniquely identifies the type of
+                        the serialized
+
+                        protocol buffer message. This string must contain at
+                        least
+
+                        one "/" character. The last segment of the URL's path
+                        must represent
+
+                        the fully qualified name of the type (as in
+
+                        `path/google.protobuf.Duration`). The name should be in
+                        a canonical form
+
+                        (e.g., leading "." is not accepted).
+
+
+                        In practice, teams usually precompile into the binary
+                        all types that they
+
+                        expect it to use in the context of Any. However, for
+                        URLs which use the
+
+                        scheme `http`, `https`, or no scheme, one can optionally
+                        set up a type
+
+                        server that maps type URLs to message definitions as
+                        follows:
+
+
+                        * If no scheme is provided, `https` is assumed.
+
+                        * An HTTP GET on the URL must yield a
+                        [google.protobuf.Type][]
+                          value in binary format, or produce an error.
+                        * Applications are allowed to cache lookup results based
+                        on the
+                          URL, or have them precompiled into a binary to avoid any
+                          lookup. Therefore, binary compatibility needs to be preserved
+                          on changes to types. (Use versioned type names to manage
+                          breaking changes.)
+
+                        Note: this functionality is not currently available in
+                        the official
+
+                        protobuf release, and it is not used for type URLs
+                        beginning with
+
+                        type.googleapis.com.
+
+
+                        Schemes other than `http`, `https` (or the empty scheme)
+                        might be
+
+                        used with implementation specific semantics.
+                    value:
+                      type: string
+                      format: byte
+                      description: >-
+                        Must be a valid serialized protocol buffer of the above
+                        specified type.
+                  description: >-
+                    `Any` contains an arbitrary serialized protocol buffer
+                    message along with a
+
+                    URL that describes the type of the serialized message.
+
+
+                    Protobuf library provides support to pack/unpack Any values
+                    in the form
+
+                    of utility functions or additional generated methods of the
+                    Any type.
+
+
+                    Example 1: Pack and unpack a message in C++.
+
+                        Foo foo = ...;
+                        Any any;
+                        any.PackFrom(foo);
+                        ...
+                        if (any.UnpackTo(&foo)) {
+                          ...
+                        }
+
+                    Example 2: Pack and unpack a message in Java.
+
+                        Foo foo = ...;
+                        Any any = Any.pack(foo);
+                        ...
+                        if (any.is(Foo.class)) {
+                          foo = any.unpack(Foo.class);
+                        }
+
+                    Example 3: Pack and unpack a message in Python.
+
+                        foo = Foo(...)
+                        any = Any()
+                        any.Pack(foo)
+                        ...
+                        if any.Is(Foo.DESCRIPTOR):
+                          any.Unpack(foo)
+                          ...
+
+                    Example 4: Pack and unpack a message in Go
+
+                         foo := &pb.Foo{...}
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
+                         ...
+                         foo := &pb.Foo{}
+                         if err := any.UnmarshalTo(foo); err != nil {
+                           ...
+                         }
+
+                    The pack methods provided by protobuf library will by
+                    default use
+
+                    'type.googleapis.com/full.type.name' as the type URL and the
+                    unpack
+
+                    methods only use the fully qualified type name after the
+                    last '/'
+
+                    in the type URL, for example "foo.bar.com/x/y.z" will yield
+                    type
+
+                    name "y.z".
+
+
+
+                    JSON
+
+
+                    The JSON representation of an `Any` value uses the regular
+
+                    representation of the deserialized, embedded message, with
+                    an
+
+                    additional field `@type` which contains the type URL.
+                    Example:
+
+                        package google.profile;
+                        message Person {
+                          string first_name = 1;
+                          string last_name = 2;
+                        }
+
+                        {
+                          "@type": "type.googleapis.com/google.profile.Person",
+                          "firstName": <string>,
+                          "lastName": <string>
+                        }
+
+                    If the embedded message type is well-known and has a custom
+                    JSON
+
+                    representation, that representation will be embedded adding
+                    a field
+
+                    `value` which holds the custom JSON in addition to the
+                    `@type`
+
+                    field. Example (for message [google.protobuf.Duration][]):
+
+                        {
+                          "@type": "type.googleapis.com/google.protobuf.Duration",
+                          "value": "1.212s"
+                        }
+      parameters:
+        - name: address
+          description: address is the account address string.
+          in: path
+          required: true
+          type: string
+      tags:
+        - Query
   /cosmos/auth/v1beta1/accounts:
     get:
-      summary: Accounts returns all the existing accounts
-      description: 'Since: cosmos-sdk 0.43'
+      summary: Accounts returns all the existing accounts.
+      description: >-
+        When called from another module, this query might consume a high amount
+        of
+
+        gas if the pagination field is incorrectly set.
+
+
+        Since: cosmos-sdk 0.43
       operationId: Accounts
       responses:
         '200':
@@ -3958,7 +4384,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -3968,13 +4394,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -3996,7 +4425,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -4173,7 +4601,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -4183,13 +4611,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -4211,7 +4642,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -4416,7 +4846,7 @@ paths:
                         foo = any.unpack(Foo.class);
                       }
 
-                   Example 3: Pack and unpack a message in Python.
+                  Example 3: Pack and unpack a message in Python.
 
                       foo = Foo(...)
                       any = Any()
@@ -4426,13 +4856,16 @@ paths:
                         any.Unpack(foo)
                         ...
 
-                   Example 4: Pack and unpack a message in Go
+                  Example 4: Pack and unpack a message in Go
 
                        foo := &pb.Foo{...}
-                       any, err := ptypes.MarshalAny(foo)
+                       any, err := anypb.New(foo)
+                       if err != nil {
+                         ...
+                       }
                        ...
                        foo := &pb.Foo{}
-                       if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                       if err := any.UnmarshalTo(foo); err != nil {
                          ...
                        }
 
@@ -4454,7 +4887,6 @@ paths:
 
                   JSON
 
-                  ====
 
                   The JSON representation of an `Any` value uses the regular
 
@@ -4605,7 +5037,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -4615,13 +5047,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -4643,7 +5078,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -4819,7 +5253,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -4829,13 +5263,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -4857,7 +5294,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -4897,6 +5333,8 @@ paths:
       parameters:
         - name: id
           description: |-
+            Deprecated, use account_id instead
+
             id is the account number of the address to be queried. This field
             should have been an uint64 (like all account numbers), and will be
             updated to uint64 in a future version of the auth query.
@@ -4904,438 +5342,15 @@ paths:
           required: true
           type: string
           format: int64
-      tags:
-        - Query
-  /cosmos/auth/v1beta1/bech32/{address_bytes}:
-    get:
-      summary: AddressBytesToString converts Account Address bytes to string
-      description: 'Since: cosmos-sdk 0.46'
-      operationId: AddressBytesToString
-      responses:
-        '200':
-          description: A successful response.
-          schema:
-            type: object
-            properties:
-              address_string:
-                type: string
-            description: >-
-              AddressBytesToStringResponse is the response type for
-              AddressString rpc method.
+        - name: account_id
+          description: |-
+            account_id is the account number of the address to be queried.
 
-
-              Since: cosmos-sdk 0.46
-        default:
-          description: An unexpected error response.
-          schema:
-            type: object
-            properties:
-              error:
-                type: string
-              code:
-                type: integer
-                format: int32
-              message:
-                type: string
-              details:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    type_url:
-                      type: string
-                      description: >-
-                        A URL/resource name that uniquely identifies the type of
-                        the serialized
-
-                        protocol buffer message. This string must contain at
-                        least
-
-                        one "/" character. The last segment of the URL's path
-                        must represent
-
-                        the fully qualified name of the type (as in
-
-                        `path/google.protobuf.Duration`). The name should be in
-                        a canonical form
-
-                        (e.g., leading "." is not accepted).
-
-
-                        In practice, teams usually precompile into the binary
-                        all types that they
-
-                        expect it to use in the context of Any. However, for
-                        URLs which use the
-
-                        scheme `http`, `https`, or no scheme, one can optionally
-                        set up a type
-
-                        server that maps type URLs to message definitions as
-                        follows:
-
-
-                        * If no scheme is provided, `https` is assumed.
-
-                        * An HTTP GET on the URL must yield a
-                        [google.protobuf.Type][]
-                          value in binary format, or produce an error.
-                        * Applications are allowed to cache lookup results based
-                        on the
-                          URL, or have them precompiled into a binary to avoid any
-                          lookup. Therefore, binary compatibility needs to be preserved
-                          on changes to types. (Use versioned type names to manage
-                          breaking changes.)
-
-                        Note: this functionality is not currently available in
-                        the official
-
-                        protobuf release, and it is not used for type URLs
-                        beginning with
-
-                        type.googleapis.com.
-
-
-                        Schemes other than `http`, `https` (or the empty scheme)
-                        might be
-
-                        used with implementation specific semantics.
-                    value:
-                      type: string
-                      format: byte
-                      description: >-
-                        Must be a valid serialized protocol buffer of the above
-                        specified type.
-                  description: >-
-                    `Any` contains an arbitrary serialized protocol buffer
-                    message along with a
-
-                    URL that describes the type of the serialized message.
-
-
-                    Protobuf library provides support to pack/unpack Any values
-                    in the form
-
-                    of utility functions or additional generated methods of the
-                    Any type.
-
-
-                    Example 1: Pack and unpack a message in C++.
-
-                        Foo foo = ...;
-                        Any any;
-                        any.PackFrom(foo);
-                        ...
-                        if (any.UnpackTo(&foo)) {
-                          ...
-                        }
-
-                    Example 2: Pack and unpack a message in Java.
-
-                        Foo foo = ...;
-                        Any any = Any.pack(foo);
-                        ...
-                        if (any.is(Foo.class)) {
-                          foo = any.unpack(Foo.class);
-                        }
-
-                     Example 3: Pack and unpack a message in Python.
-
-                        foo = Foo(...)
-                        any = Any()
-                        any.Pack(foo)
-                        ...
-                        if any.Is(Foo.DESCRIPTOR):
-                          any.Unpack(foo)
-                          ...
-
-                     Example 4: Pack and unpack a message in Go
-
-                         foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
-                         ...
-                         foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
-                           ...
-                         }
-
-                    The pack methods provided by protobuf library will by
-                    default use
-
-                    'type.googleapis.com/full.type.name' as the type URL and the
-                    unpack
-
-                    methods only use the fully qualified type name after the
-                    last '/'
-
-                    in the type URL, for example "foo.bar.com/x/y.z" will yield
-                    type
-
-                    name "y.z".
-
-
-
-                    JSON
-
-                    ====
-
-                    The JSON representation of an `Any` value uses the regular
-
-                    representation of the deserialized, embedded message, with
-                    an
-
-                    additional field `@type` which contains the type URL.
-                    Example:
-
-                        package google.profile;
-                        message Person {
-                          string first_name = 1;
-                          string last_name = 2;
-                        }
-
-                        {
-                          "@type": "type.googleapis.com/google.profile.Person",
-                          "firstName": <string>,
-                          "lastName": <string>
-                        }
-
-                    If the embedded message type is well-known and has a custom
-                    JSON
-
-                    representation, that representation will be embedded adding
-                    a field
-
-                    `value` which holds the custom JSON in addition to the
-                    `@type`
-
-                    field. Example (for message [google.protobuf.Duration][]):
-
-                        {
-                          "@type": "type.googleapis.com/google.protobuf.Duration",
-                          "value": "1.212s"
-                        }
-      parameters:
-        - name: address_bytes
-          in: path
-          required: true
+            Since: cosmos-sdk 0.47
+          in: query
+          required: false
           type: string
-          format: byte
-      tags:
-        - Query
-  /cosmos/auth/v1beta1/bech32/{address_string}:
-    get:
-      summary: AddressStringToBytes converts Address string to bytes
-      description: 'Since: cosmos-sdk 0.46'
-      operationId: AddressStringToBytes
-      responses:
-        '200':
-          description: A successful response.
-          schema:
-            type: object
-            properties:
-              address_bytes:
-                type: string
-                format: byte
-            description: >-
-              AddressStringToBytesResponse is the response type for AddressBytes
-              rpc method.
-
-
-              Since: cosmos-sdk 0.46
-        default:
-          description: An unexpected error response.
-          schema:
-            type: object
-            properties:
-              error:
-                type: string
-              code:
-                type: integer
-                format: int32
-              message:
-                type: string
-              details:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    type_url:
-                      type: string
-                      description: >-
-                        A URL/resource name that uniquely identifies the type of
-                        the serialized
-
-                        protocol buffer message. This string must contain at
-                        least
-
-                        one "/" character. The last segment of the URL's path
-                        must represent
-
-                        the fully qualified name of the type (as in
-
-                        `path/google.protobuf.Duration`). The name should be in
-                        a canonical form
-
-                        (e.g., leading "." is not accepted).
-
-
-                        In practice, teams usually precompile into the binary
-                        all types that they
-
-                        expect it to use in the context of Any. However, for
-                        URLs which use the
-
-                        scheme `http`, `https`, or no scheme, one can optionally
-                        set up a type
-
-                        server that maps type URLs to message definitions as
-                        follows:
-
-
-                        * If no scheme is provided, `https` is assumed.
-
-                        * An HTTP GET on the URL must yield a
-                        [google.protobuf.Type][]
-                          value in binary format, or produce an error.
-                        * Applications are allowed to cache lookup results based
-                        on the
-                          URL, or have them precompiled into a binary to avoid any
-                          lookup. Therefore, binary compatibility needs to be preserved
-                          on changes to types. (Use versioned type names to manage
-                          breaking changes.)
-
-                        Note: this functionality is not currently available in
-                        the official
-
-                        protobuf release, and it is not used for type URLs
-                        beginning with
-
-                        type.googleapis.com.
-
-
-                        Schemes other than `http`, `https` (or the empty scheme)
-                        might be
-
-                        used with implementation specific semantics.
-                    value:
-                      type: string
-                      format: byte
-                      description: >-
-                        Must be a valid serialized protocol buffer of the above
-                        specified type.
-                  description: >-
-                    `Any` contains an arbitrary serialized protocol buffer
-                    message along with a
-
-                    URL that describes the type of the serialized message.
-
-
-                    Protobuf library provides support to pack/unpack Any values
-                    in the form
-
-                    of utility functions or additional generated methods of the
-                    Any type.
-
-
-                    Example 1: Pack and unpack a message in C++.
-
-                        Foo foo = ...;
-                        Any any;
-                        any.PackFrom(foo);
-                        ...
-                        if (any.UnpackTo(&foo)) {
-                          ...
-                        }
-
-                    Example 2: Pack and unpack a message in Java.
-
-                        Foo foo = ...;
-                        Any any = Any.pack(foo);
-                        ...
-                        if (any.is(Foo.class)) {
-                          foo = any.unpack(Foo.class);
-                        }
-
-                     Example 3: Pack and unpack a message in Python.
-
-                        foo = Foo(...)
-                        any = Any()
-                        any.Pack(foo)
-                        ...
-                        if any.Is(Foo.DESCRIPTOR):
-                          any.Unpack(foo)
-                          ...
-
-                     Example 4: Pack and unpack a message in Go
-
-                         foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
-                         ...
-                         foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
-                           ...
-                         }
-
-                    The pack methods provided by protobuf library will by
-                    default use
-
-                    'type.googleapis.com/full.type.name' as the type URL and the
-                    unpack
-
-                    methods only use the fully qualified type name after the
-                    last '/'
-
-                    in the type URL, for example "foo.bar.com/x/y.z" will yield
-                    type
-
-                    name "y.z".
-
-
-
-                    JSON
-
-                    ====
-
-                    The JSON representation of an `Any` value uses the regular
-
-                    representation of the deserialized, embedded message, with
-                    an
-
-                    additional field `@type` which contains the type URL.
-                    Example:
-
-                        package google.profile;
-                        message Person {
-                          string first_name = 1;
-                          string last_name = 2;
-                        }
-
-                        {
-                          "@type": "type.googleapis.com/google.profile.Person",
-                          "firstName": <string>,
-                          "lastName": <string>
-                        }
-
-                    If the embedded message type is well-known and has a custom
-                    JSON
-
-                    representation, that representation will be embedded adding
-                    a field
-
-                    `value` which holds the custom JSON in addition to the
-                    `@type`
-
-                    field. Example (for message [google.protobuf.Duration][]):
-
-                        {
-                          "@type": "type.googleapis.com/google.protobuf.Duration",
-                          "value": "1.212s"
-                        }
-      parameters:
-        - name: address_string
-          in: path
-          required: true
-          type: string
+          format: uint64
       tags:
         - Query
   /cosmos/auth/v1beta1/module_accounts:
@@ -5451,7 +5466,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -5461,13 +5476,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -5489,7 +5507,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -5646,7 +5663,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -5656,13 +5673,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -5684,7 +5704,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -5832,7 +5851,7 @@ paths:
                         foo = any.unpack(Foo.class);
                       }
 
-                   Example 3: Pack and unpack a message in Python.
+                  Example 3: Pack and unpack a message in Python.
 
                       foo = Foo(...)
                       any = Any()
@@ -5842,13 +5861,16 @@ paths:
                         any.Unpack(foo)
                         ...
 
-                   Example 4: Pack and unpack a message in Go
+                  Example 4: Pack and unpack a message in Go
 
                        foo := &pb.Foo{...}
-                       any, err := ptypes.MarshalAny(foo)
+                       any, err := anypb.New(foo)
+                       if err != nil {
+                         ...
+                       }
                        ...
                        foo := &pb.Foo{}
-                       if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                       if err := any.UnmarshalTo(foo); err != nil {
                          ...
                        }
 
@@ -5870,7 +5892,6 @@ paths:
 
                   JSON
 
-                  ====
 
                   The JSON representation of an `Any` value uses the regular
 
@@ -6021,7 +6042,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -6031,13 +6052,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -6059,7 +6083,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -6130,9 +6153,6 @@ paths:
                     type: string
                     format: uint64
                   sig_verify_cost_secp256k1:
-                    type: string
-                    format: uint64
-                  sig_verify_cost_ethsecp256k1:
                     type: string
                     format: uint64
             description: >-
@@ -6252,7 +6272,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -6262,13 +6282,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -6290,7 +6313,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -6444,7 +6466,7 @@ paths:
                               foo = any.unpack(Foo.class);
                             }
 
-                         Example 3: Pack and unpack a message in Python.
+                        Example 3: Pack and unpack a message in Python.
 
                             foo = Foo(...)
                             any = Any()
@@ -6454,13 +6476,16 @@ paths:
                               any.Unpack(foo)
                               ...
 
-                         Example 4: Pack and unpack a message in Go
+                        Example 4: Pack and unpack a message in Go
 
                              foo := &pb.Foo{...}
-                             any, err := ptypes.MarshalAny(foo)
+                             any, err := anypb.New(foo)
+                             if err != nil {
+                               ...
+                             }
                              ...
                              foo := &pb.Foo{}
-                             if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                             if err := any.UnmarshalTo(foo); err != nil {
                                ...
                              }
 
@@ -6482,7 +6507,6 @@ paths:
 
                         JSON
 
-                        ====
 
                         The JSON representation of an `Any` value uses the
                         regular
@@ -6674,7 +6698,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -6684,13 +6708,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -6712,7 +6739,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -6943,7 +6969,7 @@ paths:
                               foo = any.unpack(Foo.class);
                             }
 
-                         Example 3: Pack and unpack a message in Python.
+                        Example 3: Pack and unpack a message in Python.
 
                             foo = Foo(...)
                             any = Any()
@@ -6953,13 +6979,16 @@ paths:
                               any.Unpack(foo)
                               ...
 
-                         Example 4: Pack and unpack a message in Go
+                        Example 4: Pack and unpack a message in Go
 
                              foo := &pb.Foo{...}
-                             any, err := ptypes.MarshalAny(foo)
+                             any, err := anypb.New(foo)
+                             if err != nil {
+                               ...
+                             }
                              ...
                              foo := &pb.Foo{}
-                             if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                             if err := any.UnmarshalTo(foo); err != nil {
                                ...
                              }
 
@@ -6981,7 +7010,6 @@ paths:
 
                         JSON
 
-                        ====
 
                         The JSON representation of an `Any` value uses the
                         regular
@@ -7165,7 +7193,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -7175,13 +7203,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -7203,7 +7234,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -7423,7 +7453,7 @@ paths:
                               foo = any.unpack(Foo.class);
                             }
 
-                         Example 3: Pack and unpack a message in Python.
+                        Example 3: Pack and unpack a message in Python.
 
                             foo = Foo(...)
                             any = Any()
@@ -7433,13 +7463,16 @@ paths:
                               any.Unpack(foo)
                               ...
 
-                         Example 4: Pack and unpack a message in Go
+                        Example 4: Pack and unpack a message in Go
 
                              foo := &pb.Foo{...}
-                             any, err := ptypes.MarshalAny(foo)
+                             any, err := anypb.New(foo)
+                             if err != nil {
+                               ...
+                             }
                              ...
                              foo := &pb.Foo{}
-                             if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                             if err := any.UnmarshalTo(foo); err != nil {
                                ...
                              }
 
@@ -7461,7 +7494,6 @@ paths:
 
                         JSON
 
-                        ====
 
                         The JSON representation of an `Any` value uses the
                         regular
@@ -7645,7 +7677,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -7655,13 +7687,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -7683,7 +7718,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -7786,6 +7820,11 @@ paths:
   /cosmos/bank/v1beta1/balances/{address}:
     get:
       summary: AllBalances queries the balance of all coins for a single account.
+      description: >-
+        When called from another module, this query might consume a high amount
+        of
+
+        gas if the pagination field is incorrectly set.
       operationId: AllBalances
       responses:
         '200':
@@ -7919,6 +7958,16 @@ paths:
           in: query
           required: false
           type: boolean
+        - name: resolve_denom
+          description: >-
+            resolve_denom is the flag to resolve the denom into a human-readable
+            form from the metadata.
+
+
+            Since: cosmos-sdk 0.48
+          in: query
+          required: false
+          type: boolean
       tags:
         - Query
   /cosmos/bank/v1beta1/balances/{address}/by_denom:
@@ -7991,7 +8040,14 @@ paths:
         token
 
         denomination.
-      description: 'Since: cosmos-sdk 0.46'
+      description: >-
+        When called from another module, this query might consume a high amount
+        of
+
+        gas if the pagination field is incorrectly set.
+
+
+        Since: cosmos-sdk 0.46
       operationId: DenomOwners
       responses:
         '200':
@@ -8520,6 +8576,18 @@ paths:
                         (whether a denom is
 
                         sendable).
+                    description: >-
+                      Deprecated: Use of SendEnabled in params is deprecated.
+
+                      For genesis, use the newly added send_enabled field in the
+                      genesis object.
+
+                      Storage, lookup, and manipulation of this information is
+                      now in the keeper.
+
+
+                      As of cosmos-sdk 0.47, this only exists for backwards
+                      compatibility of genesis files.
                   default_send_enabled:
                     type: boolean
                 description: Params defines the parameters for the bank module.
@@ -8550,12 +8618,176 @@ paths:
                       format: byte
       tags:
         - Query
+  /cosmos/bank/v1beta1/send_enabled:
+    get:
+      summary: SendEnabled queries for SendEnabled entries.
+      description: >-
+        This query only returns denominations that have specific SendEnabled
+        settings.
+
+        Any denomination that does not have a specific setting will use the
+        default
+
+        params.default_send_enabled, and will not be returned by this query.
+
+
+        Since: cosmos-sdk 0.47
+      operationId: SendEnabled
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              send_enabled:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    denom:
+                      type: string
+                    enabled:
+                      type: boolean
+                  description: >-
+                    SendEnabled maps coin denom to a send_enabled status
+                    (whether a denom is
+
+                    sendable).
+              pagination:
+                description: >-
+                  pagination defines the pagination in the response. This field
+                  is only
+
+                  populated if the denoms field in the request is empty.
+                type: object
+                properties:
+                  next_key:
+                    type: string
+                    format: byte
+                    description: |-
+                      next_key is the key to be passed to PageRequest.key to
+                      query the next page most efficiently. It will be empty if
+                      there are no more results.
+                  total:
+                    type: string
+                    format: uint64
+                    title: >-
+                      total is total number of results available if
+                      PageRequest.count_total
+
+                      was set, its value is undefined otherwise
+            description: >-
+              QuerySendEnabledResponse defines the RPC response of a SendEnable
+              query.
+
+
+              Since: cosmos-sdk 0.47
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                    value:
+                      type: string
+                      format: byte
+      parameters:
+        - name: denoms
+          description: >-
+            denoms is the specific denoms you want look up. Leave empty to get
+            all entries.
+          in: query
+          required: false
+          type: array
+          items:
+            type: string
+          collectionFormat: multi
+        - name: pagination.key
+          description: |-
+            key is a value returned in PageResponse.next_key to begin
+            querying the next page most efficiently. Only one of offset or key
+            should be set.
+          in: query
+          required: false
+          type: string
+          format: byte
+        - name: pagination.offset
+          description: >-
+            offset is a numeric offset that can be used when key is unavailable.
+
+            It is less efficient than using key. Only one of offset or key
+            should
+
+            be set.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.limit
+          description: >-
+            limit is the total number of results to be returned in the result
+            page.
+
+            If left empty it will default to a value to be set by each app.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.count_total
+          description: >-
+            count_total is set to true  to indicate that the result set should
+            include
+
+            a count of the total number of items available for pagination in
+            UIs.
+
+            count_total is only respected when offset is used. It is ignored
+            when key
+
+            is set.
+          in: query
+          required: false
+          type: boolean
+        - name: pagination.reverse
+          description: >-
+            reverse is set to true if results are to be returned in the
+            descending order.
+
+
+            Since: cosmos-sdk 0.43
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - Query
   /cosmos/bank/v1beta1/spendable_balances/{address}:
     get:
-      summary: |-
-        SpendableBalances queries the spenable balance of all coins for a single
+      summary: >-
+        SpendableBalances queries the spendable balance of all coins for a
+        single
+
         account.
-      description: 'Since: cosmos-sdk 0.46'
+      description: >-
+        When called from another module, this query might consume a high amount
+        of
+
+        gas if the pagination field is incorrectly set.
+
+
+        Since: cosmos-sdk 0.46
       operationId: SpendableBalances
       responses:
         '200':
@@ -8694,9 +8926,94 @@ paths:
           type: boolean
       tags:
         - Query
+  /cosmos/bank/v1beta1/spendable_balances/{address}/by_denom:
+    get:
+      summary: >-
+        SpendableBalanceByDenom queries the spendable balance of a single denom
+        for
+
+        a single account.
+      description: >-
+        When called from another module, this query might consume a high amount
+        of
+
+        gas if the pagination field is incorrectly set.
+
+
+        Since: cosmos-sdk 0.47
+      operationId: SpendableBalanceByDenom
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              balance:
+                type: object
+                properties:
+                  denom:
+                    type: string
+                  amount:
+                    type: string
+                description: >-
+                  Coin defines a token with a denomination and an amount.
+
+
+                  NOTE: The amount field is an Int which implements the custom
+                  method
+
+                  signatures required by gogoproto.
+            description: >-
+              QuerySpendableBalanceByDenomResponse defines the gRPC response
+              structure for
+
+              querying an account's spendable balance for a specific denom.
+
+
+              Since: cosmos-sdk 0.47
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                    value:
+                      type: string
+                      format: byte
+      parameters:
+        - name: address
+          description: address is the address to query balances for.
+          in: path
+          required: true
+          type: string
+        - name: denom
+          description: denom is the coin denom to query balances for.
+          in: query
+          required: false
+          type: string
+      tags:
+        - Query
   /cosmos/bank/v1beta1/supply:
     get:
       summary: TotalSupply queries the total supply of all coins.
+      description: >-
+        When called from another module, this query might consume a high amount
+        of
+
+        gas if the pagination field is incorrectly set.
       operationId: TotalSupply
       responses:
         '200':
@@ -8833,6 +9150,11 @@ paths:
   /cosmos/bank/v1beta1/supply/by_denom:
     get:
       summary: SupplyOf queries the supply of a single coin.
+      description: >-
+        When called from another module, this query might consume a high amount
+        of
+
+        gas if the pagination field is incorrectly set.
       operationId: SupplyOf
       responses:
         '200':
@@ -8892,11 +9214,12 @@ paths:
     get:
       summary: >-
         ABCIQuery defines a query handler that supports ABCI queries directly to
+        the
 
-        the application, bypassing Tendermint completely. The ABCI query must
+        application, bypassing Tendermint completely. The ABCI query must
+        contain
 
-        contain a valid and supported path, including app, custom, p2p, and
-        store.
+        a valid and supported path, including app, custom, p2p, and store.
       description: 'Since: cosmos-sdk 0.46'
       operationId: ABCIQuery
       responses:
@@ -8941,24 +9264,20 @@ paths:
                         ProofOp defines an operation used for calculating Merkle
                         root. The data could
 
-                        be arbitrary format, providing nessecary data for
+                        be arbitrary format, providing necessary data for
                         example neighbouring node
 
                         hash.
 
 
                         Note: This type is a duplicate of the ProofOp proto type
-                        defined in
-
-                        Tendermint.
+                        defined in Tendermint.
                 description: >-
                   ProofOps is Merkle proof defined by the list of ProofOps.
 
 
                   Note: This type is a duplicate of the ProofOps proto type
-                  defined in
-
-                  Tendermint.
+                  defined in Tendermint.
               height:
                 type: string
                 format: int64
@@ -8966,9 +9285,7 @@ paths:
                 type: string
             description: >-
               ABCIQueryResponse defines the response structure for the ABCIQuery
-              gRPC
-
-              query.
+              gRPC query.
 
 
               Note: This type is a duplicate of the ResponseQuery proto type
@@ -9089,7 +9406,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -9099,13 +9416,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -9127,7 +9447,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -9292,7 +9611,7 @@ paths:
                       proposer_address:
                         type: string
                         format: byte
-                    description: Header defines the structure of a Tendermint block header.
+                    description: Header defines the structure of a block header.
                   data:
                     type: object
                     properties:
@@ -9538,8 +9857,8 @@ paths:
                                               type: string
                                               format: byte
                                           description: >-
-                                            Header defines the structure of a
-                                            Tendermint block header.
+                                            Header defines the structure of a block
+                                            header.
                                         commit:
                                           type: object
                                           properties:
@@ -9620,7 +9939,7 @@ paths:
                                                     format: byte
                                                 title: >-
                                                   PublicKey defines the keys available for
-                                                  use with Tendermint Validators
+                                                  use with Validators
                                               voting_power:
                                                 type: string
                                                 format: int64
@@ -9644,7 +9963,7 @@ paths:
                                                   format: byte
                                               title: >-
                                                 PublicKey defines the keys available for
-                                                use with Tendermint Validators
+                                                use with Validators
                                             voting_power:
                                               type: string
                                               format: int64
@@ -9676,7 +9995,7 @@ paths:
                                             format: byte
                                         title: >-
                                           PublicKey defines the keys available for
-                                          use with Tendermint Validators
+                                          use with Validators
                                       voting_power:
                                         type: string
                                         format: int64
@@ -9831,10 +10150,10 @@ paths:
                         type: string
                         description: >-
                           proposer_address is the original block proposer
-                          address, formatted as a Bech32 string.
+                          address, formatted as a hex string.
 
                           In Tendermint, this type is `bytes`, but in the SDK,
-                          we convert it to a Bech32 string
+                          we convert it to a hex string
 
                           for better UX.
                     description: Header defines the structure of a Tendermint block header.
@@ -10083,8 +10402,8 @@ paths:
                                               type: string
                                               format: byte
                                           description: >-
-                                            Header defines the structure of a
-                                            Tendermint block header.
+                                            Header defines the structure of a block
+                                            header.
                                         commit:
                                           type: object
                                           properties:
@@ -10165,7 +10484,7 @@ paths:
                                                     format: byte
                                                 title: >-
                                                   PublicKey defines the keys available for
-                                                  use with Tendermint Validators
+                                                  use with Validators
                                               voting_power:
                                                 type: string
                                                 format: int64
@@ -10189,7 +10508,7 @@ paths:
                                                   format: byte
                                               title: >-
                                                 PublicKey defines the keys available for
-                                                use with Tendermint Validators
+                                                use with Validators
                                             voting_power:
                                               type: string
                                               format: int64
@@ -10221,7 +10540,7 @@ paths:
                                             format: byte
                                         title: >-
                                           PublicKey defines the keys available for
-                                          use with Tendermint Validators
+                                          use with Validators
                                       voting_power:
                                         type: string
                                         format: int64
@@ -10299,12 +10618,10 @@ paths:
                   Block is tendermint type Block, with the Header proposer
                   address
 
-                  field converted to bech32 string.
+                  field converted to hex string.
             description: >-
               GetLatestBlockResponse is the response type for the
-              Query/GetLatestBlock RPC
-
-              method.
+              Query/GetLatestBlock RPC method.
         default:
           description: An unexpected error response.
           schema:
@@ -10419,7 +10736,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -10429,13 +10746,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -10457,7 +10777,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -10603,7 +10922,7 @@ paths:
                       proposer_address:
                         type: string
                         format: byte
-                    description: Header defines the structure of a Tendermint block header.
+                    description: Header defines the structure of a block header.
                   data:
                     type: object
                     properties:
@@ -10849,8 +11168,8 @@ paths:
                                               type: string
                                               format: byte
                                           description: >-
-                                            Header defines the structure of a
-                                            Tendermint block header.
+                                            Header defines the structure of a block
+                                            header.
                                         commit:
                                           type: object
                                           properties:
@@ -10931,7 +11250,7 @@ paths:
                                                     format: byte
                                                 title: >-
                                                   PublicKey defines the keys available for
-                                                  use with Tendermint Validators
+                                                  use with Validators
                                               voting_power:
                                                 type: string
                                                 format: int64
@@ -10955,7 +11274,7 @@ paths:
                                                   format: byte
                                               title: >-
                                                 PublicKey defines the keys available for
-                                                use with Tendermint Validators
+                                                use with Validators
                                             voting_power:
                                               type: string
                                               format: int64
@@ -10987,7 +11306,7 @@ paths:
                                             format: byte
                                         title: >-
                                           PublicKey defines the keys available for
-                                          use with Tendermint Validators
+                                          use with Validators
                                       voting_power:
                                         type: string
                                         format: int64
@@ -11142,10 +11461,10 @@ paths:
                         type: string
                         description: >-
                           proposer_address is the original block proposer
-                          address, formatted as a Bech32 string.
+                          address, formatted as a hex string.
 
                           In Tendermint, this type is `bytes`, but in the SDK,
-                          we convert it to a Bech32 string
+                          we convert it to a hex string
 
                           for better UX.
                     description: Header defines the structure of a Tendermint block header.
@@ -11394,8 +11713,8 @@ paths:
                                               type: string
                                               format: byte
                                           description: >-
-                                            Header defines the structure of a
-                                            Tendermint block header.
+                                            Header defines the structure of a block
+                                            header.
                                         commit:
                                           type: object
                                           properties:
@@ -11476,7 +11795,7 @@ paths:
                                                     format: byte
                                                 title: >-
                                                   PublicKey defines the keys available for
-                                                  use with Tendermint Validators
+                                                  use with Validators
                                               voting_power:
                                                 type: string
                                                 format: int64
@@ -11500,7 +11819,7 @@ paths:
                                                   format: byte
                                               title: >-
                                                 PublicKey defines the keys available for
-                                                use with Tendermint Validators
+                                                use with Validators
                                             voting_power:
                                               type: string
                                               format: int64
@@ -11532,7 +11851,7 @@ paths:
                                             format: byte
                                         title: >-
                                           PublicKey defines the keys available for
-                                          use with Tendermint Validators
+                                          use with Validators
                                       voting_power:
                                         type: string
                                         format: int64
@@ -11610,12 +11929,10 @@ paths:
                   Block is tendermint type Block, with the Header proposer
                   address
 
-                  field converted to bech32 string.
+                  field converted to hex string.
             description: >-
               GetBlockByHeightResponse is the response type for the
-              Query/GetBlockByHeight
-
-              RPC method.
+              Query/GetBlockByHeight RPC method.
         default:
           description: An unexpected error response.
           schema:
@@ -11730,7 +12047,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -11740,13 +12057,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -11768,7 +12088,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -11894,9 +12213,7 @@ paths:
                 description: VersionInfo is the type for the GetNodeInfoResponse message.
             description: >-
               GetNodeInfoResponse is the response type for the Query/GetNodeInfo
-              RPC
-
-              method.
+              RPC method.
         default:
           description: An unexpected error response.
           schema:
@@ -12011,7 +12328,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -12021,13 +12338,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -12049,7 +12369,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -12217,7 +12536,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -12227,13 +12546,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -12255,7 +12577,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -12414,7 +12735,7 @@ paths:
                               foo = any.unpack(Foo.class);
                             }
 
-                         Example 3: Pack and unpack a message in Python.
+                        Example 3: Pack and unpack a message in Python.
 
                             foo = Foo(...)
                             any = Any()
@@ -12424,13 +12745,16 @@ paths:
                               any.Unpack(foo)
                               ...
 
-                         Example 4: Pack and unpack a message in Go
+                        Example 4: Pack and unpack a message in Go
 
                              foo := &pb.Foo{...}
-                             any, err := ptypes.MarshalAny(foo)
+                             any, err := anypb.New(foo)
+                             if err != nil {
+                               ...
+                             }
                              ...
                              foo := &pb.Foo{}
-                             if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                             if err := any.UnmarshalTo(foo); err != nil {
                                ...
                              }
 
@@ -12452,7 +12776,6 @@ paths:
 
                         JSON
 
-                        ====
 
                         The JSON representation of an `Any` value uses the
                         regular
@@ -12517,7 +12840,7 @@ paths:
                       PageRequest.count_total
 
                       was set, its value is undefined otherwise
-            description: |-
+            description: >-
               GetLatestValidatorSetResponse is the response type for the
               Query/GetValidatorSetByHeight RPC method.
         default:
@@ -12634,7 +12957,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -12644,13 +12967,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -12672,7 +12998,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -12888,7 +13213,7 @@ paths:
                               foo = any.unpack(Foo.class);
                             }
 
-                         Example 3: Pack and unpack a message in Python.
+                        Example 3: Pack and unpack a message in Python.
 
                             foo = Foo(...)
                             any = Any()
@@ -12898,13 +13223,16 @@ paths:
                               any.Unpack(foo)
                               ...
 
-                         Example 4: Pack and unpack a message in Go
+                        Example 4: Pack and unpack a message in Go
 
                              foo := &pb.Foo{...}
-                             any, err := ptypes.MarshalAny(foo)
+                             any, err := anypb.New(foo)
+                             if err != nil {
+                               ...
+                             }
                              ...
                              foo := &pb.Foo{}
-                             if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                             if err := any.UnmarshalTo(foo); err != nil {
                                ...
                              }
 
@@ -12926,7 +13254,6 @@ paths:
 
                         JSON
 
-                        ====
 
                         The JSON representation of an `Any` value uses the
                         regular
@@ -12991,7 +13318,7 @@ paths:
                       PageRequest.count_total
 
                       was set, its value is undefined otherwise
-            description: |-
+            description: >-
               GetValidatorSetByHeightResponse is the response type for the
               Query/GetValidatorSetByHeight RPC method.
         default:
@@ -13108,7 +13435,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -13118,13 +13445,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -13146,7 +13476,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -13504,7 +13833,7 @@ paths:
   /cosmos/distribution/v1beta1/delegators/{delegator_address}/rewards:
     get:
       summary: |-
-        DelegationTotalRewards queries the total rewards accrued by a each
+        DelegationTotalRewards queries the total rewards accrued by each
         validator.
       operationId: DelegationTotalRewards
       responses:
@@ -13775,8 +14104,18 @@ paths:
                     type: string
                   base_proposer_reward:
                     type: string
+                    description: >-
+                      Deprecated: The base_proposer_reward field is deprecated
+                      and is no longer used
+
+                      in the x/distribution module's reward mechanism.
                   bonus_proposer_reward:
                     type: string
+                    description: >-
+                      Deprecated: The bonus_proposer_reward field is deprecated
+                      and is no longer used
+
+                      in the x/distribution module's reward mechanism.
                   withdraw_addr_enabled:
                     type: boolean
             description: >-
@@ -13806,6 +14145,92 @@ paths:
                       format: byte
       tags:
         - Query
+  /cosmos/distribution/v1beta1/validators/{validator_address}:
+    get:
+      summary: >-
+        ValidatorDistributionInfo queries validator commission and
+        self-delegation rewards for validator
+      operationId: ValidatorDistributionInfo
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              operator_address:
+                type: string
+                description: operator_address defines the validator operator address.
+              self_bond_rewards:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    denom:
+                      type: string
+                    amount:
+                      type: string
+                  description: >-
+                    DecCoin defines a token with a denomination and a decimal
+                    amount.
+
+
+                    NOTE: The amount field is an Dec which implements the custom
+                    method
+
+                    signatures required by gogoproto.
+                description: self_bond_rewards defines the self delegations rewards.
+              commission:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    denom:
+                      type: string
+                    amount:
+                      type: string
+                  description: >-
+                    DecCoin defines a token with a denomination and a decimal
+                    amount.
+
+
+                    NOTE: The amount field is an Dec which implements the custom
+                    method
+
+                    signatures required by gogoproto.
+                description: commission defines the commission the validator received.
+            description: >-
+              QueryValidatorDistributionInfoResponse is the response type for
+              the Query/ValidatorDistributionInfo RPC method.
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                    value:
+                      type: string
+                      format: byte
+      parameters:
+        - name: validator_address
+          description: validator_address defines the validator address to query for.
+          in: path
+          required: true
+          type: string
+      tags:
+        - Query
   /cosmos/distribution/v1beta1/validators/{validator_address}/commission:
     get:
       summary: ValidatorCommission queries accumulated commission for a validator.
@@ -13817,7 +14242,7 @@ paths:
             type: object
             properties:
               commission:
-                description: commission defines the commision the validator received.
+                description: commission defines the commission the validator received.
                 type: object
                 properties:
                   commission:
@@ -14210,7 +14635,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -14220,13 +14645,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -14248,7 +14676,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -14424,7 +14851,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -14434,13 +14861,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -14462,7 +14892,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -14558,7 +14987,7 @@ paths:
           type: boolean
       tags:
         - Query
-  /cosmos/evidence/v1beta1/evidence/{evidence_hash}:
+  /cosmos/evidence/v1beta1/evidence/{hash}:
     get:
       summary: Evidence queries evidence based on evidence hash.
       operationId: Evidence
@@ -14667,7 +15096,7 @@ paths:
                         foo = any.unpack(Foo.class);
                       }
 
-                   Example 3: Pack and unpack a message in Python.
+                  Example 3: Pack and unpack a message in Python.
 
                       foo = Foo(...)
                       any = Any()
@@ -14677,13 +15106,16 @@ paths:
                         any.Unpack(foo)
                         ...
 
-                   Example 4: Pack and unpack a message in Go
+                  Example 4: Pack and unpack a message in Go
 
                        foo := &pb.Foo{...}
-                       any, err := ptypes.MarshalAny(foo)
+                       any, err := anypb.New(foo)
+                       if err != nil {
+                         ...
+                       }
                        ...
                        foo := &pb.Foo{}
-                       if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                       if err := any.UnmarshalTo(foo); err != nil {
                          ...
                        }
 
@@ -14705,7 +15137,6 @@ paths:
 
                   JSON
 
-                  ====
 
                   The JSON representation of an `Any` value uses the regular
 
@@ -14856,7 +15287,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -14866,13 +15297,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -14894,7 +15328,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -14932,10 +15365,20 @@ paths:
                           "value": "1.212s"
                         }
       parameters:
-        - name: evidence_hash
-          description: evidence_hash defines the hash of the requested evidence.
+        - name: hash
+          description: |-
+            hash defines the evidence hash of the requested evidence.
+
+            Since: cosmos-sdk 0.47
           in: path
           required: true
+          type: string
+        - name: evidence_hash
+          description: |-
+            evidence_hash defines the hash of the requested evidence.
+            Deprecated: Use hash, a HEX encoded string, instead.
+          in: query
+          required: false
           type: string
           format: byte
       tags:
@@ -15154,7 +15597,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -15164,13 +15607,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -15192,7 +15638,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -15481,7 +15926,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -15491,13 +15936,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -15519,7 +15967,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -15858,7 +16305,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -15868,13 +16315,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -15896,7 +16346,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -16012,7 +16461,7 @@ paths:
                 properties:
                   voting_period:
                     type: string
-                    description: Length of the voting period.
+                    description: Duration of the voting period.
               deposit_params:
                 description: deposit_params defines the parameters related to deposit.
                 type: object
@@ -16040,7 +16489,8 @@ paths:
                     description: >-
                       Maximum period for Atom holders to deposit on a proposal.
                       Initial value: 2
-                       months.
+
+                      months.
               tally_params:
                 description: tally_params defines the parameters related to tally.
                 type: object
@@ -16051,7 +16501,8 @@ paths:
                     description: >-
                       Minimum percentage of total stake needed to vote for a
                       result to be
-                       considered valid.
+
+                      considered valid.
                   threshold:
                     type: string
                     format: byte
@@ -16064,7 +16515,8 @@ paths:
                     description: >-
                       Minimum value of Veto votes to Total votes ratio for
                       proposal to be
-                       vetoed. Default value: 1/3.
+
+                      vetoed. Default value: 1/3.
             description: >-
               QueryParamsResponse is the response type for the Query/Params RPC
               method.
@@ -16182,7 +16634,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -16192,13 +16644,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -16220,7 +16675,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -16287,6 +16741,7 @@ paths:
                     proposal_id:
                       type: string
                       format: uint64
+                      description: proposal_id defines the unique id of the proposal.
                     content:
                       type: object
                       properties:
@@ -16387,7 +16842,7 @@ paths:
                               foo = any.unpack(Foo.class);
                             }
 
-                         Example 3: Pack and unpack a message in Python.
+                        Example 3: Pack and unpack a message in Python.
 
                             foo = Foo(...)
                             any = Any()
@@ -16397,13 +16852,16 @@ paths:
                               any.Unpack(foo)
                               ...
 
-                         Example 4: Pack and unpack a message in Go
+                        Example 4: Pack and unpack a message in Go
 
                              foo := &pb.Foo{...}
-                             any, err := ptypes.MarshalAny(foo)
+                             any, err := anypb.New(foo)
+                             if err != nil {
+                               ...
+                             }
                              ...
                              foo := &pb.Foo{}
-                             if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                             if err := any.UnmarshalTo(foo); err != nil {
                                ...
                              }
 
@@ -16425,7 +16883,6 @@ paths:
 
                         JSON
 
-                        ====
 
                         The JSON representation of an `Any` value uses the
                         regular
@@ -16465,6 +16922,7 @@ paths:
                               "value": "1.212s"
                             }
                     status:
+                      description: status defines the proposal status.
                       type: string
                       enum:
                         - PROPOSAL_STATUS_UNSPECIFIED
@@ -16474,21 +16932,6 @@ paths:
                         - PROPOSAL_STATUS_REJECTED
                         - PROPOSAL_STATUS_FAILED
                       default: PROPOSAL_STATUS_UNSPECIFIED
-                      description: >-
-                        ProposalStatus enumerates the valid statuses of a
-                        proposal.
-
-                         - PROPOSAL_STATUS_UNSPECIFIED: PROPOSAL_STATUS_UNSPECIFIED defines the default proposal status.
-                         - PROPOSAL_STATUS_DEPOSIT_PERIOD: PROPOSAL_STATUS_DEPOSIT_PERIOD defines a proposal status during the deposit
-                        period.
-                         - PROPOSAL_STATUS_VOTING_PERIOD: PROPOSAL_STATUS_VOTING_PERIOD defines a proposal status during the voting
-                        period.
-                         - PROPOSAL_STATUS_PASSED: PROPOSAL_STATUS_PASSED defines a proposal status of a proposal that has
-                        passed.
-                         - PROPOSAL_STATUS_REJECTED: PROPOSAL_STATUS_REJECTED defines a proposal status of a proposal that has
-                        been rejected.
-                         - PROPOSAL_STATUS_FAILED: PROPOSAL_STATUS_FAILED defines a proposal status of a proposal that has
-                        failed.
                     final_tally_result:
                       description: >-
                         final_tally_result is the final tally result of the
@@ -16502,18 +16945,28 @@ paths:
                       properties:
                         'yes':
                           type: string
+                          description: yes is the number of yes votes on a proposal.
                         abstain:
                           type: string
+                          description: >-
+                            abstain is the number of abstain votes on a
+                            proposal.
                         'no':
                           type: string
+                          description: no is the number of no votes on a proposal.
                         no_with_veto:
                           type: string
+                          description: >-
+                            no_with_veto is the number of no with veto votes on
+                            a proposal.
                     submit_time:
                       type: string
                       format: date-time
+                      description: submit_time is the time of proposal submission.
                     deposit_end_time:
                       type: string
                       format: date-time
+                      description: deposit_end_time is the end time for deposition.
                     total_deposit:
                       type: array
                       items:
@@ -16532,15 +16985,21 @@ paths:
                           custom method
 
                           signatures required by gogoproto.
+                      description: total_deposit is the total deposit on the proposal.
                     voting_start_time:
                       type: string
                       format: date-time
+                      description: >-
+                        voting_start_time is the starting time to vote on a
+                        proposal.
                     voting_end_time:
                       type: string
                       format: date-time
+                      description: voting_end_time is the end time of voting on a proposal.
                   description: >-
                     Proposal defines the core field members of a governance
                     proposal.
+                description: proposals defines all the requested governance proposals.
               pagination:
                 description: pagination defines the pagination in the response.
                 type: object
@@ -16679,7 +17138,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -16689,13 +17148,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -16717,7 +17179,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -16865,6 +17326,7 @@ paths:
                   proposal_id:
                     type: string
                     format: uint64
+                    description: proposal_id defines the unique id of the proposal.
                   content:
                     type: object
                     properties:
@@ -16965,7 +17427,7 @@ paths:
                             foo = any.unpack(Foo.class);
                           }
 
-                       Example 3: Pack and unpack a message in Python.
+                      Example 3: Pack and unpack a message in Python.
 
                           foo = Foo(...)
                           any = Any()
@@ -16975,13 +17437,16 @@ paths:
                             any.Unpack(foo)
                             ...
 
-                       Example 4: Pack and unpack a message in Go
+                      Example 4: Pack and unpack a message in Go
 
                            foo := &pb.Foo{...}
-                           any, err := ptypes.MarshalAny(foo)
+                           any, err := anypb.New(foo)
+                           if err != nil {
+                             ...
+                           }
                            ...
                            foo := &pb.Foo{}
-                           if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                           if err := any.UnmarshalTo(foo); err != nil {
                              ...
                            }
 
@@ -17003,7 +17468,6 @@ paths:
 
                       JSON
 
-                      ====
 
                       The JSON representation of an `Any` value uses the regular
 
@@ -17041,6 +17505,7 @@ paths:
                             "value": "1.212s"
                           }
                   status:
+                    description: status defines the proposal status.
                     type: string
                     enum:
                       - PROPOSAL_STATUS_UNSPECIFIED
@@ -17050,21 +17515,6 @@ paths:
                       - PROPOSAL_STATUS_REJECTED
                       - PROPOSAL_STATUS_FAILED
                     default: PROPOSAL_STATUS_UNSPECIFIED
-                    description: >-
-                      ProposalStatus enumerates the valid statuses of a
-                      proposal.
-
-                       - PROPOSAL_STATUS_UNSPECIFIED: PROPOSAL_STATUS_UNSPECIFIED defines the default proposal status.
-                       - PROPOSAL_STATUS_DEPOSIT_PERIOD: PROPOSAL_STATUS_DEPOSIT_PERIOD defines a proposal status during the deposit
-                      period.
-                       - PROPOSAL_STATUS_VOTING_PERIOD: PROPOSAL_STATUS_VOTING_PERIOD defines a proposal status during the voting
-                      period.
-                       - PROPOSAL_STATUS_PASSED: PROPOSAL_STATUS_PASSED defines a proposal status of a proposal that has
-                      passed.
-                       - PROPOSAL_STATUS_REJECTED: PROPOSAL_STATUS_REJECTED defines a proposal status of a proposal that has
-                      been rejected.
-                       - PROPOSAL_STATUS_FAILED: PROPOSAL_STATUS_FAILED defines a proposal status of a proposal that has
-                      failed.
                   final_tally_result:
                     description: >-
                       final_tally_result is the final tally result of the
@@ -17078,18 +17528,26 @@ paths:
                     properties:
                       'yes':
                         type: string
+                        description: yes is the number of yes votes on a proposal.
                       abstain:
                         type: string
+                        description: abstain is the number of abstain votes on a proposal.
                       'no':
                         type: string
+                        description: no is the number of no votes on a proposal.
                       no_with_veto:
                         type: string
+                        description: >-
+                          no_with_veto is the number of no with veto votes on a
+                          proposal.
                   submit_time:
                     type: string
                     format: date-time
+                    description: submit_time is the time of proposal submission.
                   deposit_end_time:
                     type: string
                     format: date-time
+                    description: deposit_end_time is the end time for deposition.
                   total_deposit:
                     type: array
                     items:
@@ -17107,12 +17565,17 @@ paths:
                         custom method
 
                         signatures required by gogoproto.
+                    description: total_deposit is the total deposit on the proposal.
                   voting_start_time:
                     type: string
                     format: date-time
+                    description: >-
+                      voting_start_time is the starting time to vote on a
+                      proposal.
                   voting_end_time:
                     type: string
                     format: date-time
+                    description: voting_end_time is the end time of voting on a proposal.
                 description: >-
                   Proposal defines the core field members of a governance
                   proposal.
@@ -17233,7 +17696,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -17243,13 +17706,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -17271,7 +17737,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -17335,8 +17800,12 @@ paths:
                     proposal_id:
                       type: string
                       format: uint64
+                      description: proposal_id defines the unique id of the proposal.
                     depositor:
                       type: string
+                      description: >-
+                        depositor defines the deposit addresses from the
+                        proposals.
                     amount:
                       type: array
                       items:
@@ -17355,11 +17824,13 @@ paths:
                           custom method
 
                           signatures required by gogoproto.
+                      description: amount to be deposited by depositor.
                   description: >-
                     Deposit defines an amount deposited by an account address to
                     an active
 
                     proposal.
+                description: deposits defines the requested deposits.
               pagination:
                 description: pagination defines the pagination in the response.
                 type: object
@@ -17496,7 +17967,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -17506,13 +17977,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -17534,7 +18008,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -17654,8 +18127,12 @@ paths:
                   proposal_id:
                     type: string
                     format: uint64
+                    description: proposal_id defines the unique id of the proposal.
                   depositor:
                     type: string
+                    description: >-
+                      depositor defines the deposit addresses from the
+                      proposals.
                   amount:
                     type: array
                     items:
@@ -17673,6 +18150,7 @@ paths:
                         custom method
 
                         signatures required by gogoproto.
+                    description: amount to be deposited by depositor.
                 description: >-
                   Deposit defines an amount deposited by an account address to
                   an active
@@ -17795,7 +18273,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -17805,13 +18283,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -17833,7 +18314,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -17900,12 +18380,18 @@ paths:
                 properties:
                   'yes':
                     type: string
+                    description: yes is the number of yes votes on a proposal.
                   abstain:
                     type: string
+                    description: abstain is the number of abstain votes on a proposal.
                   'no':
                     type: string
+                    description: no is the number of no votes on a proposal.
                   no_with_veto:
                     type: string
+                    description: >-
+                      no_with_veto is the number of no with veto votes on a
+                      proposal.
             description: >-
               QueryTallyResultResponse is the response type for the Query/Tally
               RPC method.
@@ -18023,7 +18509,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -18033,13 +18519,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -18061,7 +18550,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -18125,8 +18613,10 @@ paths:
                     proposal_id:
                       type: string
                       format: uint64
+                      description: proposal_id defines the unique id of the proposal.
                     voter:
                       type: string
+                      description: voter is the voter address of the proposal.
                     option:
                       description: >-
                         Deprecated: Prefer to use `options` instead. This field
@@ -18151,6 +18641,9 @@ paths:
                         type: object
                         properties:
                           option:
+                            description: >-
+                              option defines the valid vote options, it must not
+                              contain duplicate vote options.
                             type: string
                             enum:
                               - VOTE_OPTION_UNSPECIFIED
@@ -18159,30 +18652,27 @@ paths:
                               - VOTE_OPTION_NO
                               - VOTE_OPTION_NO_WITH_VETO
                             default: VOTE_OPTION_UNSPECIFIED
-                            description: >-
-                              VoteOption enumerates the valid vote options for a
-                              given governance proposal.
-
-                               - VOTE_OPTION_UNSPECIFIED: VOTE_OPTION_UNSPECIFIED defines a no-op vote option.
-                               - VOTE_OPTION_YES: VOTE_OPTION_YES defines a yes vote option.
-                               - VOTE_OPTION_ABSTAIN: VOTE_OPTION_ABSTAIN defines an abstain vote option.
-                               - VOTE_OPTION_NO: VOTE_OPTION_NO defines a no vote option.
-                               - VOTE_OPTION_NO_WITH_VETO: VOTE_OPTION_NO_WITH_VETO defines a no with veto vote option.
                           weight:
                             type: string
+                            description: >-
+                              weight is the vote weight associated with the vote
+                              option.
                         description: >-
                           WeightedVoteOption defines a unit of vote for vote
                           split.
 
 
                           Since: cosmos-sdk 0.43
-                      title: 'Since: cosmos-sdk 0.43'
+                      description: |-
+                        options is the weighted vote options.
+
+                        Since: cosmos-sdk 0.43
                   description: >-
                     Vote defines a vote on a governance proposal.
 
                     A Vote consists of a proposal ID, the voter, and the vote
                     option.
-                description: votes defined the queried votes.
+                description: votes defines the queried votes.
               pagination:
                 description: pagination defines the pagination in the response.
                 type: object
@@ -18319,7 +18809,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -18329,13 +18819,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -18357,7 +18850,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -18475,8 +18967,10 @@ paths:
                   proposal_id:
                     type: string
                     format: uint64
+                    description: proposal_id defines the unique id of the proposal.
                   voter:
                     type: string
+                    description: voter is the voter address of the proposal.
                   option:
                     description: >-
                       Deprecated: Prefer to use `options` instead. This field is
@@ -18501,6 +18995,9 @@ paths:
                       type: object
                       properties:
                         option:
+                          description: >-
+                            option defines the valid vote options, it must not
+                            contain duplicate vote options.
                           type: string
                           enum:
                             - VOTE_OPTION_UNSPECIFIED
@@ -18509,24 +19006,21 @@ paths:
                             - VOTE_OPTION_NO
                             - VOTE_OPTION_NO_WITH_VETO
                           default: VOTE_OPTION_UNSPECIFIED
-                          description: >-
-                            VoteOption enumerates the valid vote options for a
-                            given governance proposal.
-
-                             - VOTE_OPTION_UNSPECIFIED: VOTE_OPTION_UNSPECIFIED defines a no-op vote option.
-                             - VOTE_OPTION_YES: VOTE_OPTION_YES defines a yes vote option.
-                             - VOTE_OPTION_ABSTAIN: VOTE_OPTION_ABSTAIN defines an abstain vote option.
-                             - VOTE_OPTION_NO: VOTE_OPTION_NO defines a no vote option.
-                             - VOTE_OPTION_NO_WITH_VETO: VOTE_OPTION_NO_WITH_VETO defines a no with veto vote option.
                         weight:
                           type: string
+                          description: >-
+                            weight is the vote weight associated with the vote
+                            option.
                       description: >-
                         WeightedVoteOption defines a unit of vote for vote
                         split.
 
 
                         Since: cosmos-sdk 0.43
-                    title: 'Since: cosmos-sdk 0.43'
+                    description: |-
+                      options is the weighted vote options.
+
+                      Since: cosmos-sdk 0.43
                 description: >-
                   Vote defines a vote on a governance proposal.
 
@@ -18649,7 +19143,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -18659,13 +19153,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -18687,7 +19184,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -19455,6 +19951,11 @@ paths:
       summary: >-
         DelegatorDelegations queries all delegations of a given delegator
         address.
+      description: >-
+        When called from another module, this query might consume a high amount
+        of
+
+        gas if the pagination field is incorrectly set.
       operationId: DelegatorDelegations
       responses:
         '200':
@@ -19651,7 +20152,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -19661,13 +20162,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -19689,7 +20193,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -19793,6 +20296,11 @@ paths:
   /cosmos/staking/v1beta1/delegators/{delegator_addr}/redelegations:
     get:
       summary: Redelegations queries redelegations of given address.
+      description: >-
+        When called from another module, this query might consume a high amount
+        of
+
+        gas if the pagination field is incorrectly set.
       operationId: Redelegations
       responses:
         '200':
@@ -19851,6 +20359,18 @@ paths:
                                   shares_dst is the amount of
                                   destination-validator shares created by
                                   redelegation.
+                              unbonding_id:
+                                type: string
+                                format: uint64
+                                title: >-
+                                  Incrementing id that uniquely identifies this
+                                  entry
+                              unbonding_on_hold_ref_count:
+                                type: string
+                                format: int64
+                                title: >-
+                                  Strictly positive if this entry's unbonding
+                                  has been stopped by external modules
                             description: >-
                               RedelegationEntry defines a redelegation object
                               with relevant metadata.
@@ -19892,6 +20412,18 @@ paths:
                                   shares_dst is the amount of
                                   destination-validator shares created by
                                   redelegation.
+                              unbonding_id:
+                                type: string
+                                format: uint64
+                                title: >-
+                                  Incrementing id that uniquely identifies this
+                                  entry
+                              unbonding_on_hold_ref_count:
+                                type: string
+                                format: int64
+                                title: >-
+                                  Strictly positive if this entry's unbonding
+                                  has been stopped by external modules
                             description: >-
                               RedelegationEntry defines a redelegation object
                               with relevant metadata.
@@ -20051,7 +20583,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -20061,13 +20593,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -20089,7 +20624,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -20207,6 +20741,11 @@ paths:
         given
 
         delegator address.
+      description: >-
+        When called from another module, this query might consume a high amount
+        of
+
+        gas if the pagination field is incorrectly set.
       operationId: DelegatorUnbondingDelegations
       responses:
         '200':
@@ -20256,6 +20795,18 @@ paths:
                             description: >-
                               balance defines the tokens to receive at
                               completion.
+                          unbonding_id:
+                            type: string
+                            format: uint64
+                            title: >-
+                              Incrementing id that uniquely identifies this
+                              entry
+                          unbonding_on_hold_ref_count:
+                            type: string
+                            format: int64
+                            title: >-
+                              Strictly positive if this entry's unbonding has
+                              been stopped by external modules
                         description: >-
                           UnbondingDelegationEntry defines an unbonding object
                           with relevant metadata.
@@ -20403,7 +20954,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -20413,13 +20964,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -20441,7 +20995,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -20547,6 +21100,11 @@ paths:
       summary: |-
         DelegatorValidators queries all validators info for given delegator
         address.
+      description: >-
+        When called from another module, this query might consume a high amount
+        of
+
+        gas if the pagination field is incorrectly set.
       operationId: StakingDelegatorValidators
       responses:
         '200':
@@ -20664,7 +21222,7 @@ paths:
                               foo = any.unpack(Foo.class);
                             }
 
-                         Example 3: Pack and unpack a message in Python.
+                        Example 3: Pack and unpack a message in Python.
 
                             foo = Foo(...)
                             any = Any()
@@ -20674,13 +21232,16 @@ paths:
                               any.Unpack(foo)
                               ...
 
-                         Example 4: Pack and unpack a message in Go
+                        Example 4: Pack and unpack a message in Go
 
                              foo := &pb.Foo{...}
-                             any, err := ptypes.MarshalAny(foo)
+                             any, err := anypb.New(foo)
+                             if err != nil {
+                               ...
+                             }
                              ...
                              foo := &pb.Foo{}
-                             if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                             if err := any.UnmarshalTo(foo); err != nil {
                                ...
                              }
 
@@ -20702,7 +21263,6 @@ paths:
 
                         JSON
 
-                        ====
 
                         The JSON representation of an `Any` value uses the
                         regular
@@ -20846,6 +21406,20 @@ paths:
 
 
                         Since: cosmos-sdk 0.46
+                    unbonding_on_hold_ref_count:
+                      type: string
+                      format: int64
+                      title: >-
+                        strictly positive if this validator's unbonding has been
+                        stopped by external modules
+                    unbonding_ids:
+                      type: array
+                      items:
+                        type: string
+                        format: uint64
+                      title: >-
+                        list of unbonding ids, each uniquely identifing an
+                        unbonding of this validator
                     self_del_address:
                       type: string
                       description: >-
@@ -21027,7 +21601,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -21037,13 +21611,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -21065,7 +21642,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -21286,7 +21862,7 @@ paths:
                             foo = any.unpack(Foo.class);
                           }
 
-                       Example 3: Pack and unpack a message in Python.
+                      Example 3: Pack and unpack a message in Python.
 
                           foo = Foo(...)
                           any = Any()
@@ -21296,13 +21872,16 @@ paths:
                             any.Unpack(foo)
                             ...
 
-                       Example 4: Pack and unpack a message in Go
+                      Example 4: Pack and unpack a message in Go
 
                            foo := &pb.Foo{...}
-                           any, err := ptypes.MarshalAny(foo)
+                           any, err := anypb.New(foo)
+                           if err != nil {
+                             ...
+                           }
                            ...
                            foo := &pb.Foo{}
-                           if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                           if err := any.UnmarshalTo(foo); err != nil {
                              ...
                            }
 
@@ -21324,7 +21903,6 @@ paths:
 
                       JSON
 
-                      ====
 
                       The JSON representation of an `Any` value uses the regular
 
@@ -21465,6 +22043,20 @@ paths:
 
 
                       Since: cosmos-sdk 0.46
+                  unbonding_on_hold_ref_count:
+                    type: string
+                    format: int64
+                    title: >-
+                      strictly positive if this validator's unbonding has been
+                      stopped by external modules
+                  unbonding_ids:
+                    type: array
+                    items:
+                      type: string
+                      format: uint64
+                    title: >-
+                      list of unbonding ids, each uniquely identifing an
+                      unbonding of this validator
                   self_del_address:
                     type: string
                     description: >-
@@ -21626,7 +22218,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -21636,13 +22228,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -21664,7 +22259,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -21804,7 +22398,7 @@ paths:
                       proposer_address:
                         type: string
                         format: byte
-                    description: Header defines the structure of a Tendermint block header.
+                    description: Header defines the structure of a block header.
                   valset:
                     type: array
                     items:
@@ -21916,7 +22510,7 @@ paths:
                                   foo = any.unpack(Foo.class);
                                 }
 
-                             Example 3: Pack and unpack a message in Python.
+                            Example 3: Pack and unpack a message in Python.
 
                                 foo = Foo(...)
                                 any = Any()
@@ -21926,13 +22520,16 @@ paths:
                                   any.Unpack(foo)
                                   ...
 
-                             Example 4: Pack and unpack a message in Go
+                            Example 4: Pack and unpack a message in Go
 
                                  foo := &pb.Foo{...}
-                                 any, err := ptypes.MarshalAny(foo)
+                                 any, err := anypb.New(foo)
+                                 if err != nil {
+                                   ...
+                                 }
                                  ...
                                  foo := &pb.Foo{}
-                                 if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                                 if err := any.UnmarshalTo(foo); err != nil {
                                    ...
                                  }
 
@@ -21954,7 +22551,6 @@ paths:
 
                             JSON
 
-                            ====
 
                             The JSON representation of an `Any` value uses the
                             regular
@@ -22099,6 +22695,20 @@ paths:
 
 
                             Since: cosmos-sdk 0.46
+                        unbonding_on_hold_ref_count:
+                          type: string
+                          format: int64
+                          title: >-
+                            strictly positive if this validator's unbonding has
+                            been stopped by external modules
+                        unbonding_ids:
+                          type: array
+                          items:
+                            type: string
+                            format: uint64
+                          title: >-
+                            list of unbonding ids, each uniquely identifing an
+                            unbonding of this validator
                         self_del_address:
                           type: string
                           description: >-
@@ -22262,7 +22872,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -22272,13 +22882,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -22300,7 +22913,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -22509,7 +23121,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -22519,13 +23131,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -22547,7 +23162,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -22719,7 +23333,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -22729,13 +23343,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -22757,7 +23374,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -22799,6 +23415,11 @@ paths:
   /cosmos/staking/v1beta1/validators:
     get:
       summary: Validators queries all validators that match the given status.
+      description: >-
+        When called from another module, this query might consume a high amount
+        of
+
+        gas if the pagination field is incorrectly set.
       operationId: Validators
       responses:
         '200':
@@ -22916,7 +23537,7 @@ paths:
                               foo = any.unpack(Foo.class);
                             }
 
-                         Example 3: Pack and unpack a message in Python.
+                        Example 3: Pack and unpack a message in Python.
 
                             foo = Foo(...)
                             any = Any()
@@ -22926,13 +23547,16 @@ paths:
                               any.Unpack(foo)
                               ...
 
-                         Example 4: Pack and unpack a message in Go
+                        Example 4: Pack and unpack a message in Go
 
                              foo := &pb.Foo{...}
-                             any, err := ptypes.MarshalAny(foo)
+                             any, err := anypb.New(foo)
+                             if err != nil {
+                               ...
+                             }
                              ...
                              foo := &pb.Foo{}
-                             if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                             if err := any.UnmarshalTo(foo); err != nil {
                                ...
                              }
 
@@ -22954,7 +23578,6 @@ paths:
 
                         JSON
 
-                        ====
 
                         The JSON representation of an `Any` value uses the
                         regular
@@ -23098,6 +23721,20 @@ paths:
 
 
                         Since: cosmos-sdk 0.46
+                    unbonding_on_hold_ref_count:
+                      type: string
+                      format: int64
+                      title: >-
+                        strictly positive if this validator's unbonding has been
+                        stopped by external modules
+                    unbonding_ids:
+                      type: array
+                      items:
+                        type: string
+                        format: uint64
+                      title: >-
+                        list of unbonding ids, each uniquely identifing an
+                        unbonding of this validator
                     self_del_address:
                       type: string
                       description: >-
@@ -23279,7 +23916,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -23289,13 +23926,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -23317,7 +23957,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -23536,7 +24175,7 @@ paths:
                             foo = any.unpack(Foo.class);
                           }
 
-                       Example 3: Pack and unpack a message in Python.
+                      Example 3: Pack and unpack a message in Python.
 
                           foo = Foo(...)
                           any = Any()
@@ -23546,13 +24185,16 @@ paths:
                             any.Unpack(foo)
                             ...
 
-                       Example 4: Pack and unpack a message in Go
+                      Example 4: Pack and unpack a message in Go
 
                            foo := &pb.Foo{...}
-                           any, err := ptypes.MarshalAny(foo)
+                           any, err := anypb.New(foo)
+                           if err != nil {
+                             ...
+                           }
                            ...
                            foo := &pb.Foo{}
-                           if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                           if err := any.UnmarshalTo(foo); err != nil {
                              ...
                            }
 
@@ -23574,7 +24216,6 @@ paths:
 
                       JSON
 
-                      ====
 
                       The JSON representation of an `Any` value uses the regular
 
@@ -23715,6 +24356,20 @@ paths:
 
 
                       Since: cosmos-sdk 0.46
+                  unbonding_on_hold_ref_count:
+                    type: string
+                    format: int64
+                    title: >-
+                      strictly positive if this validator's unbonding has been
+                      stopped by external modules
+                  unbonding_ids:
+                    type: array
+                    items:
+                      type: string
+                      format: uint64
+                    title: >-
+                      list of unbonding ids, each uniquely identifing an
+                      unbonding of this validator
                   self_del_address:
                     type: string
                     description: >-
@@ -23876,7 +24531,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -23886,13 +24541,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -23914,7 +24572,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -23962,6 +24619,11 @@ paths:
   /cosmos/staking/v1beta1/validators/{validator_addr}/delegations:
     get:
       summary: ValidatorDelegations queries delegate info for given validator.
+      description: >-
+        When called from another module, this query might consume a high amount
+        of
+
+        gas if the pagination field is incorrectly set.
       operationId: ValidatorDelegations
       responses:
         '200':
@@ -24155,7 +24817,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -24165,13 +24827,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -24193,7 +24858,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -24469,7 +25133,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -24479,13 +25143,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -24507,7 +25174,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -24607,6 +25273,16 @@ paths:
                         balance:
                           type: string
                           description: balance defines the tokens to receive at completion.
+                        unbonding_id:
+                          type: string
+                          format: uint64
+                          title: Incrementing id that uniquely identifies this entry
+                        unbonding_on_hold_ref_count:
+                          type: string
+                          format: int64
+                          title: >-
+                            Strictly positive if this entry's unbonding has been
+                            stopped by external modules
                       description: >-
                         UnbondingDelegationEntry defines an unbonding object
                         with relevant metadata.
@@ -24735,7 +25411,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -24745,13 +25421,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -24773,7 +25452,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -24828,6 +25506,11 @@ paths:
       summary: >-
         ValidatorUnbondingDelegations queries unbonding delegations of a
         validator.
+      description: >-
+        When called from another module, this query might consume a high amount
+        of
+
+        gas if the pagination field is incorrectly set.
       operationId: ValidatorUnbondingDelegations
       responses:
         '200':
@@ -24877,6 +25560,18 @@ paths:
                             description: >-
                               balance defines the tokens to receive at
                               completion.
+                          unbonding_id:
+                            type: string
+                            format: uint64
+                            title: >-
+                              Incrementing id that uniquely identifies this
+                              entry
+                          unbonding_on_hold_ref_count:
+                            type: string
+                            format: int64
+                            title: >-
+                              Strictly positive if this entry's unbonding has
+                              been stopped by external modules
                         description: >-
                           UnbondingDelegationEntry defines an unbonding object
                           with relevant metadata.
@@ -25024,7 +25719,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -25034,13 +25729,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -25062,7 +25760,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -25163,6 +25860,908 @@ paths:
           type: boolean
       tags:
         - Query
+  /cosmos/tx/v1beta1/decode:
+    post:
+      summary: TxDecode decodes the transaction.
+      description: 'Since: cosmos-sdk 0.47'
+      operationId: TxDecode
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/cosmos.tx.v1beta1.TxDecodeResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                      description: >-
+                        A URL/resource name that uniquely identifies the type of
+                        the serialized
+
+                        protocol buffer message. This string must contain at
+                        least
+
+                        one "/" character. The last segment of the URL's path
+                        must represent
+
+                        the fully qualified name of the type (as in
+
+                        `path/google.protobuf.Duration`). The name should be in
+                        a canonical form
+
+                        (e.g., leading "." is not accepted).
+
+
+                        In practice, teams usually precompile into the binary
+                        all types that they
+
+                        expect it to use in the context of Any. However, for
+                        URLs which use the
+
+                        scheme `http`, `https`, or no scheme, one can optionally
+                        set up a type
+
+                        server that maps type URLs to message definitions as
+                        follows:
+
+
+                        * If no scheme is provided, `https` is assumed.
+
+                        * An HTTP GET on the URL must yield a
+                        [google.protobuf.Type][]
+                          value in binary format, or produce an error.
+                        * Applications are allowed to cache lookup results based
+                        on the
+                          URL, or have them precompiled into a binary to avoid any
+                          lookup. Therefore, binary compatibility needs to be preserved
+                          on changes to types. (Use versioned type names to manage
+                          breaking changes.)
+
+                        Note: this functionality is not currently available in
+                        the official
+
+                        protobuf release, and it is not used for type URLs
+                        beginning with
+
+                        type.googleapis.com.
+
+
+                        Schemes other than `http`, `https` (or the empty scheme)
+                        might be
+
+                        used with implementation specific semantics.
+                    value:
+                      type: string
+                      format: byte
+                      description: >-
+                        Must be a valid serialized protocol buffer of the above
+                        specified type.
+                  description: >-
+                    `Any` contains an arbitrary serialized protocol buffer
+                    message along with a
+
+                    URL that describes the type of the serialized message.
+
+
+                    Protobuf library provides support to pack/unpack Any values
+                    in the form
+
+                    of utility functions or additional generated methods of the
+                    Any type.
+
+
+                    Example 1: Pack and unpack a message in C++.
+
+                        Foo foo = ...;
+                        Any any;
+                        any.PackFrom(foo);
+                        ...
+                        if (any.UnpackTo(&foo)) {
+                          ...
+                        }
+
+                    Example 2: Pack and unpack a message in Java.
+
+                        Foo foo = ...;
+                        Any any = Any.pack(foo);
+                        ...
+                        if (any.is(Foo.class)) {
+                          foo = any.unpack(Foo.class);
+                        }
+
+                    Example 3: Pack and unpack a message in Python.
+
+                        foo = Foo(...)
+                        any = Any()
+                        any.Pack(foo)
+                        ...
+                        if any.Is(Foo.DESCRIPTOR):
+                          any.Unpack(foo)
+                          ...
+
+                    Example 4: Pack and unpack a message in Go
+
+                         foo := &pb.Foo{...}
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
+                         ...
+                         foo := &pb.Foo{}
+                         if err := any.UnmarshalTo(foo); err != nil {
+                           ...
+                         }
+
+                    The pack methods provided by protobuf library will by
+                    default use
+
+                    'type.googleapis.com/full.type.name' as the type URL and the
+                    unpack
+
+                    methods only use the fully qualified type name after the
+                    last '/'
+
+                    in the type URL, for example "foo.bar.com/x/y.z" will yield
+                    type
+
+                    name "y.z".
+
+
+
+                    JSON
+
+
+                    The JSON representation of an `Any` value uses the regular
+
+                    representation of the deserialized, embedded message, with
+                    an
+
+                    additional field `@type` which contains the type URL.
+                    Example:
+
+                        package google.profile;
+                        message Person {
+                          string first_name = 1;
+                          string last_name = 2;
+                        }
+
+                        {
+                          "@type": "type.googleapis.com/google.profile.Person",
+                          "firstName": <string>,
+                          "lastName": <string>
+                        }
+
+                    If the embedded message type is well-known and has a custom
+                    JSON
+
+                    representation, that representation will be embedded adding
+                    a field
+
+                    `value` which holds the custom JSON in addition to the
+                    `@type`
+
+                    field. Example (for message [google.protobuf.Duration][]):
+
+                        {
+                          "@type": "type.googleapis.com/google.protobuf.Duration",
+                          "value": "1.212s"
+                        }
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              tx_bytes:
+                type: string
+                format: byte
+                description: tx_bytes is the raw transaction.
+            description: |-
+              TxDecodeRequest is the request type for the Service.TxDecode
+              RPC method.
+
+              Since: cosmos-sdk 0.47
+      tags:
+        - Service
+  /cosmos/tx/v1beta1/decode/amino:
+    post:
+      summary: TxDecodeAmino decodes an Amino transaction from encoded bytes to JSON.
+      description: 'Since: cosmos-sdk 0.47'
+      operationId: TxDecodeAmino
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              amino_json:
+                type: string
+            description: >-
+              TxDecodeAminoResponse is the response type for the
+              Service.TxDecodeAmino
+
+              RPC method.
+
+
+              Since: cosmos-sdk 0.47
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                      description: >-
+                        A URL/resource name that uniquely identifies the type of
+                        the serialized
+
+                        protocol buffer message. This string must contain at
+                        least
+
+                        one "/" character. The last segment of the URL's path
+                        must represent
+
+                        the fully qualified name of the type (as in
+
+                        `path/google.protobuf.Duration`). The name should be in
+                        a canonical form
+
+                        (e.g., leading "." is not accepted).
+
+
+                        In practice, teams usually precompile into the binary
+                        all types that they
+
+                        expect it to use in the context of Any. However, for
+                        URLs which use the
+
+                        scheme `http`, `https`, or no scheme, one can optionally
+                        set up a type
+
+                        server that maps type URLs to message definitions as
+                        follows:
+
+
+                        * If no scheme is provided, `https` is assumed.
+
+                        * An HTTP GET on the URL must yield a
+                        [google.protobuf.Type][]
+                          value in binary format, or produce an error.
+                        * Applications are allowed to cache lookup results based
+                        on the
+                          URL, or have them precompiled into a binary to avoid any
+                          lookup. Therefore, binary compatibility needs to be preserved
+                          on changes to types. (Use versioned type names to manage
+                          breaking changes.)
+
+                        Note: this functionality is not currently available in
+                        the official
+
+                        protobuf release, and it is not used for type URLs
+                        beginning with
+
+                        type.googleapis.com.
+
+
+                        Schemes other than `http`, `https` (or the empty scheme)
+                        might be
+
+                        used with implementation specific semantics.
+                    value:
+                      type: string
+                      format: byte
+                      description: >-
+                        Must be a valid serialized protocol buffer of the above
+                        specified type.
+                  description: >-
+                    `Any` contains an arbitrary serialized protocol buffer
+                    message along with a
+
+                    URL that describes the type of the serialized message.
+
+
+                    Protobuf library provides support to pack/unpack Any values
+                    in the form
+
+                    of utility functions or additional generated methods of the
+                    Any type.
+
+
+                    Example 1: Pack and unpack a message in C++.
+
+                        Foo foo = ...;
+                        Any any;
+                        any.PackFrom(foo);
+                        ...
+                        if (any.UnpackTo(&foo)) {
+                          ...
+                        }
+
+                    Example 2: Pack and unpack a message in Java.
+
+                        Foo foo = ...;
+                        Any any = Any.pack(foo);
+                        ...
+                        if (any.is(Foo.class)) {
+                          foo = any.unpack(Foo.class);
+                        }
+
+                    Example 3: Pack and unpack a message in Python.
+
+                        foo = Foo(...)
+                        any = Any()
+                        any.Pack(foo)
+                        ...
+                        if any.Is(Foo.DESCRIPTOR):
+                          any.Unpack(foo)
+                          ...
+
+                    Example 4: Pack and unpack a message in Go
+
+                         foo := &pb.Foo{...}
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
+                         ...
+                         foo := &pb.Foo{}
+                         if err := any.UnmarshalTo(foo); err != nil {
+                           ...
+                         }
+
+                    The pack methods provided by protobuf library will by
+                    default use
+
+                    'type.googleapis.com/full.type.name' as the type URL and the
+                    unpack
+
+                    methods only use the fully qualified type name after the
+                    last '/'
+
+                    in the type URL, for example "foo.bar.com/x/y.z" will yield
+                    type
+
+                    name "y.z".
+
+
+
+                    JSON
+
+
+                    The JSON representation of an `Any` value uses the regular
+
+                    representation of the deserialized, embedded message, with
+                    an
+
+                    additional field `@type` which contains the type URL.
+                    Example:
+
+                        package google.profile;
+                        message Person {
+                          string first_name = 1;
+                          string last_name = 2;
+                        }
+
+                        {
+                          "@type": "type.googleapis.com/google.profile.Person",
+                          "firstName": <string>,
+                          "lastName": <string>
+                        }
+
+                    If the embedded message type is well-known and has a custom
+                    JSON
+
+                    representation, that representation will be embedded adding
+                    a field
+
+                    `value` which holds the custom JSON in addition to the
+                    `@type`
+
+                    field. Example (for message [google.protobuf.Duration][]):
+
+                        {
+                          "@type": "type.googleapis.com/google.protobuf.Duration",
+                          "value": "1.212s"
+                        }
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              amino_binary:
+                type: string
+                format: byte
+            description: >-
+              TxDecodeAminoRequest is the request type for the
+              Service.TxDecodeAmino
+
+              RPC method.
+
+
+              Since: cosmos-sdk 0.47
+      tags:
+        - Service
+  /cosmos/tx/v1beta1/encode:
+    post:
+      summary: TxEncode encodes the transaction.
+      description: 'Since: cosmos-sdk 0.47'
+      operationId: TxEncode
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              tx_bytes:
+                type: string
+                format: byte
+                description: tx_bytes is the encoded transaction bytes.
+            description: |-
+              TxEncodeResponse is the response type for the
+              Service.TxEncode method.
+
+              Since: cosmos-sdk 0.47
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                      description: >-
+                        A URL/resource name that uniquely identifies the type of
+                        the serialized
+
+                        protocol buffer message. This string must contain at
+                        least
+
+                        one "/" character. The last segment of the URL's path
+                        must represent
+
+                        the fully qualified name of the type (as in
+
+                        `path/google.protobuf.Duration`). The name should be in
+                        a canonical form
+
+                        (e.g., leading "." is not accepted).
+
+
+                        In practice, teams usually precompile into the binary
+                        all types that they
+
+                        expect it to use in the context of Any. However, for
+                        URLs which use the
+
+                        scheme `http`, `https`, or no scheme, one can optionally
+                        set up a type
+
+                        server that maps type URLs to message definitions as
+                        follows:
+
+
+                        * If no scheme is provided, `https` is assumed.
+
+                        * An HTTP GET on the URL must yield a
+                        [google.protobuf.Type][]
+                          value in binary format, or produce an error.
+                        * Applications are allowed to cache lookup results based
+                        on the
+                          URL, or have them precompiled into a binary to avoid any
+                          lookup. Therefore, binary compatibility needs to be preserved
+                          on changes to types. (Use versioned type names to manage
+                          breaking changes.)
+
+                        Note: this functionality is not currently available in
+                        the official
+
+                        protobuf release, and it is not used for type URLs
+                        beginning with
+
+                        type.googleapis.com.
+
+
+                        Schemes other than `http`, `https` (or the empty scheme)
+                        might be
+
+                        used with implementation specific semantics.
+                    value:
+                      type: string
+                      format: byte
+                      description: >-
+                        Must be a valid serialized protocol buffer of the above
+                        specified type.
+                  description: >-
+                    `Any` contains an arbitrary serialized protocol buffer
+                    message along with a
+
+                    URL that describes the type of the serialized message.
+
+
+                    Protobuf library provides support to pack/unpack Any values
+                    in the form
+
+                    of utility functions or additional generated methods of the
+                    Any type.
+
+
+                    Example 1: Pack and unpack a message in C++.
+
+                        Foo foo = ...;
+                        Any any;
+                        any.PackFrom(foo);
+                        ...
+                        if (any.UnpackTo(&foo)) {
+                          ...
+                        }
+
+                    Example 2: Pack and unpack a message in Java.
+
+                        Foo foo = ...;
+                        Any any = Any.pack(foo);
+                        ...
+                        if (any.is(Foo.class)) {
+                          foo = any.unpack(Foo.class);
+                        }
+
+                    Example 3: Pack and unpack a message in Python.
+
+                        foo = Foo(...)
+                        any = Any()
+                        any.Pack(foo)
+                        ...
+                        if any.Is(Foo.DESCRIPTOR):
+                          any.Unpack(foo)
+                          ...
+
+                    Example 4: Pack and unpack a message in Go
+
+                         foo := &pb.Foo{...}
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
+                         ...
+                         foo := &pb.Foo{}
+                         if err := any.UnmarshalTo(foo); err != nil {
+                           ...
+                         }
+
+                    The pack methods provided by protobuf library will by
+                    default use
+
+                    'type.googleapis.com/full.type.name' as the type URL and the
+                    unpack
+
+                    methods only use the fully qualified type name after the
+                    last '/'
+
+                    in the type URL, for example "foo.bar.com/x/y.z" will yield
+                    type
+
+                    name "y.z".
+
+
+
+                    JSON
+
+
+                    The JSON representation of an `Any` value uses the regular
+
+                    representation of the deserialized, embedded message, with
+                    an
+
+                    additional field `@type` which contains the type URL.
+                    Example:
+
+                        package google.profile;
+                        message Person {
+                          string first_name = 1;
+                          string last_name = 2;
+                        }
+
+                        {
+                          "@type": "type.googleapis.com/google.profile.Person",
+                          "firstName": <string>,
+                          "lastName": <string>
+                        }
+
+                    If the embedded message type is well-known and has a custom
+                    JSON
+
+                    representation, that representation will be embedded adding
+                    a field
+
+                    `value` which holds the custom JSON in addition to the
+                    `@type`
+
+                    field. Example (for message [google.protobuf.Duration][]):
+
+                        {
+                          "@type": "type.googleapis.com/google.protobuf.Duration",
+                          "value": "1.212s"
+                        }
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/cosmos.tx.v1beta1.TxEncodeRequest'
+      tags:
+        - Service
+  /cosmos/tx/v1beta1/encode/amino:
+    post:
+      summary: TxEncodeAmino encodes an Amino transaction from JSON to encoded bytes.
+      description: 'Since: cosmos-sdk 0.47'
+      operationId: TxEncodeAmino
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              amino_binary:
+                type: string
+                format: byte
+            description: >-
+              TxEncodeAminoResponse is the response type for the
+              Service.TxEncodeAmino
+
+              RPC method.
+
+
+              Since: cosmos-sdk 0.47
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                      description: >-
+                        A URL/resource name that uniquely identifies the type of
+                        the serialized
+
+                        protocol buffer message. This string must contain at
+                        least
+
+                        one "/" character. The last segment of the URL's path
+                        must represent
+
+                        the fully qualified name of the type (as in
+
+                        `path/google.protobuf.Duration`). The name should be in
+                        a canonical form
+
+                        (e.g., leading "." is not accepted).
+
+
+                        In practice, teams usually precompile into the binary
+                        all types that they
+
+                        expect it to use in the context of Any. However, for
+                        URLs which use the
+
+                        scheme `http`, `https`, or no scheme, one can optionally
+                        set up a type
+
+                        server that maps type URLs to message definitions as
+                        follows:
+
+
+                        * If no scheme is provided, `https` is assumed.
+
+                        * An HTTP GET on the URL must yield a
+                        [google.protobuf.Type][]
+                          value in binary format, or produce an error.
+                        * Applications are allowed to cache lookup results based
+                        on the
+                          URL, or have them precompiled into a binary to avoid any
+                          lookup. Therefore, binary compatibility needs to be preserved
+                          on changes to types. (Use versioned type names to manage
+                          breaking changes.)
+
+                        Note: this functionality is not currently available in
+                        the official
+
+                        protobuf release, and it is not used for type URLs
+                        beginning with
+
+                        type.googleapis.com.
+
+
+                        Schemes other than `http`, `https` (or the empty scheme)
+                        might be
+
+                        used with implementation specific semantics.
+                    value:
+                      type: string
+                      format: byte
+                      description: >-
+                        Must be a valid serialized protocol buffer of the above
+                        specified type.
+                  description: >-
+                    `Any` contains an arbitrary serialized protocol buffer
+                    message along with a
+
+                    URL that describes the type of the serialized message.
+
+
+                    Protobuf library provides support to pack/unpack Any values
+                    in the form
+
+                    of utility functions or additional generated methods of the
+                    Any type.
+
+
+                    Example 1: Pack and unpack a message in C++.
+
+                        Foo foo = ...;
+                        Any any;
+                        any.PackFrom(foo);
+                        ...
+                        if (any.UnpackTo(&foo)) {
+                          ...
+                        }
+
+                    Example 2: Pack and unpack a message in Java.
+
+                        Foo foo = ...;
+                        Any any = Any.pack(foo);
+                        ...
+                        if (any.is(Foo.class)) {
+                          foo = any.unpack(Foo.class);
+                        }
+
+                    Example 3: Pack and unpack a message in Python.
+
+                        foo = Foo(...)
+                        any = Any()
+                        any.Pack(foo)
+                        ...
+                        if any.Is(Foo.DESCRIPTOR):
+                          any.Unpack(foo)
+                          ...
+
+                    Example 4: Pack and unpack a message in Go
+
+                         foo := &pb.Foo{...}
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
+                         ...
+                         foo := &pb.Foo{}
+                         if err := any.UnmarshalTo(foo); err != nil {
+                           ...
+                         }
+
+                    The pack methods provided by protobuf library will by
+                    default use
+
+                    'type.googleapis.com/full.type.name' as the type URL and the
+                    unpack
+
+                    methods only use the fully qualified type name after the
+                    last '/'
+
+                    in the type URL, for example "foo.bar.com/x/y.z" will yield
+                    type
+
+                    name "y.z".
+
+
+
+                    JSON
+
+
+                    The JSON representation of an `Any` value uses the regular
+
+                    representation of the deserialized, embedded message, with
+                    an
+
+                    additional field `@type` which contains the type URL.
+                    Example:
+
+                        package google.profile;
+                        message Person {
+                          string first_name = 1;
+                          string last_name = 2;
+                        }
+
+                        {
+                          "@type": "type.googleapis.com/google.profile.Person",
+                          "firstName": <string>,
+                          "lastName": <string>
+                        }
+
+                    If the embedded message type is well-known and has a custom
+                    JSON
+
+                    representation, that representation will be embedded adding
+                    a field
+
+                    `value` which holds the custom JSON in addition to the
+                    `@type`
+
+                    field. Example (for message [google.protobuf.Duration][]):
+
+                        {
+                          "@type": "type.googleapis.com/google.protobuf.Duration",
+                          "value": "1.212s"
+                        }
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              amino_json:
+                type: string
+            description: >-
+              TxEncodeAminoRequest is the request type for the
+              Service.TxEncodeAmino
+
+              RPC method.
+
+
+              Since: cosmos-sdk 0.47
+      tags:
+        - Service
   /cosmos/tx/v1beta1/simulate:
     post:
       summary: Simulate simulates executing a transaction for estimating gas usage.
@@ -25227,10 +26826,8 @@ paths:
                             properties:
                               key:
                                 type: string
-                                format: byte
                               value:
                                 type: string
-                                format: byte
                               index:
                                 type: boolean
                             description: >-
@@ -25351,7 +26948,7 @@ paths:
                               foo = any.unpack(Foo.class);
                             }
 
-                         Example 3: Pack and unpack a message in Python.
+                        Example 3: Pack and unpack a message in Python.
 
                             foo = Foo(...)
                             any = Any()
@@ -25361,13 +26958,16 @@ paths:
                               any.Unpack(foo)
                               ...
 
-                         Example 4: Pack and unpack a message in Go
+                        Example 4: Pack and unpack a message in Go
 
                              foo := &pb.Foo{...}
-                             any, err := ptypes.MarshalAny(foo)
+                             any, err := anypb.New(foo)
+                             if err != nil {
+                               ...
+                             }
                              ...
                              foo := &pb.Foo{}
-                             if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                             if err := any.UnmarshalTo(foo); err != nil {
                                ...
                              }
 
@@ -25389,7 +26989,6 @@ paths:
 
                         JSON
 
-                        ====
 
                         The JSON representation of an `Any` value uses the
                         regular
@@ -25551,7 +27150,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -25561,13 +27160,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -25589,7 +27191,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -25757,7 +27358,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -25767,13 +27368,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -25795,7 +27399,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -25834,7 +27437,13 @@ paths:
                         }
       parameters:
         - name: events
-          description: events is the list of transaction event type.
+          description: >-
+            events is the list of transaction event type.
+
+            Deprecated post v0.47.x: use query instead, which should contain a
+            valid
+
+            events query.
           in: query
           required: false
           type: array
@@ -25899,7 +27508,8 @@ paths:
           type: boolean
         - name: order_by
           description: |2-
-             - ORDER_BY_UNSPECIFIED: ORDER_BY_UNSPECIFIED specifies an unknown sorting order. OrderBy defaults to ASC in this case.
+             - ORDER_BY_UNSPECIFIED: ORDER_BY_UNSPECIFIED specifies an unknown sorting order. OrderBy defaults
+            to ASC in this case.
              - ORDER_BY_ASC: ORDER_BY_ASC defines ascending order
              - ORDER_BY_DESC: ORDER_BY_DESC defines descending order
           in: query
@@ -25911,7 +27521,7 @@ paths:
             - ORDER_BY_DESC
           default: ORDER_BY_UNSPECIFIED
         - name: page
-          description: >-
+          description: |-
             page is the page number to query, starts at 1. If not provided, will
             default to first page.
           in: query
@@ -25928,6 +27538,18 @@ paths:
           required: false
           type: string
           format: uint64
+        - name: query
+          description: >-
+            query defines the transaction event query that is proxied to
+            Tendermint's
+
+            TxSearch RPC method. The query must be valid.
+
+
+            Since Cosmos SDK 0.48
+          in: query
+          required: false
+          type: string
       tags:
         - Service
     post:
@@ -26125,7 +27747,7 @@ paths:
                             foo = any.unpack(Foo.class);
                           }
 
-                       Example 3: Pack and unpack a message in Python.
+                      Example 3: Pack and unpack a message in Python.
 
                           foo = Foo(...)
                           any = Any()
@@ -26135,13 +27757,16 @@ paths:
                             any.Unpack(foo)
                             ...
 
-                       Example 4: Pack and unpack a message in Go
+                      Example 4: Pack and unpack a message in Go
 
                            foo := &pb.Foo{...}
-                           any, err := ptypes.MarshalAny(foo)
+                           any, err := anypb.New(foo)
+                           if err != nil {
+                             ...
+                           }
                            ...
                            foo := &pb.Foo{}
-                           if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                           if err := any.UnmarshalTo(foo); err != nil {
                              ...
                            }
 
@@ -26163,7 +27788,6 @@ paths:
 
                       JSON
 
-                      ====
 
                       The JSON representation of an `Any` value uses the regular
 
@@ -26224,10 +27848,8 @@ paths:
                             properties:
                               key:
                                 type: string
-                                format: byte
                               value:
                                 type: string
-                                format: byte
                               index:
                                 type: boolean
                             description: >-
@@ -26378,7 +28000,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -26388,13 +28010,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -26416,7 +28041,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -26474,15 +28098,18 @@ paths:
                 default: BROADCAST_MODE_UNSPECIFIED
                 description: >-
                   BroadcastMode specifies the broadcast mode for the
-                  TxService.Broadcast RPC method.
+                  TxService.Broadcast RPC
+
+                  method.
 
                    - BROADCAST_MODE_UNSPECIFIED: zero-value for mode ordering
-                   - BROADCAST_MODE_BLOCK: BROADCAST_MODE_BLOCK defines a tx broadcasting mode where the client waits for
-                  the tx to be committed in a block.
-                   - BROADCAST_MODE_SYNC: BROADCAST_MODE_SYNC defines a tx broadcasting mode where the client waits for
-                  a CheckTx execution response only.
-                   - BROADCAST_MODE_ASYNC: BROADCAST_MODE_ASYNC defines a tx broadcasting mode where the client returns
-                  immediately.
+                   - BROADCAST_MODE_BLOCK: DEPRECATED: use BROADCAST_MODE_SYNC instead,
+                  BROADCAST_MODE_BLOCK is not supported by the SDK from v0.47.x
+                  onwards.
+                   - BROADCAST_MODE_SYNC: BROADCAST_MODE_SYNC defines a tx broadcasting mode where the client waits
+                  for a CheckTx execution response only.
+                   - BROADCAST_MODE_ASYNC: BROADCAST_MODE_ASYNC defines a tx broadcasting mode where the client
+                  returns immediately.
             description: >-
               BroadcastTxRequest is the request type for the
               Service.BroadcastTxRequest
@@ -26614,7 +28241,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -26624,13 +28251,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -26652,7 +28282,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -26877,7 +28506,7 @@ paths:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -26887,13 +28516,16 @@ paths:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -26915,7 +28547,6 @@ paths:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -27228,34 +28859,6 @@ paths:
       tags:
         - Query
 definitions:
-  bnbchain.greenfield.bridge.Params:
-    type: object
-    properties:
-      transfer_out_relayer_fee:
-        type: string
-        title: Relayer fee for the cross chain transfer out tx
-      transfer_out_ack_relayer_fee:
-        type: string
-        title: >-
-          Relayer fee for the ACK or FAIL_ACK package of the cross chain
-          transfer out tx
-    description: Params defines the parameters for the module.
-  bnbchain.greenfield.bridge.QueryParamsResponse:
-    type: object
-    properties:
-      params:
-        description: params holds all the parameters of this module.
-        type: object
-        properties:
-          transfer_out_relayer_fee:
-            type: string
-            title: Relayer fee for the cross chain transfer out tx
-          transfer_out_ack_relayer_fee:
-            type: string
-            title: >-
-              Relayer fee for the ACK or FAIL_ACK package of the cross chain
-              transfer out tx
-    description: QueryParamsResponse is response type for the Query/Params RPC method.
   google.protobuf.Any:
     type: object
     properties:
@@ -27345,7 +28948,7 @@ definitions:
             foo = any.unpack(Foo.class);
           }
 
-       Example 3: Pack and unpack a message in Python.
+      Example 3: Pack and unpack a message in Python.
 
           foo = Foo(...)
           any = Any()
@@ -27355,13 +28958,16 @@ definitions:
             any.Unpack(foo)
             ...
 
-       Example 4: Pack and unpack a message in Go
+      Example 4: Pack and unpack a message in Go
 
            foo := &pb.Foo{...}
-           any, err := ptypes.MarshalAny(foo)
+           any, err := anypb.New(foo)
+           if err != nil {
+             ...
+           }
            ...
            foo := &pb.Foo{}
-           if err := ptypes.UnmarshalAny(any, foo); err != nil {
+           if err := any.UnmarshalTo(foo); err != nil {
              ...
            }
 
@@ -27379,7 +28985,6 @@ definitions:
 
       JSON
 
-      ====
 
       The JSON representation of an `Any` value uses the regular
 
@@ -27411,6 +29016,34 @@ definitions:
             "@type": "type.googleapis.com/google.protobuf.Duration",
             "value": "1.212s"
           }
+  greenfield.bridge.Params:
+    type: object
+    properties:
+      transfer_out_relayer_fee:
+        type: string
+        title: Relayer fee for the cross chain transfer out tx
+      transfer_out_ack_relayer_fee:
+        type: string
+        title: >-
+          Relayer fee for the ACK or FAIL_ACK package of the cross chain
+          transfer out tx
+    description: Params defines the parameters for the module.
+  greenfield.bridge.QueryParamsResponse:
+    type: object
+    properties:
+      params:
+        description: params holds all the parameters of this module.
+        type: object
+        properties:
+          transfer_out_relayer_fee:
+            type: string
+            title: Relayer fee for the cross chain transfer out tx
+          transfer_out_ack_relayer_fee:
+            type: string
+            title: >-
+              Relayer fee for the ACK or FAIL_ACK package of the cross chain
+              transfer out tx
+    description: QueryParamsResponse is response type for the Query/Params RPC method.
   grpc.gateway.runtime.Error:
     type: object
     properties:
@@ -27519,7 +29152,7 @@ definitions:
                   foo = any.unpack(Foo.class);
                 }
 
-             Example 3: Pack and unpack a message in Python.
+            Example 3: Pack and unpack a message in Python.
 
                 foo = Foo(...)
                 any = Any()
@@ -27529,13 +29162,16 @@ definitions:
                   any.Unpack(foo)
                   ...
 
-             Example 4: Pack and unpack a message in Go
+            Example 4: Pack and unpack a message in Go
 
                  foo := &pb.Foo{...}
-                 any, err := ptypes.MarshalAny(foo)
+                 any, err := anypb.New(foo)
+                 if err != nil {
+                   ...
+                 }
                  ...
                  foo := &pb.Foo{}
-                 if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                 if err := any.UnmarshalTo(foo); err != nil {
                    ...
                  }
 
@@ -27553,7 +29189,6 @@ definitions:
 
             JSON
 
-            ====
 
             The JSON representation of an `Any` value uses the regular
 
@@ -27585,7 +29220,84 @@ definitions:
                   "@type": "type.googleapis.com/google.protobuf.Duration",
                   "value": "1.212s"
                 }
-  bnbchain.greenfield.payment.AutoSettleRecord:
+  cosmos.base.query.v1beta1.PageRequest:
+    type: object
+    properties:
+      key:
+        type: string
+        format: byte
+        description: |-
+          key is a value returned in PageResponse.next_key to begin
+          querying the next page most efficiently. Only one of offset or key
+          should be set.
+      offset:
+        type: string
+        format: uint64
+        description: |-
+          offset is a numeric offset that can be used when key is unavailable.
+          It is less efficient than using key. Only one of offset or key should
+          be set.
+      limit:
+        type: string
+        format: uint64
+        description: >-
+          limit is the total number of results to be returned in the result
+          page.
+
+          If left empty it will default to a value to be set by each app.
+      count_total:
+        type: boolean
+        description: >-
+          count_total is set to true  to indicate that the result set should
+          include
+
+          a count of the total number of items available for pagination in UIs.
+
+          count_total is only respected when offset is used. It is ignored when
+          key
+
+          is set.
+      reverse:
+        type: boolean
+        description: >-
+          reverse is set to true if results are to be returned in the descending
+          order.
+
+
+          Since: cosmos-sdk 0.43
+    description: |-
+      message SomeRequest {
+               Foo some_parameter = 1;
+               PageRequest pagination = 2;
+       }
+    title: |-
+      PageRequest is to be embedded in gRPC request messages for efficient
+      pagination. Ex:
+  cosmos.base.query.v1beta1.PageResponse:
+    type: object
+    properties:
+      next_key:
+        type: string
+        format: byte
+        description: |-
+          next_key is the key to be passed to PageRequest.key to
+          query the next page most efficiently. It will be empty if
+          there are no more results.
+      total:
+        type: string
+        format: uint64
+        title: |-
+          total is total number of results available if PageRequest.count_total
+          was set, its value is undefined otherwise
+    description: |-
+      PageResponse is to be embedded in gRPC response messages where the
+      corresponding request message has used PageRequest.
+
+       message SomeResponse {
+               repeated Bar results = 1;
+               PageResponse page = 2;
+       }
+  greenfield.payment.AutoSettleRecord:
     type: object
     properties:
       timestamp:
@@ -27604,7 +29316,7 @@ definitions:
 
       and settle the stream account if the timestamp is less than the current
       time.
-  bnbchain.greenfield.payment.OutFlow:
+  greenfield.payment.OutFlow:
     type: object
     properties:
       to_address:
@@ -27618,7 +29330,7 @@ definitions:
     title: |-
       OutFlow defines the accumulative outflow stream rate in BNB
       from a stream account to a Storage Provider
-  bnbchain.greenfield.payment.Params:
+  greenfield.payment.Params:
     type: object
     properties:
       reserve_time:
@@ -27654,7 +29366,7 @@ definitions:
           The tax rate to pay for validators in storage payment. The default
           value is 1%(0.01)
     description: Params defines the parameters for the module.
-  bnbchain.greenfield.payment.PaymentAccount:
+  greenfield.payment.PaymentAccount:
     type: object
     properties:
       addr:
@@ -27667,7 +29379,7 @@ definitions:
         type: boolean
         title: whether the payment account is refundable
     title: PaymentAccount defines a payment account
-  bnbchain.greenfield.payment.PaymentAccountCount:
+  greenfield.payment.PaymentAccountCount:
     type: object
     properties:
       owner:
@@ -27680,7 +29392,7 @@ definitions:
     title: >-
       PaymentAccountCount defines the state struct which stores the number of
       payment accounts for an account
-  bnbchain.greenfield.payment.QueryAllAutoSettleRecordResponse:
+  greenfield.payment.QueryAllAutoSettleRecordResponse:
     type: object
     properties:
       auto_settle_record:
@@ -27731,7 +29443,7 @@ definitions:
                    repeated Bar results = 1;
                    PageResponse page = 2;
            }
-  bnbchain.greenfield.payment.QueryAllPaymentAccountCountResponse:
+  greenfield.payment.QueryAllPaymentAccountCountResponse:
     type: object
     properties:
       payment_account_count:
@@ -27775,7 +29487,7 @@ definitions:
                    repeated Bar results = 1;
                    PageResponse page = 2;
            }
-  bnbchain.greenfield.payment.QueryAllPaymentAccountResponse:
+  greenfield.payment.QueryAllPaymentAccountResponse:
     type: object
     properties:
       payment_account:
@@ -27819,7 +29531,7 @@ definitions:
                    repeated Bar results = 1;
                    PageResponse page = 2;
            }
-  bnbchain.greenfield.payment.QueryAllStreamRecordResponse:
+  greenfield.payment.QueryAllStreamRecordResponse:
     type: object
     properties:
       stream_record:
@@ -27917,12 +29629,16 @@ definitions:
                    repeated Bar results = 1;
                    PageResponse page = 2;
            }
-  bnbchain.greenfield.payment.QueryDynamicBalanceResponse:
+  greenfield.payment.QueryDynamicBalanceResponse:
     type: object
     properties:
       dynamic_balance:
         type: string
+        title: dynamic balance is static balance + flowDelta
       stream_record:
+        title: >-
+          the stream record of the given account, if it does not exist, it will
+          be default values
         type: object
         properties:
           account:
@@ -27988,11 +29704,23 @@ definitions:
                 OutFlow defines the accumulative outflow stream rate in BNB
                 from a stream account to a Storage Provider
             title: the accumulated outflow rates of the stream account
-        title: Stream Payment Record of a stream account
       current_timestamp:
         type: string
         format: int64
-  bnbchain.greenfield.payment.QueryGetPaymentAccountCountResponse:
+        title: the timestamp of the current block
+      bank_balance:
+        type: string
+        title: bank_balance is the BNB balance of the bank module
+      available_balance:
+        type: string
+        title: available_balance is bank balance + static balance
+      locked_fee:
+        type: string
+        title: locked_fee is buffer balance + locked balance
+      change_rate:
+        type: string
+        title: change_rate is the netflow rate of the given account
+  greenfield.payment.QueryGetPaymentAccountCountResponse:
     type: object
     properties:
       payment_account_count:
@@ -28008,7 +29736,7 @@ definitions:
         title: >-
           PaymentAccountCount defines the state struct which stores the number
           of payment accounts for an account
-  bnbchain.greenfield.payment.QueryGetPaymentAccountResponse:
+  greenfield.payment.QueryGetPaymentAccountResponse:
     type: object
     properties:
       payment_account:
@@ -28024,14 +29752,14 @@ definitions:
             type: boolean
             title: whether the payment account is refundable
         title: PaymentAccount defines a payment account
-  bnbchain.greenfield.payment.QueryGetPaymentAccountsByOwnerResponse:
+  greenfield.payment.QueryGetPaymentAccountsByOwnerResponse:
     type: object
     properties:
       paymentAccounts:
         type: array
         items:
           type: string
-  bnbchain.greenfield.payment.QueryGetStreamRecordResponse:
+  greenfield.payment.QueryGetStreamRecordResponse:
     type: object
     properties:
       stream_record:
@@ -28101,7 +29829,7 @@ definitions:
                 from a stream account to a Storage Provider
             title: the accumulated outflow rates of the stream account
         title: Stream Payment Record of a stream account
-  bnbchain.greenfield.payment.QueryParamsResponse:
+  greenfield.payment.QueryParamsResponse:
     type: object
     properties:
       params:
@@ -28143,7 +29871,7 @@ definitions:
               The tax rate to pay for validators in storage payment. The default
               value is 1%(0.01)
     description: QueryParamsResponse is response type for the Query/Params RPC method.
-  bnbchain.greenfield.payment.StreamAccountStatus:
+  greenfield.payment.StreamAccountStatus:
     type: string
     enum:
       - STREAM_ACCOUNT_STATUS_ACTIVE
@@ -28157,7 +29885,7 @@ definitions:
 
       It can be unfrozen by depositing more BNB to the stream account.
     title: StreamAccountStatus defines the status of a stream account
-  bnbchain.greenfield.payment.StreamRecord:
+  greenfield.payment.StreamRecord:
     type: object
     properties:
       account:
@@ -28223,84 +29951,7 @@ definitions:
             from a stream account to a Storage Provider
         title: the accumulated outflow rates of the stream account
     title: Stream Payment Record of a stream account
-  cosmos.base.query.v1beta1.PageRequest:
-    type: object
-    properties:
-      key:
-        type: string
-        format: byte
-        description: |-
-          key is a value returned in PageResponse.next_key to begin
-          querying the next page most efficiently. Only one of offset or key
-          should be set.
-      offset:
-        type: string
-        format: uint64
-        description: |-
-          offset is a numeric offset that can be used when key is unavailable.
-          It is less efficient than using key. Only one of offset or key should
-          be set.
-      limit:
-        type: string
-        format: uint64
-        description: >-
-          limit is the total number of results to be returned in the result
-          page.
-
-          If left empty it will default to a value to be set by each app.
-      count_total:
-        type: boolean
-        description: >-
-          count_total is set to true  to indicate that the result set should
-          include
-
-          a count of the total number of items available for pagination in UIs.
-
-          count_total is only respected when offset is used. It is ignored when
-          key
-
-          is set.
-      reverse:
-        type: boolean
-        description: >-
-          reverse is set to true if results are to be returned in the descending
-          order.
-
-
-          Since: cosmos-sdk 0.43
-    description: |-
-      message SomeRequest {
-               Foo some_parameter = 1;
-               PageRequest pagination = 2;
-       }
-    title: |-
-      PageRequest is to be embedded in gRPC request messages for efficient
-      pagination. Ex:
-  cosmos.base.query.v1beta1.PageResponse:
-    type: object
-    properties:
-      next_key:
-        type: string
-        format: byte
-        description: |-
-          next_key is the key to be passed to PageRequest.key to
-          query the next page most efficiently. It will be empty if
-          there are no more results.
-      total:
-        type: string
-        format: uint64
-        title: |-
-          total is total number of results available if PageRequest.count_total
-          was set, its value is undefined otherwise
-    description: |-
-      PageResponse is to be embedded in gRPC response messages where the
-      corresponding request message has used PageRequest.
-
-       message SomeResponse {
-               repeated Bar results = 1;
-               PageResponse page = 2;
-       }
-  bnbchain.greenfield.sp.Description:
+  greenfield.sp.Description:
     type: object
     properties:
       moniker:
@@ -28321,7 +29972,7 @@ definitions:
         type: string
         description: details define other optional details.
     description: Description defines a storage provider description.
-  bnbchain.greenfield.sp.Params:
+  greenfield.sp.Params:
     type: object
     properties:
       deposit_denom:
@@ -28336,7 +29987,7 @@ definitions:
           the ratio of the store price of the secondary sp to the primary sp,
           the default value is 80%
     description: Params defines the parameters for the module.
-  bnbchain.greenfield.sp.QueryGetSecondarySpStorePriceByTimeResponse:
+  greenfield.sp.QueryGetSecondarySpStorePriceByTimeResponse:
     type: object
     properties:
       secondary_sp_store_price:
@@ -28350,7 +30001,7 @@ definitions:
             type: string
             title: store price, in bnb wei per charge byte
         title: global secondary sp store price, the price for all secondary sps
-  bnbchain.greenfield.sp.QueryGetSpStoragePriceByTimeResponse:
+  greenfield.sp.QueryGetSpStoragePriceByTimeResponse:
     type: object
     properties:
       sp_storage_price:
@@ -28374,7 +30025,7 @@ definitions:
             type: string
             title: store price, in bnb wei per charge byte
         title: storage price of a specific sp
-  bnbchain.greenfield.sp.QueryParamsResponse:
+  greenfield.sp.QueryParamsResponse:
     type: object
     properties:
       params:
@@ -28395,7 +30046,7 @@ definitions:
               the ratio of the store price of the secondary sp to the primary
               sp, the default value is 80%
     description: QueryParamsResponse is response type for the Query/Params RPC method.
-  bnbchain.greenfield.sp.QueryStorageProviderResponse:
+  greenfield.sp.QueryStorageProviderResponse:
     type: object
     properties:
       storageProvider:
@@ -28470,7 +30121,7 @@ definitions:
                 type: string
                 description: details define other optional details.
         title: StorageProvider defines the meta info of storage provider
-  bnbchain.greenfield.sp.QueryStorageProvidersResponse:
+  greenfield.sp.QueryStorageProvidersResponse:
     type: object
     properties:
       sps:
@@ -28570,7 +30221,7 @@ definitions:
               PageRequest.count_total
 
               was set, its value is undefined otherwise
-  bnbchain.greenfield.sp.SecondarySpStorePrice:
+  greenfield.sp.SecondarySpStorePrice:
     type: object
     properties:
       update_time_sec:
@@ -28581,7 +30232,7 @@ definitions:
         type: string
         title: store price, in bnb wei per charge byte
     title: global secondary sp store price, the price for all secondary sps
-  bnbchain.greenfield.sp.SpStoragePrice:
+  greenfield.sp.SpStoragePrice:
     type: object
     properties:
       sp_address:
@@ -28602,7 +30253,7 @@ definitions:
         type: string
         title: store price, in bnb wei per charge byte
     title: storage price of a specific sp
-  bnbchain.greenfield.sp.Status:
+  greenfield.sp.Status:
     type: string
     enum:
       - STATUS_IN_SERVICE
@@ -28611,7 +30262,7 @@ definitions:
       - STATUS_OUT_OF_SERVICE
     default: STATUS_IN_SERVICE
     description: Status is the status of a storage provider.
-  bnbchain.greenfield.sp.StorageProvider:
+  greenfield.sp.StorageProvider:
     type: object
     properties:
       operator_address:
@@ -28679,7 +30330,7 @@ definitions:
             type: string
             description: details define other optional details.
     title: StorageProvider defines the meta info of storage provider
-  bnbchain.greenfield.common.UInt64Value:
+  greenfield.common.UInt64Value:
     type: object
     properties:
       value:
@@ -28690,7 +30341,7 @@ definitions:
       Wrapper message for `uint64`.
 
       The JSON representation for `UInt64Value` is JSON string.
-  bnbchain.greenfield.permission.ActionType:
+  greenfield.permission.ActionType:
     type: string
     enum:
       - ACTION_UNSPECIFIED
@@ -28710,7 +30361,7 @@ definitions:
     title: >-
       ActionType defines the operations you can execute in greenfield storage
       network
-  bnbchain.greenfield.permission.Effect:
+  greenfield.permission.Effect:
     type: string
     enum:
       - EFFECT_UNSPECIFIED
@@ -28720,7 +30371,7 @@ definitions:
     title: >-
       Effect define the effect of the operation permission, include Allow or
       deny
-  bnbchain.greenfield.permission.GroupMember:
+  greenfield.permission.GroupMember:
     type: object
     properties:
       id:
@@ -28734,7 +30385,7 @@ definitions:
       member:
         type: string
         title: member is the account address of the member
-  bnbchain.greenfield.permission.Policy:
+  greenfield.permission.Policy:
     type: object
     properties:
       id:
@@ -28867,7 +30518,7 @@ definitions:
 
           Notices: Its priority is higher than the expiration time inside the
           Statement
-  bnbchain.greenfield.permission.Principal:
+  greenfield.permission.Principal:
     type: object
     properties:
       type:
@@ -28888,7 +30539,7 @@ definitions:
     description: >-
       Principal define the roles that can grant permissions. Currently, it can
       be account or group.
-  bnbchain.greenfield.permission.PrincipalType:
+  greenfield.permission.PrincipalType:
     type: string
     enum:
       - PRINCIPAL_TYPE_UNSPECIFIED
@@ -28898,7 +30549,7 @@ definitions:
     description: |-
       PrincipalType refers to the identity type of system users or entities.
       In Greenfield, it usually refers to accounts or groups.
-  bnbchain.greenfield.permission.Statement:
+  greenfield.permission.Statement:
     type: object
     properties:
       effect:
@@ -28967,7 +30618,7 @@ definitions:
             type: string
             format: uint64
             description: The uint64 value.
-  bnbchain.greenfield.resource.ResourceType:
+  greenfield.resource.ResourceType:
     type: string
     enum:
       - RESOURCE_TYPE_UNSPECIFIED
@@ -28975,7 +30626,7 @@ definitions:
       - RESOURCE_TYPE_OBJECT
       - RESOURCE_TYPE_GROUP
     default: RESOURCE_TYPE_UNSPECIFIED
-  bnbchain.greenfield.storage.BillingInfo:
+  greenfield.storage.BillingInfo:
     type: object
     properties:
       price_time:
@@ -29005,7 +30656,7 @@ definitions:
           title: secondary sp objects size statistics
         title: secondary sp objects size statistics
     title: BillingInfo is the billing information of the bucket
-  bnbchain.greenfield.storage.BucketInfo:
+  greenfield.storage.BucketInfo:
     type: object
     properties:
       owner:
@@ -29102,7 +30753,7 @@ definitions:
           - BUCKET_STATUS_CREATED
           - BUCKET_STATUS_DISCONTINUED
         default: BUCKET_STATUS_CREATED
-  bnbchain.greenfield.storage.BucketMetaData:
+  greenfield.storage.BucketMetaData:
     type: object
     properties:
       description:
@@ -29127,7 +30778,7 @@ definitions:
             value:
               type: string
         title: attributes
-  bnbchain.greenfield.storage.BucketStatus:
+  greenfield.storage.BucketStatus:
     type: string
     enum:
       - BUCKET_STATUS_CREATED
@@ -29141,7 +30792,7 @@ definitions:
 
       When a Discontinue Object transaction is received on chain, the status is
       set to 'Discontinued'.
-  bnbchain.greenfield.storage.GroupInfo:
+  greenfield.storage.GroupInfo:
     type: object
     properties:
       owner:
@@ -29161,7 +30812,7 @@ definitions:
       id:
         type: string
         title: id is the unique identifier of group
-  bnbchain.greenfield.storage.GroupMetaData:
+  greenfield.storage.GroupMetaData:
     type: object
     properties:
       description:
@@ -29186,7 +30837,7 @@ definitions:
             value:
               type: string
         title: attributes
-  bnbchain.greenfield.storage.ObjectInfo:
+  greenfield.storage.ObjectInfo:
     type: object
     properties:
       owner:
@@ -29265,7 +30916,7 @@ definitions:
         items:
           type: string
         title: secondary_sp_addresses define the addresses of secondary_sps
-  bnbchain.greenfield.storage.ObjectMetaData:
+  greenfield.storage.ObjectMetaData:
     type: object
     properties:
       description:
@@ -29290,7 +30941,7 @@ definitions:
             value:
               type: string
         title: attributes
-  bnbchain.greenfield.storage.ObjectStatus:
+  greenfield.storage.ObjectStatus:
     type: string
     enum:
       - OBJECT_STATUS_CREATED
@@ -29311,7 +30962,7 @@ definitions:
       transaction is
 
       received on chain, the status is set to 'Discontinued'.
-  bnbchain.greenfield.storage.Params:
+  greenfield.storage.Params:
     type: object
     properties:
       max_segment_size:
@@ -29383,7 +31034,7 @@ definitions:
         format: uint64
         title: The max delete objects in each end block
     description: Params defines the parameters for the module.
-  bnbchain.greenfield.storage.QueryBucketNFTResponse:
+  greenfield.storage.QueryBucketNFTResponse:
     type: object
     properties:
       meta_data:
@@ -29411,7 +31062,7 @@ definitions:
                 value:
                   type: string
             title: attributes
-  bnbchain.greenfield.storage.QueryGroupNFTResponse:
+  greenfield.storage.QueryGroupNFTResponse:
     type: object
     properties:
       meta_data:
@@ -29439,7 +31090,7 @@ definitions:
                 value:
                   type: string
             title: attributes
-  bnbchain.greenfield.storage.QueryHeadBucketResponse:
+  greenfield.storage.QueryHeadBucketResponse:
     type: object
     properties:
       bucket_info:
@@ -29541,7 +31192,7 @@ definitions:
               - BUCKET_STATUS_CREATED
               - BUCKET_STATUS_DISCONTINUED
             default: BUCKET_STATUS_CREATED
-  bnbchain.greenfield.storage.QueryHeadGroupMemberResponse:
+  greenfield.storage.QueryHeadGroupMemberResponse:
     type: object
     properties:
       group_member:
@@ -29558,7 +31209,7 @@ definitions:
           member:
             type: string
             title: member is the account address of the member
-  bnbchain.greenfield.storage.QueryHeadGroupResponse:
+  greenfield.storage.QueryHeadGroupResponse:
     type: object
     properties:
       group_info:
@@ -29583,7 +31234,7 @@ definitions:
           id:
             type: string
             title: id is the unique identifier of group
-  bnbchain.greenfield.storage.QueryHeadObjectResponse:
+  greenfield.storage.QueryHeadObjectResponse:
     type: object
     properties:
       object_info:
@@ -29665,7 +31316,7 @@ definitions:
             items:
               type: string
             title: secondary_sp_addresses define the addresses of secondary_sps
-  bnbchain.greenfield.storage.QueryListBucketsResponse:
+  greenfield.storage.QueryListBucketsResponse:
     type: object
     properties:
       bucket_infos:
@@ -29795,7 +31446,7 @@ definitions:
                    repeated Bar results = 1;
                    PageResponse page = 2;
            }
-  bnbchain.greenfield.storage.QueryListGroupResponse:
+  greenfield.storage.QueryListGroupResponse:
     type: object
     properties:
       pagination:
@@ -29850,7 +31501,7 @@ definitions:
             id:
               type: string
               title: id is the unique identifier of group
-  bnbchain.greenfield.storage.QueryListObjectsResponse:
+  greenfield.storage.QueryListObjectsResponse:
     type: object
     properties:
       object_infos:
@@ -29962,7 +31613,7 @@ definitions:
                    repeated Bar results = 1;
                    PageResponse page = 2;
            }
-  bnbchain.greenfield.storage.QueryObjectNFTResponse:
+  greenfield.storage.QueryObjectNFTResponse:
     type: object
     properties:
       meta_data:
@@ -29990,7 +31641,7 @@ definitions:
                 value:
                   type: string
             title: attributes
-  bnbchain.greenfield.storage.QueryParamsResponse:
+  greenfield.storage.QueryParamsResponse:
     type: object
     properties:
       params:
@@ -30072,7 +31723,7 @@ definitions:
             format: uint64
             title: The max delete objects in each end block
     description: QueryParamsResponse is response type for the Query/Params RPC method.
-  bnbchain.greenfield.storage.QueryPolicyForAccountResponse:
+  greenfield.storage.QueryPolicyForAccountResponse:
     type: object
     properties:
       policy:
@@ -30214,7 +31865,7 @@ definitions:
 
               Notices: Its priority is higher than the expiration time inside
               the Statement
-  bnbchain.greenfield.storage.QueryPolicyForGroupResponse:
+  greenfield.storage.QueryPolicyForGroupResponse:
     type: object
     properties:
       policy:
@@ -30356,7 +32007,7 @@ definitions:
 
               Notices: Its priority is higher than the expiration time inside
               the Statement
-  bnbchain.greenfield.storage.QueryVerifyPermissionResponse:
+  greenfield.storage.QueryVerifyPermissionResponse:
     type: object
     properties:
       effect:
@@ -30369,7 +32020,7 @@ definitions:
         title: >-
           Effect define the effect of the operation permission, include Allow or
           deny
-  bnbchain.greenfield.storage.RedundancyType:
+  greenfield.storage.RedundancyType:
     type: string
     enum:
       - REDUNDANCY_EC_TYPE
@@ -30378,7 +32029,7 @@ definitions:
     description: |-
       RedundancyType represents the redundancy algorithm type for object data,
       which can be either multi-replica or erasure coding.
-  bnbchain.greenfield.storage.SecondarySpObjectsSize:
+  greenfield.storage.SecondarySpObjectsSize:
     type: object
     properties:
       sp_address:
@@ -30389,7 +32040,7 @@ definitions:
         format: uint64
         title: size is the total size of the objects in the secondary sp
     title: secondary sp objects size statistics
-  bnbchain.greenfield.storage.SourceType:
+  greenfield.storage.SourceType:
     type: string
     enum:
       - SOURCE_TYPE_ORIGIN
@@ -30399,14 +32050,14 @@ definitions:
     title: |-
       SourceType represents the source of resource creation, which can
       from Greenfield native or from a cross-chain transfer from BSC
-  bnbchain.greenfield.storage.Trait:
+  greenfield.storage.Trait:
     type: object
     properties:
       trait_type:
         type: string
       value:
         type: string
-  bnbchain.greenfield.storage.VisibilityType:
+  greenfield.storage.VisibilityType:
     type: string
     enum:
       - VISIBILITY_TYPE_UNSPECIFIED
@@ -30418,29 +32069,186 @@ definitions:
       VisibilityType is the resources public status.
 
        - VISIBILITY_TYPE_INHERIT: If the bucket Visibility is inherit, it's finally set to private. If the object Visibility is inherit, it's the same as bucket.
-  cosmos.auth.v1beta1.AddressBytesToStringResponse:
+  cosmos.auth.v1beta1.BaseAccount:
     type: object
     properties:
-      address_string:
+      address:
         type: string
-    description: >-
-      AddressBytesToStringResponse is the response type for AddressString rpc
-      method.
+      pub_key:
+        type: object
+        properties:
+          type_url:
+            type: string
+            description: >-
+              A URL/resource name that uniquely identifies the type of the
+              serialized
+
+              protocol buffer message. This string must contain at least
+
+              one "/" character. The last segment of the URL's path must
+              represent
+
+              the fully qualified name of the type (as in
+
+              `path/google.protobuf.Duration`). The name should be in a
+              canonical form
+
+              (e.g., leading "." is not accepted).
 
 
-      Since: cosmos-sdk 0.46
-  cosmos.auth.v1beta1.AddressStringToBytesResponse:
-    type: object
-    properties:
-      address_bytes:
+              In practice, teams usually precompile into the binary all types
+              that they
+
+              expect it to use in the context of Any. However, for URLs which
+              use the
+
+              scheme `http`, `https`, or no scheme, one can optionally set up a
+              type
+
+              server that maps type URLs to message definitions as follows:
+
+
+              * If no scheme is provided, `https` is assumed.
+
+              * An HTTP GET on the URL must yield a [google.protobuf.Type][]
+                value in binary format, or produce an error.
+              * Applications are allowed to cache lookup results based on the
+                URL, or have them precompiled into a binary to avoid any
+                lookup. Therefore, binary compatibility needs to be preserved
+                on changes to types. (Use versioned type names to manage
+                breaking changes.)
+
+              Note: this functionality is not currently available in the
+              official
+
+              protobuf release, and it is not used for type URLs beginning with
+
+              type.googleapis.com.
+
+
+              Schemes other than `http`, `https` (or the empty scheme) might be
+
+              used with implementation specific semantics.
+          value:
+            type: string
+            format: byte
+            description: >-
+              Must be a valid serialized protocol buffer of the above specified
+              type.
+        description: >-
+          `Any` contains an arbitrary serialized protocol buffer message along
+          with a
+
+          URL that describes the type of the serialized message.
+
+
+          Protobuf library provides support to pack/unpack Any values in the
+          form
+
+          of utility functions or additional generated methods of the Any type.
+
+
+          Example 1: Pack and unpack a message in C++.
+
+              Foo foo = ...;
+              Any any;
+              any.PackFrom(foo);
+              ...
+              if (any.UnpackTo(&foo)) {
+                ...
+              }
+
+          Example 2: Pack and unpack a message in Java.
+
+              Foo foo = ...;
+              Any any = Any.pack(foo);
+              ...
+              if (any.is(Foo.class)) {
+                foo = any.unpack(Foo.class);
+              }
+
+          Example 3: Pack and unpack a message in Python.
+
+              foo = Foo(...)
+              any = Any()
+              any.Pack(foo)
+              ...
+              if any.Is(Foo.DESCRIPTOR):
+                any.Unpack(foo)
+                ...
+
+          Example 4: Pack and unpack a message in Go
+
+               foo := &pb.Foo{...}
+               any, err := anypb.New(foo)
+               if err != nil {
+                 ...
+               }
+               ...
+               foo := &pb.Foo{}
+               if err := any.UnmarshalTo(foo); err != nil {
+                 ...
+               }
+
+          The pack methods provided by protobuf library will by default use
+
+          'type.googleapis.com/full.type.name' as the type URL and the unpack
+
+          methods only use the fully qualified type name after the last '/'
+
+          in the type URL, for example "foo.bar.com/x/y.z" will yield type
+
+          name "y.z".
+
+
+
+          JSON
+
+
+          The JSON representation of an `Any` value uses the regular
+
+          representation of the deserialized, embedded message, with an
+
+          additional field `@type` which contains the type URL. Example:
+
+              package google.profile;
+              message Person {
+                string first_name = 1;
+                string last_name = 2;
+              }
+
+              {
+                "@type": "type.googleapis.com/google.profile.Person",
+                "firstName": <string>,
+                "lastName": <string>
+              }
+
+          If the embedded message type is well-known and has a custom JSON
+
+          representation, that representation will be embedded adding a field
+
+          `value` which holds the custom JSON in addition to the `@type`
+
+          field. Example (for message [google.protobuf.Duration][]):
+
+              {
+                "@type": "type.googleapis.com/google.protobuf.Duration",
+                "value": "1.212s"
+              }
+      account_number:
         type: string
-        format: byte
+        format: uint64
+      sequence:
+        type: string
+        format: uint64
     description: >-
-      AddressStringToBytesResponse is the response type for AddressBytes rpc
-      method.
+      BaseAccount defines a base account type. It contains all the necessary
+      fields
 
+      for basic account functionality. Any custom account type should extend
+      this
 
-      Since: cosmos-sdk 0.46
+      type for additional functionality (e.g. vesting).
   cosmos.auth.v1beta1.Params:
     type: object
     properties:
@@ -30459,9 +32267,6 @@ definitions:
       sig_verify_cost_secp256k1:
         type: string
         format: uint64
-      sig_verify_cost_ethsecp256k1:
-        type: string
-        format: uint64
     description: Params defines the parameters for the auth module.
   cosmos.auth.v1beta1.QueryAccountAddressByIDResponse:
     type: object
@@ -30472,6 +32277,192 @@ definitions:
     title: >-
       QueryAccountAddressByIDResponse is the response type for
       AccountAddressByID rpc method
+  cosmos.auth.v1beta1.QueryAccountInfoResponse:
+    type: object
+    properties:
+      info:
+        description: info is the account info which is represented by BaseAccount.
+        type: object
+        properties:
+          address:
+            type: string
+          pub_key:
+            type: object
+            properties:
+              type_url:
+                type: string
+                description: >-
+                  A URL/resource name that uniquely identifies the type of the
+                  serialized
+
+                  protocol buffer message. This string must contain at least
+
+                  one "/" character. The last segment of the URL's path must
+                  represent
+
+                  the fully qualified name of the type (as in
+
+                  `path/google.protobuf.Duration`). The name should be in a
+                  canonical form
+
+                  (e.g., leading "." is not accepted).
+
+
+                  In practice, teams usually precompile into the binary all
+                  types that they
+
+                  expect it to use in the context of Any. However, for URLs
+                  which use the
+
+                  scheme `http`, `https`, or no scheme, one can optionally set
+                  up a type
+
+                  server that maps type URLs to message definitions as follows:
+
+
+                  * If no scheme is provided, `https` is assumed.
+
+                  * An HTTP GET on the URL must yield a [google.protobuf.Type][]
+                    value in binary format, or produce an error.
+                  * Applications are allowed to cache lookup results based on
+                  the
+                    URL, or have them precompiled into a binary to avoid any
+                    lookup. Therefore, binary compatibility needs to be preserved
+                    on changes to types. (Use versioned type names to manage
+                    breaking changes.)
+
+                  Note: this functionality is not currently available in the
+                  official
+
+                  protobuf release, and it is not used for type URLs beginning
+                  with
+
+                  type.googleapis.com.
+
+
+                  Schemes other than `http`, `https` (or the empty scheme) might
+                  be
+
+                  used with implementation specific semantics.
+              value:
+                type: string
+                format: byte
+                description: >-
+                  Must be a valid serialized protocol buffer of the above
+                  specified type.
+            description: >-
+              `Any` contains an arbitrary serialized protocol buffer message
+              along with a
+
+              URL that describes the type of the serialized message.
+
+
+              Protobuf library provides support to pack/unpack Any values in the
+              form
+
+              of utility functions or additional generated methods of the Any
+              type.
+
+
+              Example 1: Pack and unpack a message in C++.
+
+                  Foo foo = ...;
+                  Any any;
+                  any.PackFrom(foo);
+                  ...
+                  if (any.UnpackTo(&foo)) {
+                    ...
+                  }
+
+              Example 2: Pack and unpack a message in Java.
+
+                  Foo foo = ...;
+                  Any any = Any.pack(foo);
+                  ...
+                  if (any.is(Foo.class)) {
+                    foo = any.unpack(Foo.class);
+                  }
+
+              Example 3: Pack and unpack a message in Python.
+
+                  foo = Foo(...)
+                  any = Any()
+                  any.Pack(foo)
+                  ...
+                  if any.Is(Foo.DESCRIPTOR):
+                    any.Unpack(foo)
+                    ...
+
+              Example 4: Pack and unpack a message in Go
+
+                   foo := &pb.Foo{...}
+                   any, err := anypb.New(foo)
+                   if err != nil {
+                     ...
+                   }
+                   ...
+                   foo := &pb.Foo{}
+                   if err := any.UnmarshalTo(foo); err != nil {
+                     ...
+                   }
+
+              The pack methods provided by protobuf library will by default use
+
+              'type.googleapis.com/full.type.name' as the type URL and the
+              unpack
+
+              methods only use the fully qualified type name after the last '/'
+
+              in the type URL, for example "foo.bar.com/x/y.z" will yield type
+
+              name "y.z".
+
+
+
+              JSON
+
+
+              The JSON representation of an `Any` value uses the regular
+
+              representation of the deserialized, embedded message, with an
+
+              additional field `@type` which contains the type URL. Example:
+
+                  package google.profile;
+                  message Person {
+                    string first_name = 1;
+                    string last_name = 2;
+                  }
+
+                  {
+                    "@type": "type.googleapis.com/google.profile.Person",
+                    "firstName": <string>,
+                    "lastName": <string>
+                  }
+
+              If the embedded message type is well-known and has a custom JSON
+
+              representation, that representation will be embedded adding a
+              field
+
+              `value` which holds the custom JSON in addition to the `@type`
+
+              field. Example (for message [google.protobuf.Duration][]):
+
+                  {
+                    "@type": "type.googleapis.com/google.protobuf.Duration",
+                    "value": "1.212s"
+                  }
+          account_number:
+            type: string
+            format: uint64
+          sequence:
+            type: string
+            format: uint64
+    description: |-
+      QueryAccountInfoResponse is the Query/AccountInfo response type.
+
+      Since: cosmos-sdk 0.47
   cosmos.auth.v1beta1.QueryAccountResponse:
     type: object
     properties:
@@ -30568,7 +32559,7 @@ definitions:
                 foo = any.unpack(Foo.class);
               }
 
-           Example 3: Pack and unpack a message in Python.
+          Example 3: Pack and unpack a message in Python.
 
               foo = Foo(...)
               any = Any()
@@ -30578,13 +32569,16 @@ definitions:
                 any.Unpack(foo)
                 ...
 
-           Example 4: Pack and unpack a message in Go
+          Example 4: Pack and unpack a message in Go
 
                foo := &pb.Foo{...}
-               any, err := ptypes.MarshalAny(foo)
+               any, err := anypb.New(foo)
+               if err != nil {
+                 ...
+               }
                ...
                foo := &pb.Foo{}
-               if err := ptypes.UnmarshalAny(any, foo); err != nil {
+               if err := any.UnmarshalTo(foo); err != nil {
                  ...
                }
 
@@ -30602,7 +32596,6 @@ definitions:
 
           JSON
 
-          ====
 
           The JSON representation of an `Any` value uses the regular
 
@@ -30738,7 +32731,7 @@ definitions:
                   foo = any.unpack(Foo.class);
                 }
 
-             Example 3: Pack and unpack a message in Python.
+            Example 3: Pack and unpack a message in Python.
 
                 foo = Foo(...)
                 any = Any()
@@ -30748,13 +32741,16 @@ definitions:
                   any.Unpack(foo)
                   ...
 
-             Example 4: Pack and unpack a message in Go
+            Example 4: Pack and unpack a message in Go
 
                  foo := &pb.Foo{...}
-                 any, err := ptypes.MarshalAny(foo)
+                 any, err := anypb.New(foo)
+                 if err != nil {
+                   ...
+                 }
                  ...
                  foo := &pb.Foo{}
-                 if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                 if err := any.UnmarshalTo(foo); err != nil {
                    ...
                  }
 
@@ -30772,7 +32768,6 @@ definitions:
 
             JSON
 
-            ====
 
             The JSON representation of an `Any` value uses the regular
 
@@ -30926,7 +32921,7 @@ definitions:
                 foo = any.unpack(Foo.class);
               }
 
-           Example 3: Pack and unpack a message in Python.
+          Example 3: Pack and unpack a message in Python.
 
               foo = Foo(...)
               any = Any()
@@ -30936,13 +32931,16 @@ definitions:
                 any.Unpack(foo)
                 ...
 
-           Example 4: Pack and unpack a message in Go
+          Example 4: Pack and unpack a message in Go
 
                foo := &pb.Foo{...}
-               any, err := ptypes.MarshalAny(foo)
+               any, err := anypb.New(foo)
+               if err != nil {
+                 ...
+               }
                ...
                foo := &pb.Foo{}
-               if err := ptypes.UnmarshalAny(any, foo); err != nil {
+               if err := any.UnmarshalTo(foo); err != nil {
                  ...
                }
 
@@ -30960,7 +32958,6 @@ definitions:
 
           JSON
 
-          ====
 
           The JSON representation of an `Any` value uses the regular
 
@@ -31096,7 +33093,7 @@ definitions:
                   foo = any.unpack(Foo.class);
                 }
 
-             Example 3: Pack and unpack a message in Python.
+            Example 3: Pack and unpack a message in Python.
 
                 foo = Foo(...)
                 any = Any()
@@ -31106,13 +33103,16 @@ definitions:
                   any.Unpack(foo)
                   ...
 
-             Example 4: Pack and unpack a message in Go
+            Example 4: Pack and unpack a message in Go
 
                  foo := &pb.Foo{...}
-                 any, err := ptypes.MarshalAny(foo)
+                 any, err := anypb.New(foo)
+                 if err != nil {
+                   ...
+                 }
                  ...
                  foo := &pb.Foo{}
-                 if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                 if err := any.UnmarshalTo(foo); err != nil {
                    ...
                  }
 
@@ -31130,7 +33130,6 @@ definitions:
 
             JSON
 
-            ====
 
             The JSON representation of an `Any` value uses the regular
 
@@ -31188,9 +33187,6 @@ definitions:
             type: string
             format: uint64
           sig_verify_cost_secp256k1:
-            type: string
-            format: uint64
-          sig_verify_cost_ethsecp256k1:
             type: string
             format: uint64
     description: QueryParamsResponse is the response type for the Query/Params RPC method.
@@ -31290,7 +33286,7 @@ definitions:
                 foo = any.unpack(Foo.class);
               }
 
-           Example 3: Pack and unpack a message in Python.
+          Example 3: Pack and unpack a message in Python.
 
               foo = Foo(...)
               any = Any()
@@ -31300,13 +33296,16 @@ definitions:
                 any.Unpack(foo)
                 ...
 
-           Example 4: Pack and unpack a message in Go
+          Example 4: Pack and unpack a message in Go
 
                foo := &pb.Foo{...}
-               any, err := ptypes.MarshalAny(foo)
+               any, err := anypb.New(foo)
+               if err != nil {
+                 ...
+               }
                ...
                foo := &pb.Foo{}
-               if err := ptypes.UnmarshalAny(any, foo); err != nil {
+               if err := any.UnmarshalTo(foo); err != nil {
                  ...
                }
 
@@ -31324,7 +33323,6 @@ definitions:
 
           JSON
 
-          ====
 
           The JSON representation of an `Any` value uses the regular
 
@@ -31469,7 +33467,7 @@ definitions:
                 foo = any.unpack(Foo.class);
               }
 
-           Example 3: Pack and unpack a message in Python.
+          Example 3: Pack and unpack a message in Python.
 
               foo = Foo(...)
               any = Any()
@@ -31479,13 +33477,16 @@ definitions:
                 any.Unpack(foo)
                 ...
 
-           Example 4: Pack and unpack a message in Go
+          Example 4: Pack and unpack a message in Go
 
                foo := &pb.Foo{...}
-               any, err := ptypes.MarshalAny(foo)
+               any, err := anypb.New(foo)
+               if err != nil {
+                 ...
+               }
                ...
                foo := &pb.Foo{}
-               if err := ptypes.UnmarshalAny(any, foo); err != nil {
+               if err := any.UnmarshalTo(foo); err != nil {
                  ...
                }
 
@@ -31503,7 +33504,6 @@ definitions:
 
           JSON
 
-          ====
 
           The JSON representation of an `Any` value uses the regular
 
@@ -31654,7 +33654,7 @@ definitions:
                       foo = any.unpack(Foo.class);
                     }
 
-                 Example 3: Pack and unpack a message in Python.
+                Example 3: Pack and unpack a message in Python.
 
                     foo = Foo(...)
                     any = Any()
@@ -31664,13 +33664,16 @@ definitions:
                       any.Unpack(foo)
                       ...
 
-                 Example 4: Pack and unpack a message in Go
+                Example 4: Pack and unpack a message in Go
 
                      foo := &pb.Foo{...}
-                     any, err := ptypes.MarshalAny(foo)
+                     any, err := anypb.New(foo)
+                     if err != nil {
+                       ...
+                     }
                      ...
                      foo := &pb.Foo{}
-                     if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                     if err := any.UnmarshalTo(foo); err != nil {
                        ...
                      }
 
@@ -31691,7 +33694,6 @@ definitions:
 
                 JSON
 
-                ====
 
                 The JSON representation of an `Any` value uses the regular
 
@@ -31866,7 +33868,7 @@ definitions:
                       foo = any.unpack(Foo.class);
                     }
 
-                 Example 3: Pack and unpack a message in Python.
+                Example 3: Pack and unpack a message in Python.
 
                     foo = Foo(...)
                     any = Any()
@@ -31876,13 +33878,16 @@ definitions:
                       any.Unpack(foo)
                       ...
 
-                 Example 4: Pack and unpack a message in Go
+                Example 4: Pack and unpack a message in Go
 
                      foo := &pb.Foo{...}
-                     any, err := ptypes.MarshalAny(foo)
+                     any, err := anypb.New(foo)
+                     if err != nil {
+                       ...
+                     }
                      ...
                      foo := &pb.Foo{}
-                     if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                     if err := any.UnmarshalTo(foo); err != nil {
                        ...
                      }
 
@@ -31903,7 +33908,6 @@ definitions:
 
                 JSON
 
-                ====
 
                 The JSON representation of an `Any` value uses the regular
 
@@ -32074,7 +34078,7 @@ definitions:
                       foo = any.unpack(Foo.class);
                     }
 
-                 Example 3: Pack and unpack a message in Python.
+                Example 3: Pack and unpack a message in Python.
 
                     foo = Foo(...)
                     any = Any()
@@ -32084,13 +34088,16 @@ definitions:
                       any.Unpack(foo)
                       ...
 
-                 Example 4: Pack and unpack a message in Go
+                Example 4: Pack and unpack a message in Go
 
                      foo := &pb.Foo{...}
-                     any, err := ptypes.MarshalAny(foo)
+                     any, err := anypb.New(foo)
+                     if err != nil {
+                       ...
+                     }
                      ...
                      foo := &pb.Foo{}
-                     if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                     if err := any.UnmarshalTo(foo); err != nil {
                        ...
                      }
 
@@ -32111,7 +34118,6 @@ definitions:
 
                 JSON
 
-                ====
 
                 The JSON representation of an `Any` value uses the regular
 
@@ -32334,6 +34340,18 @@ definitions:
             denom is
 
             sendable).
+        description: >-
+          Deprecated: Use of SendEnabled in params is deprecated.
+
+          For genesis, use the newly added send_enabled field in the genesis
+          object.
+
+          Storage, lookup, and manipulation of this information is now in the
+          keeper.
+
+
+          As of cosmos-sdk 0.47, this only exists for backwards compatibility of
+          genesis files.
       default_send_enabled:
         type: boolean
     description: Params defines the parameters for the bank module.
@@ -32687,12 +34705,89 @@ definitions:
                 denom is
 
                 sendable).
+            description: >-
+              Deprecated: Use of SendEnabled in params is deprecated.
+
+              For genesis, use the newly added send_enabled field in the genesis
+              object.
+
+              Storage, lookup, and manipulation of this information is now in
+              the keeper.
+
+
+              As of cosmos-sdk 0.47, this only exists for backwards
+              compatibility of genesis files.
           default_send_enabled:
             type: boolean
         description: Params defines the parameters for the bank module.
     description: >-
       QueryParamsResponse defines the response type for querying x/bank
       parameters.
+  cosmos.bank.v1beta1.QuerySendEnabledResponse:
+    type: object
+    properties:
+      send_enabled:
+        type: array
+        items:
+          type: object
+          properties:
+            denom:
+              type: string
+            enabled:
+              type: boolean
+          description: >-
+            SendEnabled maps coin denom to a send_enabled status (whether a
+            denom is
+
+            sendable).
+      pagination:
+        description: |-
+          pagination defines the pagination in the response. This field is only
+          populated if the denoms field in the request is empty.
+        type: object
+        properties:
+          next_key:
+            type: string
+            format: byte
+            description: |-
+              next_key is the key to be passed to PageRequest.key to
+              query the next page most efficiently. It will be empty if
+              there are no more results.
+          total:
+            type: string
+            format: uint64
+            title: >-
+              total is total number of results available if
+              PageRequest.count_total
+
+              was set, its value is undefined otherwise
+    description: |-
+      QuerySendEnabledResponse defines the RPC response of a SendEnable query.
+
+      Since: cosmos-sdk 0.47
+  cosmos.bank.v1beta1.QuerySpendableBalanceByDenomResponse:
+    type: object
+    properties:
+      balance:
+        type: object
+        properties:
+          denom:
+            type: string
+          amount:
+            type: string
+        description: |-
+          Coin defines a token with a denomination and an amount.
+
+          NOTE: The amount field is an Int which implements the custom method
+          signatures required by gogoproto.
+    description: >-
+      QuerySpendableBalanceByDenomResponse defines the gRPC response structure
+      for
+
+      querying an account's spendable balance for a specific denom.
+
+
+      Since: cosmos-sdk 0.47
   cosmos.bank.v1beta1.QuerySpendableBalancesResponse:
     type: object
     properties:
@@ -32862,18 +34957,17 @@ definitions:
                 ProofOp defines an operation used for calculating Merkle root.
                 The data could
 
-                be arbitrary format, providing nessecary data for example
+                be arbitrary format, providing necessary data for example
                 neighbouring node
 
                 hash.
 
 
                 Note: This type is a duplicate of the ProofOp proto type defined
-                in
-
-                Tendermint.
-        description: |-
+                in Tendermint.
+        description: >-
           ProofOps is Merkle proof defined by the list of ProofOps.
+
 
           Note: This type is a duplicate of the ProofOps proto type defined in
           Tendermint.
@@ -32882,11 +34976,13 @@ definitions:
         format: int64
       codespace:
         type: string
-    description: |-
+    description: >-
       ABCIQueryResponse defines the response structure for the ABCIQuery gRPC
       query.
 
+
       Note: This type is a duplicate of the ResponseQuery proto type defined in
+
       Tendermint.
   cosmos.base.tendermint.v1beta1.Block:
     type: object
@@ -32968,10 +35064,10 @@ definitions:
             type: string
             description: >-
               proposer_address is the original block proposer address, formatted
-              as a Bech32 string.
+              as a hex string.
 
               In Tendermint, this type is `bytes`, but in the SDK, we convert it
-              to a Bech32 string
+              to a hex string
 
               for better UX.
         description: Header defines the structure of a Tendermint block header.
@@ -33215,9 +35311,7 @@ definitions:
                                 proposer_address:
                                   type: string
                                   format: byte
-                              description: >-
-                                Header defines the structure of a Tendermint
-                                block header.
+                              description: Header defines the structure of a block header.
                             commit:
                               type: object
                               properties:
@@ -33297,7 +35391,7 @@ definitions:
                                         format: byte
                                     title: >-
                                       PublicKey defines the keys available for
-                                      use with Tendermint Validators
+                                      use with Validators
                                   voting_power:
                                     type: string
                                     format: int64
@@ -33321,7 +35415,7 @@ definitions:
                                       format: byte
                                   title: >-
                                     PublicKey defines the keys available for use
-                                    with Tendermint Validators
+                                    with Validators
                                 voting_power:
                                   type: string
                                   format: int64
@@ -33353,7 +35447,7 @@ definitions:
                                 format: byte
                             title: >-
                               PublicKey defines the keys available for use with
-                              Tendermint Validators
+                              Validators
                           voting_power:
                             type: string
                             format: int64
@@ -33424,7 +35518,7 @@ definitions:
           validators.
     description: |-
       Block is tendermint type Block, with the Header proposer address
-      field converted to bech32 string.
+      field converted to hex string.
   cosmos.base.tendermint.v1beta1.GetBlockByHeightResponse:
     type: object
     properties:
@@ -33525,7 +35619,7 @@ definitions:
               proposer_address:
                 type: string
                 format: byte
-            description: Header defines the structure of a Tendermint block header.
+            description: Header defines the structure of a block header.
           data:
             type: object
             properties:
@@ -33768,8 +35862,8 @@ definitions:
                                       type: string
                                       format: byte
                                   description: >-
-                                    Header defines the structure of a Tendermint
-                                    block header.
+                                    Header defines the structure of a block
+                                    header.
                                 commit:
                                   type: object
                                   properties:
@@ -33849,7 +35943,7 @@ definitions:
                                             format: byte
                                         title: >-
                                           PublicKey defines the keys available for
-                                          use with Tendermint Validators
+                                          use with Validators
                                       voting_power:
                                         type: string
                                         format: int64
@@ -33873,7 +35967,7 @@ definitions:
                                           format: byte
                                       title: >-
                                         PublicKey defines the keys available for
-                                        use with Tendermint Validators
+                                        use with Validators
                                     voting_power:
                                       type: string
                                       format: int64
@@ -33905,7 +35999,7 @@ definitions:
                                     format: byte
                                 title: >-
                                   PublicKey defines the keys available for use
-                                  with Tendermint Validators
+                                  with Validators
                               voting_power:
                                 type: string
                                 format: int64
@@ -34055,10 +36149,10 @@ definitions:
                 type: string
                 description: >-
                   proposer_address is the original block proposer address,
-                  formatted as a Bech32 string.
+                  formatted as a hex string.
 
                   In Tendermint, this type is `bytes`, but in the SDK, we
-                  convert it to a Bech32 string
+                  convert it to a hex string
 
                   for better UX.
             description: Header defines the structure of a Tendermint block header.
@@ -34304,8 +36398,8 @@ definitions:
                                       type: string
                                       format: byte
                                   description: >-
-                                    Header defines the structure of a Tendermint
-                                    block header.
+                                    Header defines the structure of a block
+                                    header.
                                 commit:
                                   type: object
                                   properties:
@@ -34385,7 +36479,7 @@ definitions:
                                             format: byte
                                         title: >-
                                           PublicKey defines the keys available for
-                                          use with Tendermint Validators
+                                          use with Validators
                                       voting_power:
                                         type: string
                                         format: int64
@@ -34409,7 +36503,7 @@ definitions:
                                           format: byte
                                       title: >-
                                         PublicKey defines the keys available for
-                                        use with Tendermint Validators
+                                        use with Validators
                                     voting_power:
                                       type: string
                                       format: int64
@@ -34441,7 +36535,7 @@ definitions:
                                     format: byte
                                 title: >-
                                   PublicKey defines the keys available for use
-                                  with Tendermint Validators
+                                  with Validators
                               voting_power:
                                 type: string
                                 format: int64
@@ -34512,12 +36606,10 @@ definitions:
               of validators.
         description: |-
           Block is tendermint type Block, with the Header proposer address
-          field converted to bech32 string.
+          field converted to hex string.
     description: >-
       GetBlockByHeightResponse is the response type for the
-      Query/GetBlockByHeight
-
-      RPC method.
+      Query/GetBlockByHeight RPC method.
   cosmos.base.tendermint.v1beta1.GetLatestBlockResponse:
     type: object
     properties:
@@ -34618,7 +36710,7 @@ definitions:
               proposer_address:
                 type: string
                 format: byte
-            description: Header defines the structure of a Tendermint block header.
+            description: Header defines the structure of a block header.
           data:
             type: object
             properties:
@@ -34861,8 +36953,8 @@ definitions:
                                       type: string
                                       format: byte
                                   description: >-
-                                    Header defines the structure of a Tendermint
-                                    block header.
+                                    Header defines the structure of a block
+                                    header.
                                 commit:
                                   type: object
                                   properties:
@@ -34942,7 +37034,7 @@ definitions:
                                             format: byte
                                         title: >-
                                           PublicKey defines the keys available for
-                                          use with Tendermint Validators
+                                          use with Validators
                                       voting_power:
                                         type: string
                                         format: int64
@@ -34966,7 +37058,7 @@ definitions:
                                           format: byte
                                       title: >-
                                         PublicKey defines the keys available for
-                                        use with Tendermint Validators
+                                        use with Validators
                                     voting_power:
                                       type: string
                                       format: int64
@@ -34998,7 +37090,7 @@ definitions:
                                     format: byte
                                 title: >-
                                   PublicKey defines the keys available for use
-                                  with Tendermint Validators
+                                  with Validators
                               voting_power:
                                 type: string
                                 format: int64
@@ -35148,10 +37240,10 @@ definitions:
                 type: string
                 description: >-
                   proposer_address is the original block proposer address,
-                  formatted as a Bech32 string.
+                  formatted as a hex string.
 
                   In Tendermint, this type is `bytes`, but in the SDK, we
-                  convert it to a Bech32 string
+                  convert it to a hex string
 
                   for better UX.
             description: Header defines the structure of a Tendermint block header.
@@ -35397,8 +37489,8 @@ definitions:
                                       type: string
                                       format: byte
                                   description: >-
-                                    Header defines the structure of a Tendermint
-                                    block header.
+                                    Header defines the structure of a block
+                                    header.
                                 commit:
                                   type: object
                                   properties:
@@ -35478,7 +37570,7 @@ definitions:
                                             format: byte
                                         title: >-
                                           PublicKey defines the keys available for
-                                          use with Tendermint Validators
+                                          use with Validators
                                       voting_power:
                                         type: string
                                         format: int64
@@ -35502,7 +37594,7 @@ definitions:
                                           format: byte
                                       title: >-
                                         PublicKey defines the keys available for
-                                        use with Tendermint Validators
+                                        use with Validators
                                     voting_power:
                                       type: string
                                       format: int64
@@ -35534,7 +37626,7 @@ definitions:
                                     format: byte
                                 title: >-
                                   PublicKey defines the keys available for use
-                                  with Tendermint Validators
+                                  with Validators
                               voting_power:
                                 type: string
                                 format: int64
@@ -35605,12 +37697,10 @@ definitions:
               of validators.
         description: |-
           Block is tendermint type Block, with the Header proposer address
-          field converted to bech32 string.
+          field converted to hex string.
     description: >-
       GetLatestBlockResponse is the response type for the Query/GetLatestBlock
-      RPC
-
-      method.
+      RPC method.
   cosmos.base.tendermint.v1beta1.GetLatestValidatorSetResponse:
     type: object
     properties:
@@ -35723,7 +37813,7 @@ definitions:
                       foo = any.unpack(Foo.class);
                     }
 
-                 Example 3: Pack and unpack a message in Python.
+                Example 3: Pack and unpack a message in Python.
 
                     foo = Foo(...)
                     any = Any()
@@ -35733,13 +37823,16 @@ definitions:
                       any.Unpack(foo)
                       ...
 
-                 Example 4: Pack and unpack a message in Go
+                Example 4: Pack and unpack a message in Go
 
                      foo := &pb.Foo{...}
-                     any, err := ptypes.MarshalAny(foo)
+                     any, err := anypb.New(foo)
+                     if err != nil {
+                       ...
+                     }
                      ...
                      foo := &pb.Foo{}
-                     if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                     if err := any.UnmarshalTo(foo); err != nil {
                        ...
                      }
 
@@ -35760,7 +37853,6 @@ definitions:
 
                 JSON
 
-                ====
 
                 The JSON representation of an `Any` value uses the regular
 
@@ -35819,7 +37911,7 @@ definitions:
               PageRequest.count_total
 
               was set, its value is undefined otherwise
-    description: |-
+    description: >-
       GetLatestValidatorSetResponse is the response type for the
       Query/GetValidatorSetByHeight RPC method.
   cosmos.base.tendermint.v1beta1.GetNodeInfoResponse:
@@ -35894,7 +37986,7 @@ definitions:
             type: string
             title: 'Since: cosmos-sdk 0.43'
         description: VersionInfo is the type for the GetNodeInfoResponse message.
-    description: |-
+    description: >-
       GetNodeInfoResponse is the response type for the Query/GetNodeInfo RPC
       method.
   cosmos.base.tendermint.v1beta1.GetSyncingResponse:
@@ -36017,7 +38109,7 @@ definitions:
                       foo = any.unpack(Foo.class);
                     }
 
-                 Example 3: Pack and unpack a message in Python.
+                Example 3: Pack and unpack a message in Python.
 
                     foo = Foo(...)
                     any = Any()
@@ -36027,13 +38119,16 @@ definitions:
                       any.Unpack(foo)
                       ...
 
-                 Example 4: Pack and unpack a message in Go
+                Example 4: Pack and unpack a message in Go
 
                      foo := &pb.Foo{...}
-                     any, err := ptypes.MarshalAny(foo)
+                     any, err := anypb.New(foo)
+                     if err != nil {
+                       ...
+                     }
                      ...
                      foo := &pb.Foo{}
-                     if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                     if err := any.UnmarshalTo(foo); err != nil {
                        ...
                      }
 
@@ -36054,7 +38149,6 @@ definitions:
 
                 JSON
 
-                ====
 
                 The JSON representation of an `Any` value uses the regular
 
@@ -36113,7 +38207,7 @@ definitions:
               PageRequest.count_total
 
               was set, its value is undefined otherwise
-    description: |-
+    description: >-
       GetValidatorSetByHeightResponse is the response type for the
       Query/GetValidatorSetByHeight RPC method.
   cosmos.base.tendermint.v1beta1.Header:
@@ -36193,10 +38287,10 @@ definitions:
         type: string
         description: >-
           proposer_address is the original block proposer address, formatted as
-          a Bech32 string.
+          a hex string.
 
           In Tendermint, this type is `bytes`, but in the SDK, we convert it to
-          a Bech32 string
+          a hex string
 
           for better UX.
     description: Header defines the structure of a Tendermint block header.
@@ -36228,14 +38322,13 @@ definitions:
       ProofOp defines an operation used for calculating Merkle root. The data
       could
 
-      be arbitrary format, providing nessecary data for example neighbouring
+      be arbitrary format, providing necessary data for example neighbouring
       node
 
       hash.
 
 
       Note: This type is a duplicate of the ProofOp proto type defined in
-
       Tendermint.
   cosmos.base.tendermint.v1beta1.ProofOps:
     type: object
@@ -36257,17 +38350,17 @@ definitions:
             ProofOp defines an operation used for calculating Merkle root. The
             data could
 
-            be arbitrary format, providing nessecary data for example
+            be arbitrary format, providing necessary data for example
             neighbouring node
 
             hash.
 
 
             Note: This type is a duplicate of the ProofOp proto type defined in
-
             Tendermint.
-    description: |-
+    description: >-
       ProofOps is Merkle proof defined by the list of ProofOps.
+
 
       Note: This type is a duplicate of the ProofOps proto type defined in
       Tendermint.
@@ -36369,7 +38462,7 @@ definitions:
                 foo = any.unpack(Foo.class);
               }
 
-           Example 3: Pack and unpack a message in Python.
+          Example 3: Pack and unpack a message in Python.
 
               foo = Foo(...)
               any = Any()
@@ -36379,13 +38472,16 @@ definitions:
                 any.Unpack(foo)
                 ...
 
-           Example 4: Pack and unpack a message in Go
+          Example 4: Pack and unpack a message in Go
 
                foo := &pb.Foo{...}
-               any, err := ptypes.MarshalAny(foo)
+               any, err := anypb.New(foo)
+               if err != nil {
+                 ...
+               }
                ...
                foo := &pb.Foo{}
-               if err := ptypes.UnmarshalAny(any, foo); err != nil {
+               if err := any.UnmarshalTo(foo); err != nil {
                  ...
                }
 
@@ -36403,7 +38499,6 @@ definitions:
 
           JSON
 
-          ====
 
           The JSON representation of an `Any` value uses the regular
 
@@ -36485,7 +38580,7 @@ definitions:
       secp256k1:
         type: string
         format: byte
-    title: PublicKey defines the keys available for use with Tendermint Validators
+    title: PublicKey defines the keys available for use with Validators
   tendermint.p2p.DefaultNodeInfo:
     type: object
     properties:
@@ -36619,7 +38714,7 @@ definitions:
           proposer_address:
             type: string
             format: byte
-        description: Header defines the structure of a Tendermint block header.
+        description: Header defines the structure of a block header.
       data:
         type: object
         properties:
@@ -36860,9 +38955,7 @@ definitions:
                                 proposer_address:
                                   type: string
                                   format: byte
-                              description: >-
-                                Header defines the structure of a Tendermint
-                                block header.
+                              description: Header defines the structure of a block header.
                             commit:
                               type: object
                               properties:
@@ -36942,7 +39035,7 @@ definitions:
                                         format: byte
                                     title: >-
                                       PublicKey defines the keys available for
-                                      use with Tendermint Validators
+                                      use with Validators
                                   voting_power:
                                     type: string
                                     format: int64
@@ -36966,7 +39059,7 @@ definitions:
                                       format: byte
                                   title: >-
                                     PublicKey defines the keys available for use
-                                    with Tendermint Validators
+                                    with Validators
                                 voting_power:
                                   type: string
                                   format: int64
@@ -36998,7 +39091,7 @@ definitions:
                                 format: byte
                             title: >-
                               PublicKey defines the keys available for use with
-                              Tendermint Validators
+                              Validators
                           voting_power:
                             type: string
                             format: int64
@@ -37526,7 +39619,7 @@ definitions:
                       proposer_address:
                         type: string
                         format: byte
-                    description: Header defines the structure of a Tendermint block header.
+                    description: Header defines the structure of a block header.
                   commit:
                     type: object
                     properties:
@@ -37606,7 +39699,7 @@ definitions:
                               format: byte
                           title: >-
                             PublicKey defines the keys available for use with
-                            Tendermint Validators
+                            Validators
                         voting_power:
                           type: string
                           format: int64
@@ -37630,7 +39723,7 @@ definitions:
                             format: byte
                         title: >-
                           PublicKey defines the keys available for use with
-                          Tendermint Validators
+                          Validators
                       voting_power:
                         type: string
                         format: int64
@@ -37660,9 +39753,7 @@ definitions:
                     secp256k1:
                       type: string
                       format: byte
-                  title: >-
-                    PublicKey defines the keys available for use with Tendermint
-                    Validators
+                  title: PublicKey defines the keys available for use with Validators
                 voting_power:
                   type: string
                   format: int64
@@ -37900,9 +39991,7 @@ definitions:
                             proposer_address:
                               type: string
                               format: byte
-                          description: >-
-                            Header defines the structure of a Tendermint block
-                            header.
+                          description: Header defines the structure of a block header.
                         commit:
                           type: object
                           properties:
@@ -37982,7 +40071,7 @@ definitions:
                                     format: byte
                                 title: >-
                                   PublicKey defines the keys available for use
-                                  with Tendermint Validators
+                                  with Validators
                               voting_power:
                                 type: string
                                 format: int64
@@ -38006,7 +40095,7 @@ definitions:
                                   format: byte
                               title: >-
                                 PublicKey defines the keys available for use
-                                with Tendermint Validators
+                                with Validators
                             voting_power:
                               type: string
                               format: int64
@@ -38038,7 +40127,7 @@ definitions:
                             format: byte
                         title: >-
                           PublicKey defines the keys available for use with
-                          Tendermint Validators
+                          Validators
                       voting_power:
                         type: string
                         format: int64
@@ -38130,7 +40219,7 @@ definitions:
       proposer_address:
         type: string
         format: byte
-    description: Header defines the structure of a Tendermint block header.
+    description: Header defines the structure of a block header.
   tendermint.types.LightBlock:
     type: object
     properties:
@@ -38213,7 +40302,7 @@ definitions:
               proposer_address:
                 type: string
                 format: byte
-            description: Header defines the structure of a Tendermint block header.
+            description: Header defines the structure of a block header.
           commit:
             type: object
             properties:
@@ -38287,9 +40376,7 @@ definitions:
                     secp256k1:
                       type: string
                       format: byte
-                  title: >-
-                    PublicKey defines the keys available for use with Tendermint
-                    Validators
+                  title: PublicKey defines the keys available for use with Validators
                 voting_power:
                   type: string
                   format: int64
@@ -38311,9 +40398,7 @@ definitions:
                   secp256k1:
                     type: string
                     format: byte
-                title: >-
-                  PublicKey defines the keys available for use with Tendermint
-                  Validators
+                title: PublicKey defines the keys available for use with Validators
               voting_power:
                 type: string
                 format: int64
@@ -38408,7 +40493,7 @@ definitions:
                   proposer_address:
                     type: string
                     format: byte
-                description: Header defines the structure of a Tendermint block header.
+                description: Header defines the structure of a block header.
               commit:
                 type: object
                 properties:
@@ -38486,7 +40571,7 @@ definitions:
                           format: byte
                       title: >-
                         PublicKey defines the keys available for use with
-                        Tendermint Validators
+                        Validators
                     voting_power:
                       type: string
                       format: int64
@@ -38510,7 +40595,7 @@ definitions:
                         format: byte
                     title: >-
                       PublicKey defines the keys available for use with
-                      Tendermint Validators
+                      Validators
                   voting_power:
                     type: string
                     format: int64
@@ -38540,9 +40625,7 @@ definitions:
                 secp256k1:
                   type: string
                   format: byte
-              title: >-
-                PublicKey defines the keys available for use with Tendermint
-                Validators
+              title: PublicKey defines the keys available for use with Validators
             voting_power:
               type: string
               format: int64
@@ -38647,7 +40730,7 @@ definitions:
           proposer_address:
             type: string
             format: byte
-        description: Header defines the structure of a Tendermint block header.
+        description: Header defines the structure of a block header.
       commit:
         type: object
         properties:
@@ -38729,9 +40812,7 @@ definitions:
           secp256k1:
             type: string
             format: byte
-        title: >-
-          PublicKey defines the keys available for use with Tendermint
-          Validators
+        title: PublicKey defines the keys available for use with Validators
       voting_power:
         type: string
         format: int64
@@ -38758,9 +40839,7 @@ definitions:
                 secp256k1:
                   type: string
                   format: byte
-              title: >-
-                PublicKey defines the keys available for use with Tendermint
-                Validators
+              title: PublicKey defines the keys available for use with Validators
             voting_power:
               type: string
               format: int64
@@ -38782,9 +40861,7 @@ definitions:
               secp256k1:
                 type: string
                 format: byte
-            title: >-
-              PublicKey defines the keys available for use with Tendermint
-              Validators
+            title: PublicKey defines the keys available for use with Validators
           voting_power:
             type: string
             format: int64
@@ -38956,8 +41033,18 @@ definitions:
         type: string
       base_proposer_reward:
         type: string
+        description: >-
+          Deprecated: The base_proposer_reward field is deprecated and is no
+          longer used
+
+          in the x/distribution module's reward mechanism.
       bonus_proposer_reward:
         type: string
+        description: >-
+          Deprecated: The bonus_proposer_reward field is deprecated and is no
+          longer used
+
+          in the x/distribution module's reward mechanism.
       withdraw_addr_enabled:
         type: boolean
     description: Params defines the set of params for the distribution module.
@@ -39086,8 +41173,18 @@ definitions:
             type: string
           base_proposer_reward:
             type: string
+            description: >-
+              Deprecated: The base_proposer_reward field is deprecated and is no
+              longer used
+
+              in the x/distribution module's reward mechanism.
           bonus_proposer_reward:
             type: string
+            description: >-
+              Deprecated: The bonus_proposer_reward field is deprecated and is
+              no longer used
+
+              in the x/distribution module's reward mechanism.
           withdraw_addr_enabled:
             type: boolean
     description: QueryParamsResponse is the response type for the Query/Params RPC method.
@@ -39095,7 +41192,7 @@ definitions:
     type: object
     properties:
       commission:
-        description: commission defines the commision the validator received.
+        description: commission defines the commission the validator received.
         type: object
         properties:
           commission:
@@ -39119,6 +41216,45 @@ definitions:
     title: |-
       QueryValidatorCommissionResponse is the response type for the
       Query/ValidatorCommission RPC method
+  cosmos.distribution.v1beta1.QueryValidatorDistributionInfoResponse:
+    type: object
+    properties:
+      operator_address:
+        type: string
+        description: operator_address defines the validator operator address.
+      self_bond_rewards:
+        type: array
+        items:
+          type: object
+          properties:
+            denom:
+              type: string
+            amount:
+              type: string
+          description: |-
+            DecCoin defines a token with a denomination and a decimal amount.
+
+            NOTE: The amount field is an Dec which implements the custom method
+            signatures required by gogoproto.
+        description: self_bond_rewards defines the self delegations rewards.
+      commission:
+        type: array
+        items:
+          type: object
+          properties:
+            denom:
+              type: string
+            amount:
+              type: string
+          description: |-
+            DecCoin defines a token with a denomination and a decimal amount.
+
+            NOTE: The amount field is an Dec which implements the custom method
+            signatures required by gogoproto.
+        description: commission defines the commission the validator received.
+    description: >-
+      QueryValidatorDistributionInfoResponse is the response type for the
+      Query/ValidatorDistributionInfo RPC method.
   cosmos.distribution.v1beta1.QueryValidatorOutstandingRewardsResponse:
     type: object
     properties:
@@ -39346,7 +41482,7 @@ definitions:
                   foo = any.unpack(Foo.class);
                 }
 
-             Example 3: Pack and unpack a message in Python.
+            Example 3: Pack and unpack a message in Python.
 
                 foo = Foo(...)
                 any = Any()
@@ -39356,13 +41492,16 @@ definitions:
                   any.Unpack(foo)
                   ...
 
-             Example 4: Pack and unpack a message in Go
+            Example 4: Pack and unpack a message in Go
 
                  foo := &pb.Foo{...}
-                 any, err := ptypes.MarshalAny(foo)
+                 any, err := anypb.New(foo)
+                 if err != nil {
+                   ...
+                 }
                  ...
                  foo := &pb.Foo{}
-                 if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                 if err := any.UnmarshalTo(foo); err != nil {
                    ...
                  }
 
@@ -39380,7 +41519,6 @@ definitions:
 
             JSON
 
-            ====
 
             The JSON representation of an `Any` value uses the regular
 
@@ -39533,7 +41671,7 @@ definitions:
                 foo = any.unpack(Foo.class);
               }
 
-           Example 3: Pack and unpack a message in Python.
+          Example 3: Pack and unpack a message in Python.
 
               foo = Foo(...)
               any = Any()
@@ -39543,13 +41681,16 @@ definitions:
                 any.Unpack(foo)
                 ...
 
-           Example 4: Pack and unpack a message in Go
+          Example 4: Pack and unpack a message in Go
 
                foo := &pb.Foo{...}
-               any, err := ptypes.MarshalAny(foo)
+               any, err := anypb.New(foo)
+               if err != nil {
+                 ...
+               }
                ...
                foo := &pb.Foo{}
-               if err := ptypes.UnmarshalAny(any, foo); err != nil {
+               if err := any.UnmarshalTo(foo); err != nil {
                  ...
                }
 
@@ -39567,7 +41708,6 @@ definitions:
 
           JSON
 
-          ====
 
           The JSON representation of an `Any` value uses the regular
 
@@ -39991,8 +42131,10 @@ definitions:
       proposal_id:
         type: string
         format: uint64
+        description: proposal_id defines the unique id of the proposal.
       depositor:
         type: string
+        description: depositor defines the deposit addresses from the proposals.
       amount:
         type: array
         items:
@@ -40007,6 +42149,7 @@ definitions:
 
             NOTE: The amount field is an Int which implements the custom method
             signatures required by gogoproto.
+        description: amount to be deposited by depositor.
     description: |-
       Deposit defines an amount deposited by an account address to an active
       proposal.
@@ -40033,7 +42176,8 @@ definitions:
         description: >-
           Maximum period for Atom holders to deposit on a proposal. Initial
           value: 2
-           months.
+
+          months.
     description: DepositParams defines the params for deposits on governance proposals.
   cosmos.gov.v1beta1.Proposal:
     type: object
@@ -40041,6 +42185,7 @@ definitions:
       proposal_id:
         type: string
         format: uint64
+        description: proposal_id defines the unique id of the proposal.
       content:
         type: object
         properties:
@@ -40134,7 +42279,7 @@ definitions:
                 foo = any.unpack(Foo.class);
               }
 
-           Example 3: Pack and unpack a message in Python.
+          Example 3: Pack and unpack a message in Python.
 
               foo = Foo(...)
               any = Any()
@@ -40144,13 +42289,16 @@ definitions:
                 any.Unpack(foo)
                 ...
 
-           Example 4: Pack and unpack a message in Go
+          Example 4: Pack and unpack a message in Go
 
                foo := &pb.Foo{...}
-               any, err := ptypes.MarshalAny(foo)
+               any, err := anypb.New(foo)
+               if err != nil {
+                 ...
+               }
                ...
                foo := &pb.Foo{}
-               if err := ptypes.UnmarshalAny(any, foo); err != nil {
+               if err := any.UnmarshalTo(foo); err != nil {
                  ...
                }
 
@@ -40168,7 +42316,6 @@ definitions:
 
           JSON
 
-          ====
 
           The JSON representation of an `Any` value uses the regular
 
@@ -40201,6 +42348,7 @@ definitions:
                 "value": "1.212s"
               }
       status:
+        description: status defines the proposal status.
         type: string
         enum:
           - PROPOSAL_STATUS_UNSPECIFIED
@@ -40210,20 +42358,6 @@ definitions:
           - PROPOSAL_STATUS_REJECTED
           - PROPOSAL_STATUS_FAILED
         default: PROPOSAL_STATUS_UNSPECIFIED
-        description: |-
-          ProposalStatus enumerates the valid statuses of a proposal.
-
-           - PROPOSAL_STATUS_UNSPECIFIED: PROPOSAL_STATUS_UNSPECIFIED defines the default proposal status.
-           - PROPOSAL_STATUS_DEPOSIT_PERIOD: PROPOSAL_STATUS_DEPOSIT_PERIOD defines a proposal status during the deposit
-          period.
-           - PROPOSAL_STATUS_VOTING_PERIOD: PROPOSAL_STATUS_VOTING_PERIOD defines a proposal status during the voting
-          period.
-           - PROPOSAL_STATUS_PASSED: PROPOSAL_STATUS_PASSED defines a proposal status of a proposal that has
-          passed.
-           - PROPOSAL_STATUS_REJECTED: PROPOSAL_STATUS_REJECTED defines a proposal status of a proposal that has
-          been rejected.
-           - PROPOSAL_STATUS_FAILED: PROPOSAL_STATUS_FAILED defines a proposal status of a proposal that has
-          failed.
       final_tally_result:
         description: |-
           final_tally_result is the final tally result of the proposal. When
@@ -40233,18 +42367,24 @@ definitions:
         properties:
           'yes':
             type: string
+            description: yes is the number of yes votes on a proposal.
           abstain:
             type: string
+            description: abstain is the number of abstain votes on a proposal.
           'no':
             type: string
+            description: no is the number of no votes on a proposal.
           no_with_veto:
             type: string
+            description: no_with_veto is the number of no with veto votes on a proposal.
       submit_time:
         type: string
         format: date-time
+        description: submit_time is the time of proposal submission.
       deposit_end_time:
         type: string
         format: date-time
+        description: deposit_end_time is the end time for deposition.
       total_deposit:
         type: array
         items:
@@ -40259,12 +42399,15 @@ definitions:
 
             NOTE: The amount field is an Int which implements the custom method
             signatures required by gogoproto.
+        description: total_deposit is the total deposit on the proposal.
       voting_start_time:
         type: string
         format: date-time
+        description: voting_start_time is the starting time to vote on a proposal.
       voting_end_time:
         type: string
         format: date-time
+        description: voting_end_time is the end time of voting on a proposal.
     description: Proposal defines the core field members of a governance proposal.
   cosmos.gov.v1beta1.ProposalStatus:
     type: string
@@ -40299,8 +42442,10 @@ definitions:
           proposal_id:
             type: string
             format: uint64
+            description: proposal_id defines the unique id of the proposal.
           depositor:
             type: string
+            description: depositor defines the deposit addresses from the proposals.
           amount:
             type: array
             items:
@@ -40318,6 +42463,7 @@ definitions:
                 method
 
                 signatures required by gogoproto.
+            description: amount to be deposited by depositor.
         description: |-
           Deposit defines an amount deposited by an account address to an active
           proposal.
@@ -40335,8 +42481,10 @@ definitions:
             proposal_id:
               type: string
               format: uint64
+              description: proposal_id defines the unique id of the proposal.
             depositor:
               type: string
+              description: depositor defines the deposit addresses from the proposals.
             amount:
               type: array
               items:
@@ -40354,11 +42502,13 @@ definitions:
                   method
 
                   signatures required by gogoproto.
+              description: amount to be deposited by depositor.
           description: >-
             Deposit defines an amount deposited by an account address to an
             active
 
             proposal.
+        description: deposits defines the requested deposits.
       pagination:
         description: pagination defines the pagination in the response.
         type: object
@@ -40390,7 +42540,7 @@ definitions:
         properties:
           voting_period:
             type: string
-            description: Length of the voting period.
+            description: Duration of the voting period.
       deposit_params:
         description: deposit_params defines the parameters related to deposit.
         type: object
@@ -40418,7 +42568,8 @@ definitions:
             description: >-
               Maximum period for Atom holders to deposit on a proposal. Initial
               value: 2
-               months.
+
+              months.
       tally_params:
         description: tally_params defines the parameters related to tally.
         type: object
@@ -40429,7 +42580,8 @@ definitions:
             description: >-
               Minimum percentage of total stake needed to vote for a result to
               be
-               considered valid.
+
+              considered valid.
           threshold:
             type: string
             format: byte
@@ -40442,7 +42594,8 @@ definitions:
             description: >-
               Minimum value of Veto votes to Total votes ratio for proposal to
               be
-               vetoed. Default value: 1/3.
+
+              vetoed. Default value: 1/3.
     description: QueryParamsResponse is the response type for the Query/Params RPC method.
   cosmos.gov.v1beta1.QueryProposalResponse:
     type: object
@@ -40453,6 +42606,7 @@ definitions:
           proposal_id:
             type: string
             format: uint64
+            description: proposal_id defines the unique id of the proposal.
           content:
             type: object
             properties:
@@ -40550,7 +42704,7 @@ definitions:
                     foo = any.unpack(Foo.class);
                   }
 
-               Example 3: Pack and unpack a message in Python.
+              Example 3: Pack and unpack a message in Python.
 
                   foo = Foo(...)
                   any = Any()
@@ -40560,13 +42714,16 @@ definitions:
                     any.Unpack(foo)
                     ...
 
-               Example 4: Pack and unpack a message in Go
+              Example 4: Pack and unpack a message in Go
 
                    foo := &pb.Foo{...}
-                   any, err := ptypes.MarshalAny(foo)
+                   any, err := anypb.New(foo)
+                   if err != nil {
+                     ...
+                   }
                    ...
                    foo := &pb.Foo{}
-                   if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                   if err := any.UnmarshalTo(foo); err != nil {
                      ...
                    }
 
@@ -40585,7 +42742,6 @@ definitions:
 
               JSON
 
-              ====
 
               The JSON representation of an `Any` value uses the regular
 
@@ -40619,6 +42775,7 @@ definitions:
                     "value": "1.212s"
                   }
           status:
+            description: status defines the proposal status.
             type: string
             enum:
               - PROPOSAL_STATUS_UNSPECIFIED
@@ -40628,20 +42785,6 @@ definitions:
               - PROPOSAL_STATUS_REJECTED
               - PROPOSAL_STATUS_FAILED
             default: PROPOSAL_STATUS_UNSPECIFIED
-            description: |-
-              ProposalStatus enumerates the valid statuses of a proposal.
-
-               - PROPOSAL_STATUS_UNSPECIFIED: PROPOSAL_STATUS_UNSPECIFIED defines the default proposal status.
-               - PROPOSAL_STATUS_DEPOSIT_PERIOD: PROPOSAL_STATUS_DEPOSIT_PERIOD defines a proposal status during the deposit
-              period.
-               - PROPOSAL_STATUS_VOTING_PERIOD: PROPOSAL_STATUS_VOTING_PERIOD defines a proposal status during the voting
-              period.
-               - PROPOSAL_STATUS_PASSED: PROPOSAL_STATUS_PASSED defines a proposal status of a proposal that has
-              passed.
-               - PROPOSAL_STATUS_REJECTED: PROPOSAL_STATUS_REJECTED defines a proposal status of a proposal that has
-              been rejected.
-               - PROPOSAL_STATUS_FAILED: PROPOSAL_STATUS_FAILED defines a proposal status of a proposal that has
-              failed.
           final_tally_result:
             description: >-
               final_tally_result is the final tally result of the proposal. When
@@ -40654,18 +42797,26 @@ definitions:
             properties:
               'yes':
                 type: string
+                description: yes is the number of yes votes on a proposal.
               abstain:
                 type: string
+                description: abstain is the number of abstain votes on a proposal.
               'no':
                 type: string
+                description: no is the number of no votes on a proposal.
               no_with_veto:
                 type: string
+                description: >-
+                  no_with_veto is the number of no with veto votes on a
+                  proposal.
           submit_time:
             type: string
             format: date-time
+            description: submit_time is the time of proposal submission.
           deposit_end_time:
             type: string
             format: date-time
+            description: deposit_end_time is the end time for deposition.
           total_deposit:
             type: array
             items:
@@ -40683,12 +42834,15 @@ definitions:
                 method
 
                 signatures required by gogoproto.
+            description: total_deposit is the total deposit on the proposal.
           voting_start_time:
             type: string
             format: date-time
+            description: voting_start_time is the starting time to vote on a proposal.
           voting_end_time:
             type: string
             format: date-time
+            description: voting_end_time is the end time of voting on a proposal.
         description: Proposal defines the core field members of a governance proposal.
     description: >-
       QueryProposalResponse is the response type for the Query/Proposal RPC
@@ -40704,6 +42858,7 @@ definitions:
             proposal_id:
               type: string
               format: uint64
+              description: proposal_id defines the unique id of the proposal.
             content:
               type: object
               properties:
@@ -40803,7 +42958,7 @@ definitions:
                       foo = any.unpack(Foo.class);
                     }
 
-                 Example 3: Pack and unpack a message in Python.
+                Example 3: Pack and unpack a message in Python.
 
                     foo = Foo(...)
                     any = Any()
@@ -40813,13 +42968,16 @@ definitions:
                       any.Unpack(foo)
                       ...
 
-                 Example 4: Pack and unpack a message in Go
+                Example 4: Pack and unpack a message in Go
 
                      foo := &pb.Foo{...}
-                     any, err := ptypes.MarshalAny(foo)
+                     any, err := anypb.New(foo)
+                     if err != nil {
+                       ...
+                     }
                      ...
                      foo := &pb.Foo{}
-                     if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                     if err := any.UnmarshalTo(foo); err != nil {
                        ...
                      }
 
@@ -40840,7 +42998,6 @@ definitions:
 
                 JSON
 
-                ====
 
                 The JSON representation of an `Any` value uses the regular
 
@@ -40874,6 +43031,7 @@ definitions:
                       "value": "1.212s"
                     }
             status:
+              description: status defines the proposal status.
               type: string
               enum:
                 - PROPOSAL_STATUS_UNSPECIFIED
@@ -40883,20 +43041,6 @@ definitions:
                 - PROPOSAL_STATUS_REJECTED
                 - PROPOSAL_STATUS_FAILED
               default: PROPOSAL_STATUS_UNSPECIFIED
-              description: |-
-                ProposalStatus enumerates the valid statuses of a proposal.
-
-                 - PROPOSAL_STATUS_UNSPECIFIED: PROPOSAL_STATUS_UNSPECIFIED defines the default proposal status.
-                 - PROPOSAL_STATUS_DEPOSIT_PERIOD: PROPOSAL_STATUS_DEPOSIT_PERIOD defines a proposal status during the deposit
-                period.
-                 - PROPOSAL_STATUS_VOTING_PERIOD: PROPOSAL_STATUS_VOTING_PERIOD defines a proposal status during the voting
-                period.
-                 - PROPOSAL_STATUS_PASSED: PROPOSAL_STATUS_PASSED defines a proposal status of a proposal that has
-                passed.
-                 - PROPOSAL_STATUS_REJECTED: PROPOSAL_STATUS_REJECTED defines a proposal status of a proposal that has
-                been rejected.
-                 - PROPOSAL_STATUS_FAILED: PROPOSAL_STATUS_FAILED defines a proposal status of a proposal that has
-                failed.
             final_tally_result:
               description: >-
                 final_tally_result is the final tally result of the proposal.
@@ -40910,18 +43054,26 @@ definitions:
               properties:
                 'yes':
                   type: string
+                  description: yes is the number of yes votes on a proposal.
                 abstain:
                   type: string
+                  description: abstain is the number of abstain votes on a proposal.
                 'no':
                   type: string
+                  description: no is the number of no votes on a proposal.
                 no_with_veto:
                   type: string
+                  description: >-
+                    no_with_veto is the number of no with veto votes on a
+                    proposal.
             submit_time:
               type: string
               format: date-time
+              description: submit_time is the time of proposal submission.
             deposit_end_time:
               type: string
               format: date-time
+              description: deposit_end_time is the end time for deposition.
             total_deposit:
               type: array
               items:
@@ -40939,13 +43091,17 @@ definitions:
                   method
 
                   signatures required by gogoproto.
+              description: total_deposit is the total deposit on the proposal.
             voting_start_time:
               type: string
               format: date-time
+              description: voting_start_time is the starting time to vote on a proposal.
             voting_end_time:
               type: string
               format: date-time
+              description: voting_end_time is the end time of voting on a proposal.
           description: Proposal defines the core field members of a governance proposal.
+        description: proposals defines all the requested governance proposals.
       pagination:
         description: pagination defines the pagination in the response.
         type: object
@@ -40977,12 +43133,16 @@ definitions:
         properties:
           'yes':
             type: string
+            description: yes is the number of yes votes on a proposal.
           abstain:
             type: string
+            description: abstain is the number of abstain votes on a proposal.
           'no':
             type: string
+            description: no is the number of no votes on a proposal.
           no_with_veto:
             type: string
+            description: no_with_veto is the number of no with veto votes on a proposal.
     description: >-
       QueryTallyResultResponse is the response type for the Query/Tally RPC
       method.
@@ -40995,8 +43155,10 @@ definitions:
           proposal_id:
             type: string
             format: uint64
+            description: proposal_id defines the unique id of the proposal.
           voter:
             type: string
+            description: voter is the voter address of the proposal.
           option:
             description: >-
               Deprecated: Prefer to use `options` instead. This field is set in
@@ -41020,6 +43182,9 @@ definitions:
               type: object
               properties:
                 option:
+                  description: >-
+                    option defines the valid vote options, it must not contain
+                    duplicate vote options.
                   type: string
                   enum:
                     - VOTE_OPTION_UNSPECIFIED
@@ -41028,22 +43193,17 @@ definitions:
                     - VOTE_OPTION_NO
                     - VOTE_OPTION_NO_WITH_VETO
                   default: VOTE_OPTION_UNSPECIFIED
-                  description: >-
-                    VoteOption enumerates the valid vote options for a given
-                    governance proposal.
-
-                     - VOTE_OPTION_UNSPECIFIED: VOTE_OPTION_UNSPECIFIED defines a no-op vote option.
-                     - VOTE_OPTION_YES: VOTE_OPTION_YES defines a yes vote option.
-                     - VOTE_OPTION_ABSTAIN: VOTE_OPTION_ABSTAIN defines an abstain vote option.
-                     - VOTE_OPTION_NO: VOTE_OPTION_NO defines a no vote option.
-                     - VOTE_OPTION_NO_WITH_VETO: VOTE_OPTION_NO_WITH_VETO defines a no with veto vote option.
                 weight:
                   type: string
+                  description: weight is the vote weight associated with the vote option.
               description: |-
                 WeightedVoteOption defines a unit of vote for vote split.
 
                 Since: cosmos-sdk 0.43
-            title: 'Since: cosmos-sdk 0.43'
+            description: |-
+              options is the weighted vote options.
+
+              Since: cosmos-sdk 0.43
         description: |-
           Vote defines a vote on a governance proposal.
           A Vote consists of a proposal ID, the voter, and the vote option.
@@ -41059,8 +43219,10 @@ definitions:
             proposal_id:
               type: string
               format: uint64
+              description: proposal_id defines the unique id of the proposal.
             voter:
               type: string
+              description: voter is the voter address of the proposal.
             option:
               description: >-
                 Deprecated: Prefer to use `options` instead. This field is set
@@ -41084,6 +43246,9 @@ definitions:
                 type: object
                 properties:
                   option:
+                    description: >-
+                      option defines the valid vote options, it must not contain
+                      duplicate vote options.
                     type: string
                     enum:
                       - VOTE_OPTION_UNSPECIFIED
@@ -41092,26 +43257,21 @@ definitions:
                       - VOTE_OPTION_NO
                       - VOTE_OPTION_NO_WITH_VETO
                     default: VOTE_OPTION_UNSPECIFIED
-                    description: >-
-                      VoteOption enumerates the valid vote options for a given
-                      governance proposal.
-
-                       - VOTE_OPTION_UNSPECIFIED: VOTE_OPTION_UNSPECIFIED defines a no-op vote option.
-                       - VOTE_OPTION_YES: VOTE_OPTION_YES defines a yes vote option.
-                       - VOTE_OPTION_ABSTAIN: VOTE_OPTION_ABSTAIN defines an abstain vote option.
-                       - VOTE_OPTION_NO: VOTE_OPTION_NO defines a no vote option.
-                       - VOTE_OPTION_NO_WITH_VETO: VOTE_OPTION_NO_WITH_VETO defines a no with veto vote option.
                   weight:
                     type: string
+                    description: weight is the vote weight associated with the vote option.
                 description: |-
                   WeightedVoteOption defines a unit of vote for vote split.
 
                   Since: cosmos-sdk 0.43
-              title: 'Since: cosmos-sdk 0.43'
+              description: |-
+                options is the weighted vote options.
+
+                Since: cosmos-sdk 0.43
           description: |-
             Vote defines a vote on a governance proposal.
             A Vote consists of a proposal ID, the voter, and the vote option.
-        description: votes defined the queried votes.
+        description: votes defines the queried votes.
       pagination:
         description: pagination defines the pagination in the response.
         type: object
@@ -41140,7 +43300,7 @@ definitions:
         format: byte
         description: |-
           Minimum percentage of total stake needed to vote for a result to be
-           considered valid.
+          considered valid.
       threshold:
         type: string
         format: byte
@@ -41152,19 +43312,23 @@ definitions:
         format: byte
         description: |-
           Minimum value of Veto votes to Total votes ratio for proposal to be
-           vetoed. Default value: 1/3.
+          vetoed. Default value: 1/3.
     description: TallyParams defines the params for tallying votes on governance proposals.
   cosmos.gov.v1beta1.TallyResult:
     type: object
     properties:
       'yes':
         type: string
+        description: yes is the number of yes votes on a proposal.
       abstain:
         type: string
+        description: abstain is the number of abstain votes on a proposal.
       'no':
         type: string
+        description: no is the number of no votes on a proposal.
       no_with_veto:
         type: string
+        description: no_with_veto is the number of no with veto votes on a proposal.
     description: TallyResult defines a standard tally for a governance proposal.
   cosmos.gov.v1beta1.Vote:
     type: object
@@ -41172,8 +43336,10 @@ definitions:
       proposal_id:
         type: string
         format: uint64
+        description: proposal_id defines the unique id of the proposal.
       voter:
         type: string
+        description: voter is the voter address of the proposal.
       option:
         description: >-
           Deprecated: Prefer to use `options` instead. This field is set in
@@ -41197,6 +43363,9 @@ definitions:
           type: object
           properties:
             option:
+              description: >-
+                option defines the valid vote options, it must not contain
+                duplicate vote options.
               type: string
               enum:
                 - VOTE_OPTION_UNSPECIFIED
@@ -41205,22 +43374,17 @@ definitions:
                 - VOTE_OPTION_NO
                 - VOTE_OPTION_NO_WITH_VETO
               default: VOTE_OPTION_UNSPECIFIED
-              description: >-
-                VoteOption enumerates the valid vote options for a given
-                governance proposal.
-
-                 - VOTE_OPTION_UNSPECIFIED: VOTE_OPTION_UNSPECIFIED defines a no-op vote option.
-                 - VOTE_OPTION_YES: VOTE_OPTION_YES defines a yes vote option.
-                 - VOTE_OPTION_ABSTAIN: VOTE_OPTION_ABSTAIN defines an abstain vote option.
-                 - VOTE_OPTION_NO: VOTE_OPTION_NO defines a no vote option.
-                 - VOTE_OPTION_NO_WITH_VETO: VOTE_OPTION_NO_WITH_VETO defines a no with veto vote option.
             weight:
               type: string
+              description: weight is the vote weight associated with the vote option.
           description: |-
             WeightedVoteOption defines a unit of vote for vote split.
 
             Since: cosmos-sdk 0.43
-        title: 'Since: cosmos-sdk 0.43'
+        description: |-
+          options is the weighted vote options.
+
+          Since: cosmos-sdk 0.43
     description: |-
       Vote defines a vote on a governance proposal.
       A Vote consists of a proposal ID, the voter, and the vote option.
@@ -41247,12 +43411,15 @@ definitions:
     properties:
       voting_period:
         type: string
-        description: Length of the voting period.
+        description: Duration of the voting period.
     description: VotingParams defines the params for voting on governance proposals.
   cosmos.gov.v1beta1.WeightedVoteOption:
     type: object
     properties:
       option:
+        description: >-
+          option defines the valid vote options, it must not contain duplicate
+          vote options.
         type: string
         enum:
           - VOTE_OPTION_UNSPECIFIED
@@ -41261,17 +43428,9 @@ definitions:
           - VOTE_OPTION_NO
           - VOTE_OPTION_NO_WITH_VETO
         default: VOTE_OPTION_UNSPECIFIED
-        description: >-
-          VoteOption enumerates the valid vote options for a given governance
-          proposal.
-
-           - VOTE_OPTION_UNSPECIFIED: VOTE_OPTION_UNSPECIFIED defines a no-op vote option.
-           - VOTE_OPTION_YES: VOTE_OPTION_YES defines a yes vote option.
-           - VOTE_OPTION_ABSTAIN: VOTE_OPTION_ABSTAIN defines an abstain vote option.
-           - VOTE_OPTION_NO: VOTE_OPTION_NO defines a no vote option.
-           - VOTE_OPTION_NO_WITH_VETO: VOTE_OPTION_NO_WITH_VETO defines a no with veto vote option.
       weight:
         type: string
+        description: weight is the vote weight associated with the vote option.
     description: |-
       WeightedVoteOption defines a unit of vote for vote split.
 
@@ -41298,7 +43457,7 @@ definitions:
         type: string
         format: uint64
         title: expected blocks per year
-    description: Params holds parameters for the mint module.
+    description: Params defines the parameters for the x/mint module.
   cosmos.mint.v1beta1.QueryAnnualProvisionsResponse:
     type: object
     properties:
@@ -41929,7 +44088,7 @@ definitions:
           proposer_address:
             type: string
             format: byte
-        description: Header defines the structure of a Tendermint block header.
+        description: Header defines the structure of a block header.
       valset:
         type: array
         items:
@@ -42039,7 +44198,7 @@ definitions:
                       foo = any.unpack(Foo.class);
                     }
 
-                 Example 3: Pack and unpack a message in Python.
+                Example 3: Pack and unpack a message in Python.
 
                     foo = Foo(...)
                     any = Any()
@@ -42049,13 +44208,16 @@ definitions:
                       any.Unpack(foo)
                       ...
 
-                 Example 4: Pack and unpack a message in Go
+                Example 4: Pack and unpack a message in Go
 
                      foo := &pb.Foo{...}
-                     any, err := ptypes.MarshalAny(foo)
+                     any, err := anypb.New(foo)
+                     if err != nil {
+                       ...
+                     }
                      ...
                      foo := &pb.Foo{}
-                     if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                     if err := any.UnmarshalTo(foo); err != nil {
                        ...
                      }
 
@@ -42076,7 +44238,6 @@ definitions:
 
                 JSON
 
-                ====
 
                 The JSON representation of an `Any` value uses the regular
 
@@ -42205,6 +44366,20 @@ definitions:
 
 
                 Since: cosmos-sdk 0.46
+            unbonding_on_hold_ref_count:
+              type: string
+              format: int64
+              title: >-
+                strictly positive if this validator's unbonding has been stopped
+                by external modules
+            unbonding_ids:
+              type: array
+              items:
+                type: string
+                format: uint64
+              title: >-
+                list of unbonding ids, each uniquely identifing an unbonding of
+                this validator
             self_del_address:
               type: string
               description: >-
@@ -42290,7 +44465,7 @@ definitions:
         description: >-
           min_self_delegation defines the minimum self delegation for
           validators.
-    description: Params defines the parameters for the staking module.
+    description: Params defines the parameters for the x/staking module.
   cosmos.staking.v1beta1.Pool:
     type: object
     properties:
@@ -42472,6 +44647,16 @@ definitions:
                   balance:
                     type: string
                     description: balance defines the tokens to receive at completion.
+                  unbonding_id:
+                    type: string
+                    format: uint64
+                    title: Incrementing id that uniquely identifies this entry
+                  unbonding_on_hold_ref_count:
+                    type: string
+                    format: int64
+                    title: >-
+                      Strictly positive if this entry's unbonding has been
+                      stopped by external modules
                 description: >-
                   UnbondingDelegationEntry defines an unbonding object with
                   relevant metadata.
@@ -42611,7 +44796,7 @@ definitions:
                     foo = any.unpack(Foo.class);
                   }
 
-               Example 3: Pack and unpack a message in Python.
+              Example 3: Pack and unpack a message in Python.
 
                   foo = Foo(...)
                   any = Any()
@@ -42621,13 +44806,16 @@ definitions:
                     any.Unpack(foo)
                     ...
 
-               Example 4: Pack and unpack a message in Go
+              Example 4: Pack and unpack a message in Go
 
                    foo := &pb.Foo{...}
-                   any, err := ptypes.MarshalAny(foo)
+                   any, err := anypb.New(foo)
+                   if err != nil {
+                     ...
+                   }
                    ...
                    foo := &pb.Foo{}
-                   if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                   if err := any.UnmarshalTo(foo); err != nil {
                      ...
                    }
 
@@ -42646,7 +44834,6 @@ definitions:
 
               JSON
 
-              ====
 
               The JSON representation of an `Any` value uses the regular
 
@@ -42773,6 +44960,20 @@ definitions:
 
 
               Since: cosmos-sdk 0.46
+          unbonding_on_hold_ref_count:
+            type: string
+            format: int64
+            title: >-
+              strictly positive if this validator's unbonding has been stopped
+              by external modules
+          unbonding_ids:
+            type: array
+            items:
+              type: string
+              format: uint64
+            title: >-
+              list of unbonding ids, each uniquely identifing an unbonding of
+              this validator
           self_del_address:
             type: string
             description: >-
@@ -42930,7 +45131,7 @@ definitions:
                       foo = any.unpack(Foo.class);
                     }
 
-                 Example 3: Pack and unpack a message in Python.
+                Example 3: Pack and unpack a message in Python.
 
                     foo = Foo(...)
                     any = Any()
@@ -42940,13 +45141,16 @@ definitions:
                       any.Unpack(foo)
                       ...
 
-                 Example 4: Pack and unpack a message in Go
+                Example 4: Pack and unpack a message in Go
 
                      foo := &pb.Foo{...}
-                     any, err := ptypes.MarshalAny(foo)
+                     any, err := anypb.New(foo)
+                     if err != nil {
+                       ...
+                     }
                      ...
                      foo := &pb.Foo{}
-                     if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                     if err := any.UnmarshalTo(foo); err != nil {
                        ...
                      }
 
@@ -42967,7 +45171,6 @@ definitions:
 
                 JSON
 
-                ====
 
                 The JSON representation of an `Any` value uses the regular
 
@@ -43096,6 +45299,20 @@ definitions:
 
 
                 Since: cosmos-sdk 0.46
+            unbonding_on_hold_ref_count:
+              type: string
+              format: int64
+              title: >-
+                strictly positive if this validator's unbonding has been stopped
+                by external modules
+            unbonding_ids:
+              type: array
+              items:
+                type: string
+                format: uint64
+              title: >-
+                list of unbonding ids, each uniquely identifing an unbonding of
+                this validator
             self_del_address:
               type: string
               description: >-
@@ -43244,7 +45461,7 @@ definitions:
               proposer_address:
                 type: string
                 format: byte
-            description: Header defines the structure of a Tendermint block header.
+            description: Header defines the structure of a block header.
           valset:
             type: array
             items:
@@ -43355,7 +45572,7 @@ definitions:
                           foo = any.unpack(Foo.class);
                         }
 
-                     Example 3: Pack and unpack a message in Python.
+                    Example 3: Pack and unpack a message in Python.
 
                         foo = Foo(...)
                         any = Any()
@@ -43365,13 +45582,16 @@ definitions:
                           any.Unpack(foo)
                           ...
 
-                     Example 4: Pack and unpack a message in Go
+                    Example 4: Pack and unpack a message in Go
 
                          foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
                          ...
                          foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         if err := any.UnmarshalTo(foo); err != nil {
                            ...
                          }
 
@@ -43393,7 +45613,6 @@ definitions:
 
                     JSON
 
-                    ====
 
                     The JSON representation of an `Any` value uses the regular
 
@@ -43526,6 +45745,20 @@ definitions:
 
 
                     Since: cosmos-sdk 0.46
+                unbonding_on_hold_ref_count:
+                  type: string
+                  format: int64
+                  title: >-
+                    strictly positive if this validator's unbonding has been
+                    stopped by external modules
+                unbonding_ids:
+                  type: array
+                  items:
+                    type: string
+                    format: uint64
+                  title: >-
+                    list of unbonding ids, each uniquely identifing an unbonding
+                    of this validator
                 self_del_address:
                   type: string
                   description: >-
@@ -43678,6 +45911,16 @@ definitions:
                         description: >-
                           shares_dst is the amount of destination-validator
                           shares created by redelegation.
+                      unbonding_id:
+                        type: string
+                        format: uint64
+                        title: Incrementing id that uniquely identifies this entry
+                      unbonding_on_hold_ref_count:
+                        type: string
+                        format: int64
+                        title: >-
+                          Strictly positive if this entry's unbonding has been
+                          stopped by external modules
                     description: >-
                       RedelegationEntry defines a redelegation object with
                       relevant metadata.
@@ -43718,6 +45961,16 @@ definitions:
                         description: >-
                           shares_dst is the amount of destination-validator
                           shares created by redelegation.
+                      unbonding_id:
+                        type: string
+                        format: uint64
+                        title: Incrementing id that uniquely identifies this entry
+                      unbonding_on_hold_ref_count:
+                        type: string
+                        format: int64
+                        title: >-
+                          Strictly positive if this entry's unbonding has been
+                          stopped by external modules
                     description: >-
                       RedelegationEntry defines a redelegation object with
                       relevant metadata.
@@ -43798,6 +46051,16 @@ definitions:
                 balance:
                   type: string
                   description: balance defines the tokens to receive at completion.
+                unbonding_id:
+                  type: string
+                  format: uint64
+                  title: Incrementing id that uniquely identifies this entry
+                unbonding_on_hold_ref_count:
+                  type: string
+                  format: int64
+                  title: >-
+                    Strictly positive if this entry's unbonding has been stopped
+                    by external modules
               description: >-
                 UnbondingDelegationEntry defines an unbonding object with
                 relevant metadata.
@@ -43991,7 +46254,7 @@ definitions:
                     foo = any.unpack(Foo.class);
                   }
 
-               Example 3: Pack and unpack a message in Python.
+              Example 3: Pack and unpack a message in Python.
 
                   foo = Foo(...)
                   any = Any()
@@ -44001,13 +46264,16 @@ definitions:
                     any.Unpack(foo)
                     ...
 
-               Example 4: Pack and unpack a message in Go
+              Example 4: Pack and unpack a message in Go
 
                    foo := &pb.Foo{...}
-                   any, err := ptypes.MarshalAny(foo)
+                   any, err := anypb.New(foo)
+                   if err != nil {
+                     ...
+                   }
                    ...
                    foo := &pb.Foo{}
-                   if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                   if err := any.UnmarshalTo(foo); err != nil {
                      ...
                    }
 
@@ -44026,7 +46292,6 @@ definitions:
 
               JSON
 
-              ====
 
               The JSON representation of an `Any` value uses the regular
 
@@ -44153,6 +46418,20 @@ definitions:
 
 
               Since: cosmos-sdk 0.46
+          unbonding_on_hold_ref_count:
+            type: string
+            format: int64
+            title: >-
+              strictly positive if this validator's unbonding has been stopped
+              by external modules
+          unbonding_ids:
+            type: array
+            items:
+              type: string
+              format: uint64
+            title: >-
+              list of unbonding ids, each uniquely identifing an unbonding of
+              this validator
           self_del_address:
             type: string
             description: >-
@@ -44237,6 +46516,16 @@ definitions:
                   balance:
                     type: string
                     description: balance defines the tokens to receive at completion.
+                  unbonding_id:
+                    type: string
+                    format: uint64
+                    title: Incrementing id that uniquely identifies this entry
+                  unbonding_on_hold_ref_count:
+                    type: string
+                    format: int64
+                    title: >-
+                      Strictly positive if this entry's unbonding has been
+                      stopped by external modules
                 description: >-
                   UnbondingDelegationEntry defines an unbonding object with
                   relevant metadata.
@@ -44380,7 +46669,7 @@ definitions:
                       foo = any.unpack(Foo.class);
                     }
 
-                 Example 3: Pack and unpack a message in Python.
+                Example 3: Pack and unpack a message in Python.
 
                     foo = Foo(...)
                     any = Any()
@@ -44390,13 +46679,16 @@ definitions:
                       any.Unpack(foo)
                       ...
 
-                 Example 4: Pack and unpack a message in Go
+                Example 4: Pack and unpack a message in Go
 
                      foo := &pb.Foo{...}
-                     any, err := ptypes.MarshalAny(foo)
+                     any, err := anypb.New(foo)
+                     if err != nil {
+                       ...
+                     }
                      ...
                      foo := &pb.Foo{}
-                     if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                     if err := any.UnmarshalTo(foo); err != nil {
                        ...
                      }
 
@@ -44417,7 +46709,6 @@ definitions:
 
                 JSON
 
-                ====
 
                 The JSON representation of an `Any` value uses the regular
 
@@ -44546,6 +46837,20 @@ definitions:
 
 
                 Since: cosmos-sdk 0.46
+            unbonding_on_hold_ref_count:
+              type: string
+              format: int64
+              title: >-
+                strictly positive if this validator's unbonding has been stopped
+                by external modules
+            unbonding_ids:
+              type: array
+              items:
+                type: string
+                format: uint64
+              title: >-
+                list of unbonding ids, each uniquely identifing an unbonding of
+                this validator
             self_del_address:
               type: string
               description: >-
@@ -44654,6 +46959,16 @@ definitions:
               description: >-
                 shares_dst is the amount of destination-validator shares created
                 by redelegation.
+            unbonding_id:
+              type: string
+              format: uint64
+              title: Incrementing id that uniquely identifies this entry
+            unbonding_on_hold_ref_count:
+              type: string
+              format: int64
+              title: >-
+                Strictly positive if this entry's unbonding has been stopped by
+                external modules
           description: >-
             RedelegationEntry defines a redelegation object with relevant
             metadata.
@@ -44682,6 +46997,16 @@ definitions:
         description: >-
           shares_dst is the amount of destination-validator shares created by
           redelegation.
+      unbonding_id:
+        type: string
+        format: uint64
+        title: Incrementing id that uniquely identifies this entry
+      unbonding_on_hold_ref_count:
+        type: string
+        format: int64
+        title: >-
+          Strictly positive if this entry's unbonding has been stopped by
+          external modules
     description: RedelegationEntry defines a redelegation object with relevant metadata.
   cosmos.staking.v1beta1.RedelegationEntryResponse:
     type: object
@@ -44709,6 +47034,16 @@ definitions:
             description: >-
               shares_dst is the amount of destination-validator shares created
               by redelegation.
+          unbonding_id:
+            type: string
+            format: uint64
+            title: Incrementing id that uniquely identifies this entry
+          unbonding_on_hold_ref_count:
+            type: string
+            format: int64
+            title: >-
+              Strictly positive if this entry's unbonding has been stopped by
+              external modules
         description: >-
           RedelegationEntry defines a redelegation object with relevant
           metadata.
@@ -44767,6 +47102,16 @@ definitions:
                   description: >-
                     shares_dst is the amount of destination-validator shares
                     created by redelegation.
+                unbonding_id:
+                  type: string
+                  format: uint64
+                  title: Incrementing id that uniquely identifies this entry
+                unbonding_on_hold_ref_count:
+                  type: string
+                  format: int64
+                  title: >-
+                    Strictly positive if this entry's unbonding has been stopped
+                    by external modules
               description: >-
                 RedelegationEntry defines a redelegation object with relevant
                 metadata.
@@ -44807,6 +47152,16 @@ definitions:
                   description: >-
                     shares_dst is the amount of destination-validator shares
                     created by redelegation.
+                unbonding_id:
+                  type: string
+                  format: uint64
+                  title: Incrementing id that uniquely identifies this entry
+                unbonding_on_hold_ref_count:
+                  type: string
+                  format: int64
+                  title: >-
+                    Strictly positive if this entry's unbonding has been stopped
+                    by external modules
               description: >-
                 RedelegationEntry defines a redelegation object with relevant
                 metadata.
@@ -44857,6 +47212,16 @@ definitions:
             balance:
               type: string
               description: balance defines the tokens to receive at completion.
+            unbonding_id:
+              type: string
+              format: uint64
+              title: Incrementing id that uniquely identifies this entry
+            unbonding_on_hold_ref_count:
+              type: string
+              format: int64
+              title: >-
+                Strictly positive if this entry's unbonding has been stopped by
+                external modules
           description: >-
             UnbondingDelegationEntry defines an unbonding object with relevant
             metadata.
@@ -44883,6 +47248,16 @@ definitions:
       balance:
         type: string
         description: balance defines the tokens to receive at completion.
+      unbonding_id:
+        type: string
+        format: uint64
+        title: Incrementing id that uniquely identifies this entry
+      unbonding_on_hold_ref_count:
+        type: string
+        format: int64
+        title: >-
+          Strictly positive if this entry's unbonding has been stopped by
+          external modules
     description: >-
       UnbondingDelegationEntry defines an unbonding object with relevant
       metadata.
@@ -44987,7 +47362,7 @@ definitions:
                 foo = any.unpack(Foo.class);
               }
 
-           Example 3: Pack and unpack a message in Python.
+          Example 3: Pack and unpack a message in Python.
 
               foo = Foo(...)
               any = Any()
@@ -44997,13 +47372,16 @@ definitions:
                 any.Unpack(foo)
                 ...
 
-           Example 4: Pack and unpack a message in Go
+          Example 4: Pack and unpack a message in Go
 
                foo := &pb.Foo{...}
-               any, err := ptypes.MarshalAny(foo)
+               any, err := anypb.New(foo)
+               if err != nil {
+                 ...
+               }
                ...
                foo := &pb.Foo{}
-               if err := ptypes.UnmarshalAny(any, foo); err != nil {
+               if err := any.UnmarshalTo(foo); err != nil {
                  ...
                }
 
@@ -45021,7 +47399,6 @@ definitions:
 
           JSON
 
-          ====
 
           The JSON representation of an `Any` value uses the regular
 
@@ -45145,6 +47522,20 @@ definitions:
 
 
           Since: cosmos-sdk 0.46
+      unbonding_on_hold_ref_count:
+        type: string
+        format: int64
+        title: >-
+          strictly positive if this validator's unbonding has been stopped by
+          external modules
+      unbonding_ids:
+        type: array
+        items:
+          type: string
+          format: uint64
+        title: >-
+          list of unbonding ids, each uniquely identifing an unbonding of this
+          validator
       self_del_address:
         type: string
         description: >-
@@ -45283,10 +47674,8 @@ definitions:
                 properties:
                   key:
                     type: string
-                    format: byte
                   value:
                     type: string
-                    format: byte
                   index:
                     type: boolean
                 description: >-
@@ -45403,7 +47792,7 @@ definitions:
                   foo = any.unpack(Foo.class);
                 }
 
-             Example 3: Pack and unpack a message in Python.
+            Example 3: Pack and unpack a message in Python.
 
                 foo = Foo(...)
                 any = Any()
@@ -45413,13 +47802,16 @@ definitions:
                   any.Unpack(foo)
                   ...
 
-             Example 4: Pack and unpack a message in Go
+            Example 4: Pack and unpack a message in Go
 
                  foo := &pb.Foo{...}
-                 any, err := ptypes.MarshalAny(foo)
+                 any, err := anypb.New(foo)
+                 if err != nil {
+                   ...
+                 }
                  ...
                  foo := &pb.Foo{}
-                 if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                 if err := any.UnmarshalTo(foo); err != nil {
                    ...
                  }
 
@@ -45437,7 +47829,6 @@ definitions:
 
             JSON
 
-            ====
 
             The JSON representation of an `Any` value uses the regular
 
@@ -45670,7 +48061,7 @@ definitions:
                 foo = any.unpack(Foo.class);
               }
 
-           Example 3: Pack and unpack a message in Python.
+          Example 3: Pack and unpack a message in Python.
 
               foo = Foo(...)
               any = Any()
@@ -45680,13 +48071,16 @@ definitions:
                 any.Unpack(foo)
                 ...
 
-           Example 4: Pack and unpack a message in Go
+          Example 4: Pack and unpack a message in Go
 
                foo := &pb.Foo{...}
-               any, err := ptypes.MarshalAny(foo)
+               any, err := anypb.New(foo)
+               if err != nil {
+                 ...
+               }
                ...
                foo := &pb.Foo{}
-               if err := ptypes.UnmarshalAny(any, foo); err != nil {
+               if err := any.UnmarshalTo(foo); err != nil {
                  ...
                }
 
@@ -45704,7 +48098,6 @@ definitions:
 
           JSON
 
-          ====
 
           The JSON representation of an `Any` value uses the regular
 
@@ -45760,10 +48153,8 @@ definitions:
                 properties:
                   key:
                     type: string
-                    format: byte
                   value:
                     type: string
-                    format: byte
                   index:
                     type: boolean
                 description: >-
@@ -45836,7 +48227,9 @@ definitions:
       verified with raw bytes from Tx.
        - SIGN_MODE_TEXTUAL: SIGN_MODE_TEXTUAL is a future signing mode that will verify some
       human-readable textual representation on top of the binary representation
-      from SIGN_MODE_DIRECT. It is currently not supported.
+      from SIGN_MODE_DIRECT. It is currently experimental, and should be used
+      for testing purposes only, until Textual is fully released. Please follow
+      the tracking issue https://github.com/cosmos/cosmos-sdk/issues/11970.
        - SIGN_MODE_DIRECT_AUX: SIGN_MODE_DIRECT_AUX specifies a signing mode which uses
       SignDocDirectAux. As opposed to SIGN_MODE_DIRECT, this sign mode does not
       require signers signing over other signers' `signer_info`. It also allows
@@ -45982,17 +48375,17 @@ definitions:
       - BROADCAST_MODE_SYNC
       - BROADCAST_MODE_ASYNC
     default: BROADCAST_MODE_UNSPECIFIED
-    description: >-
+    description: |-
       BroadcastMode specifies the broadcast mode for the TxService.Broadcast RPC
       method.
 
        - BROADCAST_MODE_UNSPECIFIED: zero-value for mode ordering
-       - BROADCAST_MODE_BLOCK: BROADCAST_MODE_BLOCK defines a tx broadcasting mode where the client waits for
-      the tx to be committed in a block.
-       - BROADCAST_MODE_SYNC: BROADCAST_MODE_SYNC defines a tx broadcasting mode where the client waits for
-      a CheckTx execution response only.
-       - BROADCAST_MODE_ASYNC: BROADCAST_MODE_ASYNC defines a tx broadcasting mode where the client returns
-      immediately.
+       - BROADCAST_MODE_BLOCK: DEPRECATED: use BROADCAST_MODE_SYNC instead,
+      BROADCAST_MODE_BLOCK is not supported by the SDK from v0.47.x onwards.
+       - BROADCAST_MODE_SYNC: BROADCAST_MODE_SYNC defines a tx broadcasting mode where the client waits
+      for a CheckTx execution response only.
+       - BROADCAST_MODE_ASYNC: BROADCAST_MODE_ASYNC defines a tx broadcasting mode where the client
+      returns immediately.
   cosmos.tx.v1beta1.BroadcastTxRequest:
     type: object
     properties:
@@ -46010,15 +48403,17 @@ definitions:
         default: BROADCAST_MODE_UNSPECIFIED
         description: >-
           BroadcastMode specifies the broadcast mode for the TxService.Broadcast
-          RPC method.
+          RPC
+
+          method.
 
            - BROADCAST_MODE_UNSPECIFIED: zero-value for mode ordering
-           - BROADCAST_MODE_BLOCK: BROADCAST_MODE_BLOCK defines a tx broadcasting mode where the client waits for
-          the tx to be committed in a block.
-           - BROADCAST_MODE_SYNC: BROADCAST_MODE_SYNC defines a tx broadcasting mode where the client waits for
-          a CheckTx execution response only.
-           - BROADCAST_MODE_ASYNC: BROADCAST_MODE_ASYNC defines a tx broadcasting mode where the client returns
-          immediately.
+           - BROADCAST_MODE_BLOCK: DEPRECATED: use BROADCAST_MODE_SYNC instead,
+          BROADCAST_MODE_BLOCK is not supported by the SDK from v0.47.x onwards.
+           - BROADCAST_MODE_SYNC: BROADCAST_MODE_SYNC defines a tx broadcasting mode where the client waits
+          for a CheckTx execution response only.
+           - BROADCAST_MODE_ASYNC: BROADCAST_MODE_ASYNC defines a tx broadcasting mode where the client
+          returns immediately.
     description: |-
       BroadcastTxRequest is the request type for the Service.BroadcastTxRequest
       RPC method.
@@ -46206,7 +48601,7 @@ definitions:
                     foo = any.unpack(Foo.class);
                   }
 
-               Example 3: Pack and unpack a message in Python.
+              Example 3: Pack and unpack a message in Python.
 
                   foo = Foo(...)
                   any = Any()
@@ -46216,13 +48611,16 @@ definitions:
                     any.Unpack(foo)
                     ...
 
-               Example 4: Pack and unpack a message in Go
+              Example 4: Pack and unpack a message in Go
 
                    foo := &pb.Foo{...}
-                   any, err := ptypes.MarshalAny(foo)
+                   any, err := anypb.New(foo)
+                   if err != nil {
+                     ...
+                   }
                    ...
                    foo := &pb.Foo{}
-                   if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                   if err := any.UnmarshalTo(foo); err != nil {
                      ...
                    }
 
@@ -46241,7 +48639,6 @@ definitions:
 
               JSON
 
-              ====
 
               The JSON representation of an `Any` value uses the regular
 
@@ -46298,10 +48695,8 @@ definitions:
                     properties:
                       key:
                         type: string
-                        format: byte
                       value:
                         type: string
-                        format: byte
                       index:
                         type: boolean
                     description: >-
@@ -46494,7 +48889,7 @@ definitions:
               proposer_address:
                 type: string
                 format: byte
-            description: Header defines the structure of a Tendermint block header.
+            description: Header defines the structure of a block header.
           data:
             type: object
             properties:
@@ -46737,8 +49132,8 @@ definitions:
                                       type: string
                                       format: byte
                                   description: >-
-                                    Header defines the structure of a Tendermint
-                                    block header.
+                                    Header defines the structure of a block
+                                    header.
                                 commit:
                                   type: object
                                   properties:
@@ -46818,7 +49213,7 @@ definitions:
                                             format: byte
                                         title: >-
                                           PublicKey defines the keys available for
-                                          use with Tendermint Validators
+                                          use with Validators
                                       voting_power:
                                         type: string
                                         format: int64
@@ -46842,7 +49237,7 @@ definitions:
                                           format: byte
                                       title: >-
                                         PublicKey defines the keys available for
-                                        use with Tendermint Validators
+                                        use with Validators
                                     voting_power:
                                       type: string
                                       format: int64
@@ -46874,7 +49269,7 @@ definitions:
                                     format: byte
                                 title: >-
                                   PublicKey defines the keys available for use
-                                  with Tendermint Validators
+                                  with Validators
                               voting_power:
                                 type: string
                                 format: int64
@@ -46964,7 +49359,9 @@ definitions:
               was set, its value is undefined otherwise
     description: >-
       GetBlockWithTxsResponse is the response type for the
-      Service.GetBlockWithTxs method.
+      Service.GetBlockWithTxs
+
+      method.
 
 
       Since: cosmos-sdk 0.45.2
@@ -47155,7 +49552,7 @@ definitions:
                     foo = any.unpack(Foo.class);
                   }
 
-               Example 3: Pack and unpack a message in Python.
+              Example 3: Pack and unpack a message in Python.
 
                   foo = Foo(...)
                   any = Any()
@@ -47165,13 +49562,16 @@ definitions:
                     any.Unpack(foo)
                     ...
 
-               Example 4: Pack and unpack a message in Go
+              Example 4: Pack and unpack a message in Go
 
                    foo := &pb.Foo{...}
-                   any, err := ptypes.MarshalAny(foo)
+                   any, err := anypb.New(foo)
+                   if err != nil {
+                     ...
+                   }
                    ...
                    foo := &pb.Foo{}
-                   if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                   if err := any.UnmarshalTo(foo); err != nil {
                      ...
                    }
 
@@ -47190,7 +49590,6 @@ definitions:
 
               JSON
 
-              ====
 
               The JSON representation of an `Any` value uses the regular
 
@@ -47247,10 +49646,8 @@ definitions:
                     properties:
                       key:
                         type: string
-                        format: byte
                       value:
                         type: string
-                        format: byte
                       index:
                         type: boolean
                     description: >-
@@ -47476,7 +49873,7 @@ definitions:
                       foo = any.unpack(Foo.class);
                     }
 
-                 Example 3: Pack and unpack a message in Python.
+                Example 3: Pack and unpack a message in Python.
 
                     foo = Foo(...)
                     any = Any()
@@ -47486,13 +49883,16 @@ definitions:
                       any.Unpack(foo)
                       ...
 
-                 Example 4: Pack and unpack a message in Go
+                Example 4: Pack and unpack a message in Go
 
                      foo := &pb.Foo{...}
-                     any, err := ptypes.MarshalAny(foo)
+                     any, err := anypb.New(foo)
+                     if err != nil {
+                       ...
+                     }
                      ...
                      foo := &pb.Foo{}
-                     if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                     if err := any.UnmarshalTo(foo); err != nil {
                        ...
                      }
 
@@ -47513,7 +49913,6 @@ definitions:
 
                 JSON
 
-                ====
 
                 The JSON representation of an `Any` value uses the regular
 
@@ -47570,10 +49969,8 @@ definitions:
                       properties:
                         key:
                           type: string
-                          format: byte
                         value:
                           type: string
-                          format: byte
                         index:
                           type: boolean
                       description: >-
@@ -47679,7 +50076,14 @@ definitions:
               human-readable textual representation on top of the binary
               representation
 
-              from SIGN_MODE_DIRECT. It is currently not supported.
+              from SIGN_MODE_DIRECT. It is currently experimental, and should be
+              used
+
+              for testing purposes only, until Textual is fully released. Please
+              follow
+
+              the tracking issue
+              https://github.com/cosmos/cosmos-sdk/issues/11970.
                - SIGN_MODE_DIRECT_AUX: SIGN_MODE_DIRECT_AUX specifies a signing mode which uses
               SignDocDirectAux. As opposed to SIGN_MODE_DIRECT, this sign mode
               does not
@@ -47786,7 +50190,13 @@ definitions:
           human-readable textual representation on top of the binary
           representation
 
-          from SIGN_MODE_DIRECT. It is currently not supported.
+          from SIGN_MODE_DIRECT. It is currently experimental, and should be
+          used
+
+          for testing purposes only, until Textual is fully released. Please
+          follow
+
+          the tracking issue https://github.com/cosmos/cosmos-sdk/issues/11970.
            - SIGN_MODE_DIRECT_AUX: SIGN_MODE_DIRECT_AUX specifies a signing mode which uses
           SignDocDirectAux. As opposed to SIGN_MODE_DIRECT, this sign mode does
           not
@@ -47832,7 +50242,9 @@ definitions:
     default: ORDER_BY_UNSPECIFIED
     description: >-
       - ORDER_BY_UNSPECIFIED: ORDER_BY_UNSPECIFIED specifies an unknown sorting
-      order. OrderBy defaults to ASC in this case.
+      order. OrderBy defaults
+
+      to ASC in this case.
        - ORDER_BY_ASC: ORDER_BY_ASC defines ascending order
        - ORDER_BY_DESC: ORDER_BY_DESC defines descending order
     title: OrderBy defines the sorting order
@@ -47932,7 +50344,7 @@ definitions:
                 foo = any.unpack(Foo.class);
               }
 
-           Example 3: Pack and unpack a message in Python.
+          Example 3: Pack and unpack a message in Python.
 
               foo = Foo(...)
               any = Any()
@@ -47942,13 +50354,16 @@ definitions:
                 any.Unpack(foo)
                 ...
 
-           Example 4: Pack and unpack a message in Go
+          Example 4: Pack and unpack a message in Go
 
                foo := &pb.Foo{...}
-               any, err := ptypes.MarshalAny(foo)
+               any, err := anypb.New(foo)
+               if err != nil {
+                 ...
+               }
                ...
                foo := &pb.Foo{}
-               if err := ptypes.UnmarshalAny(any, foo); err != nil {
+               if err := any.UnmarshalTo(foo); err != nil {
                  ...
                }
 
@@ -47966,7 +50381,6 @@ definitions:
 
           JSON
 
-          ====
 
           The JSON representation of an `Any` value uses the regular
 
@@ -48091,10 +50505,8 @@ definitions:
                     properties:
                       key:
                         type: string
-                        format: byte
                       value:
                         type: string
-                        format: byte
                       index:
                         type: boolean
                     description: >-
@@ -48214,7 +50626,7 @@ definitions:
                       foo = any.unpack(Foo.class);
                     }
 
-                 Example 3: Pack and unpack a message in Python.
+                Example 3: Pack and unpack a message in Python.
 
                     foo = Foo(...)
                     any = Any()
@@ -48224,13 +50636,16 @@ definitions:
                       any.Unpack(foo)
                       ...
 
-                 Example 4: Pack and unpack a message in Go
+                Example 4: Pack and unpack a message in Go
 
                      foo := &pb.Foo{...}
-                     any, err := ptypes.MarshalAny(foo)
+                     any, err := anypb.New(foo)
+                     if err != nil {
+                       ...
+                     }
                      ...
                      foo := &pb.Foo{}
-                     if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                     if err := any.UnmarshalTo(foo); err != nil {
                        ...
                      }
 
@@ -48251,7 +50666,6 @@ definitions:
 
                 JSON
 
-                ====
 
                 The JSON representation of an `Any` value uses the regular
 
@@ -48426,7 +50840,7 @@ definitions:
                       foo = any.unpack(Foo.class);
                     }
 
-                 Example 3: Pack and unpack a message in Python.
+                Example 3: Pack and unpack a message in Python.
 
                     foo = Foo(...)
                     any = Any()
@@ -48436,13 +50850,16 @@ definitions:
                       any.Unpack(foo)
                       ...
 
-                 Example 4: Pack and unpack a message in Go
+                Example 4: Pack and unpack a message in Go
 
                      foo := &pb.Foo{...}
-                     any, err := ptypes.MarshalAny(foo)
+                     any, err := anypb.New(foo)
+                     if err != nil {
+                       ...
+                     }
                      ...
                      foo := &pb.Foo{}
-                     if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                     if err := any.UnmarshalTo(foo); err != nil {
                        ...
                      }
 
@@ -48463,7 +50880,6 @@ definitions:
 
                 JSON
 
-                ====
 
                 The JSON representation of an `Any` value uses the regular
 
@@ -48632,7 +51048,7 @@ definitions:
                       foo = any.unpack(Foo.class);
                     }
 
-                 Example 3: Pack and unpack a message in Python.
+                Example 3: Pack and unpack a message in Python.
 
                     foo = Foo(...)
                     any = Any()
@@ -48642,13 +51058,16 @@ definitions:
                       any.Unpack(foo)
                       ...
 
-                 Example 4: Pack and unpack a message in Go
+                Example 4: Pack and unpack a message in Go
 
                      foo := &pb.Foo{...}
-                     any, err := ptypes.MarshalAny(foo)
+                     any, err := anypb.New(foo)
+                     if err != nil {
+                       ...
+                     }
                      ...
                      foo := &pb.Foo{}
-                     if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                     if err := any.UnmarshalTo(foo); err != nil {
                        ...
                      }
 
@@ -48669,7 +51088,6 @@ definitions:
 
                 JSON
 
-                ====
 
                 The JSON representation of an `Any` value uses the regular
 
@@ -48811,7 +51229,7 @@ definitions:
                       foo = any.unpack(Foo.class);
                     }
 
-                 Example 3: Pack and unpack a message in Python.
+                Example 3: Pack and unpack a message in Python.
 
                     foo = Foo(...)
                     any = Any()
@@ -48821,13 +51239,16 @@ definitions:
                       any.Unpack(foo)
                       ...
 
-                 Example 4: Pack and unpack a message in Go
+                Example 4: Pack and unpack a message in Go
 
                      foo := &pb.Foo{...}
-                     any, err := ptypes.MarshalAny(foo)
+                     any, err := anypb.New(foo)
+                     if err != nil {
+                       ...
+                     }
                      ...
                      foo := &pb.Foo{}
-                     if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                     if err := any.UnmarshalTo(foo); err != nil {
                        ...
                      }
 
@@ -48848,7 +51269,6 @@ definitions:
 
                 JSON
 
-                ====
 
                 The JSON representation of an `Any` value uses the regular
 
@@ -49010,7 +51430,7 @@ definitions:
                   foo = any.unpack(Foo.class);
                 }
 
-             Example 3: Pack and unpack a message in Python.
+            Example 3: Pack and unpack a message in Python.
 
                 foo = Foo(...)
                 any = Any()
@@ -49020,13 +51440,16 @@ definitions:
                   any.Unpack(foo)
                   ...
 
-             Example 4: Pack and unpack a message in Go
+            Example 4: Pack and unpack a message in Go
 
                  foo := &pb.Foo{...}
-                 any, err := ptypes.MarshalAny(foo)
+                 any, err := anypb.New(foo)
+                 if err != nil {
+                   ...
+                 }
                  ...
                  foo := &pb.Foo{}
-                 if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                 if err := any.UnmarshalTo(foo); err != nil {
                    ...
                  }
 
@@ -49044,7 +51467,6 @@ definitions:
 
             JSON
 
-            ====
 
             The JSON representation of an `Any` value uses the regular
 
@@ -49206,7 +51628,7 @@ definitions:
                   foo = any.unpack(Foo.class);
                 }
 
-             Example 3: Pack and unpack a message in Python.
+            Example 3: Pack and unpack a message in Python.
 
                 foo = Foo(...)
                 any = Any()
@@ -49216,13 +51638,16 @@ definitions:
                   any.Unpack(foo)
                   ...
 
-             Example 4: Pack and unpack a message in Go
+            Example 4: Pack and unpack a message in Go
 
                  foo := &pb.Foo{...}
-                 any, err := ptypes.MarshalAny(foo)
+                 any, err := anypb.New(foo)
+                 if err != nil {
+                   ...
+                 }
                  ...
                  foo := &pb.Foo{}
-                 if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                 if err := any.UnmarshalTo(foo); err != nil {
                    ...
                  }
 
@@ -49240,7 +51665,6 @@ definitions:
 
             JSON
 
-            ====
 
             The JSON representation of an `Any` value uses the regular
 
@@ -49377,7 +51801,7 @@ definitions:
                   foo = any.unpack(Foo.class);
                 }
 
-             Example 3: Pack and unpack a message in Python.
+            Example 3: Pack and unpack a message in Python.
 
                 foo = Foo(...)
                 any = Any()
@@ -49387,13 +51811,16 @@ definitions:
                   any.Unpack(foo)
                   ...
 
-             Example 4: Pack and unpack a message in Go
+            Example 4: Pack and unpack a message in Go
 
                  foo := &pb.Foo{...}
-                 any, err := ptypes.MarshalAny(foo)
+                 any, err := anypb.New(foo)
+                 if err != nil {
+                   ...
+                 }
                  ...
                  foo := &pb.Foo{}
-                 if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                 if err := any.UnmarshalTo(foo); err != nil {
                    ...
                  }
 
@@ -49411,7 +51838,6 @@ definitions:
 
             JSON
 
-            ====
 
             The JSON representation of an `Any` value uses the regular
 
@@ -49451,6 +51877,94 @@ definitions:
 
           and can't be handled, they will be ignored
     description: TxBody is the body of a transaction that all signers sign over.
+  cosmos.tx.v1beta1.TxDecodeAminoRequest:
+    type: object
+    properties:
+      amino_binary:
+        type: string
+        format: byte
+    description: |-
+      TxDecodeAminoRequest is the request type for the Service.TxDecodeAmino
+      RPC method.
+
+      Since: cosmos-sdk 0.47
+  cosmos.tx.v1beta1.TxDecodeAminoResponse:
+    type: object
+    properties:
+      amino_json:
+        type: string
+    description: |-
+      TxDecodeAminoResponse is the response type for the Service.TxDecodeAmino
+      RPC method.
+
+      Since: cosmos-sdk 0.47
+  cosmos.tx.v1beta1.TxDecodeRequest:
+    type: object
+    properties:
+      tx_bytes:
+        type: string
+        format: byte
+        description: tx_bytes is the raw transaction.
+    description: |-
+      TxDecodeRequest is the request type for the Service.TxDecode
+      RPC method.
+
+      Since: cosmos-sdk 0.47
+  cosmos.tx.v1beta1.TxDecodeResponse:
+    type: object
+    properties:
+      tx:
+        $ref: '#/definitions/cosmos.tx.v1beta1.Tx'
+        description: tx is the decoded transaction.
+    description: |-
+      TxDecodeResponse is the response type for the
+      Service.TxDecode method.
+
+      Since: cosmos-sdk 0.47
+  cosmos.tx.v1beta1.TxEncodeAminoRequest:
+    type: object
+    properties:
+      amino_json:
+        type: string
+    description: |-
+      TxEncodeAminoRequest is the request type for the Service.TxEncodeAmino
+      RPC method.
+
+      Since: cosmos-sdk 0.47
+  cosmos.tx.v1beta1.TxEncodeAminoResponse:
+    type: object
+    properties:
+      amino_binary:
+        type: string
+        format: byte
+    description: |-
+      TxEncodeAminoResponse is the response type for the Service.TxEncodeAmino
+      RPC method.
+
+      Since: cosmos-sdk 0.47
+  cosmos.tx.v1beta1.TxEncodeRequest:
+    type: object
+    properties:
+      tx:
+        $ref: '#/definitions/cosmos.tx.v1beta1.Tx'
+        description: tx is the transaction to encode.
+    description: |-
+      TxEncodeRequest is the request type for the Service.TxEncode
+      RPC method.
+
+      Since: cosmos-sdk 0.47
+  cosmos.tx.v1beta1.TxEncodeResponse:
+    type: object
+    properties:
+      tx_bytes:
+        type: string
+        format: byte
+        description: tx_bytes is the encoded transaction bytes.
+    description: |-
+      TxEncodeResponse is the response type for the
+      Service.TxEncode method.
+
+      Since: cosmos-sdk 0.47
   tendermint.abci.Event:
     type: object
     properties:
@@ -49463,10 +51977,8 @@ definitions:
           properties:
             key:
               type: string
-              format: byte
             value:
               type: string
-              format: byte
             index:
               type: boolean
           description: EventAttribute is a single key-value pair, associated with an event.
@@ -49482,10 +51994,8 @@ definitions:
     properties:
       key:
         type: string
-        format: byte
       value:
         type: string
-        format: byte
       index:
         type: boolean
     description: EventAttribute is a single key-value pair, associated with an event.

--- a/types/openapiutil/apiconsole.go
+++ b/types/openapiutil/apiconsole.go
@@ -14,7 +14,7 @@ func Handler(title, specURL string) http.HandlerFunc {
 	t, _ := template.ParseFS(index, "index.tpl")
 
 	return func(w http.ResponseWriter, req *http.Request) {
-		t.Execute(w, struct {
+		_ = t.Execute(w, struct {
 			Title string
 			URL   string
 		}{

--- a/types/openapiutil/apiconsole.go
+++ b/types/openapiutil/apiconsole.go
@@ -1,0 +1,25 @@
+package openapiutil
+
+import (
+	"embed"
+	"html/template"
+	"net/http"
+)
+
+//go:embed index.tpl
+var index embed.FS
+
+// Handler returns a http handler that servers OpenAPI console for an OpenAPI spec at specURL.
+func Handler(title, specURL string) http.HandlerFunc {
+	t, _ := template.ParseFS(index, "index.tpl")
+
+	return func(w http.ResponseWriter, req *http.Request) {
+		t.Execute(w, struct {
+			Title string
+			URL   string
+		}{
+			title,
+			specURL,
+		})
+	}
+}

--- a/types/openapiutil/index.tpl
+++ b/types/openapiutil/index.tpl
@@ -1,6 +1,3 @@
-
-
-
 <!DOCTYPE html>
 <html lang="en">
     <head>

--- a/types/openapiutil/index.tpl
+++ b/types/openapiutil/index.tpl
@@ -1,0 +1,28 @@
+
+
+
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>{{ .Title }}</title>
+        <link rel="stylesheet" type="text/css" href="//unpkg.com/swagger-ui-dist@3.40.0/swagger-ui.css" />
+        <link rel="icon" type="image/png" href="//unpkg.com/swagger-ui-dist@3.40.0/favicon-16x16.png" />
+    </head>
+    <body>
+        <div id="swagger-ui"></div>
+
+        <script src="//unpkg.com/swagger-ui-dist@3.40.0/swagger-ui-bundle.js"></script>
+        <script>
+            // init Swagger for faucet's openapi.yml.
+            window.onload = function() {
+              window.ui = SwaggerUIBundle({
+                url: {{ .URL }},
+                dom_id: "#swagger-ui",
+                deepLinking: true,
+                layout: "BaseLayout",
+              });
+            }
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
### Description

This pr brings back the swagger server which is deleted by removing the dependency of ignite and updates the swagger.yaml file.

### Rationale

Bring back the swagger server.

### Example

n/a

### Changes

Notable changes: 
* bring back the swagger server
* updates the swagger.yaml file
