### PR TITLE
fix: null pointer access after sp not found

### DIFF
--- a/x/storage/keeper/keeper.go
+++ b/x/storage/keeper/keeper.go
@@ -318,7 +318,7 @@ func (k Keeper) UpdateBucketInfo(ctx sdk.Context, operator sdk.AccAddress, bucke
 func (k Keeper) DiscontinueBucket(ctx sdk.Context, operator sdk.AccAddress, bucketName, reason string) error {
 	sp, found := k.spKeeper.GetStorageProviderByGcAddr(ctx, operator)
 	if !found {
-		return types.ErrNoSuchStorageProvider
+		return types.ErrNoSuchStorageProvider.Wrapf("SP operator address: %s", operator.String())
 	}
 	if sp.Status != sptypes.STATUS_IN_SERVICE {
 		return sptypes.ErrStorageProviderNotInService
@@ -581,7 +581,7 @@ func (k Keeper) SealObject(
 
 	sp, found := k.spKeeper.GetStorageProviderBySealAddr(ctx, spSealAcc)
 	if !found {
-		return errors.Wrapf(types.ErrNoSuchStorageProvider, "sealAddr: %s, status: %s", spSealAcc.String(), sp.Status.String())
+		return errors.Wrapf(types.ErrNoSuchStorageProvider, "SP seal address: %s", spSealAcc.String())
 	}
 
 	if !sdk.MustAccAddressFromHex(sp.OperatorAddress).Equals(sdk.MustAccAddressFromHex(bucketInfo.PrimarySpAddress)) {
@@ -913,13 +913,13 @@ func (k Keeper) RejectSealObject(ctx sdk.Context, operator sdk.AccAddress, bucke
 
 	sp, found := k.spKeeper.GetStorageProviderBySealAddr(ctx, operator)
 	if found {
-		return errors.Wrapf(types.ErrNoSuchStorageProvider, "sealAddr: %s, status: %s", operator.String(), sp.Status.String())
+		return errors.Wrapf(types.ErrNoSuchStorageProvider, "SP seal address: %s", operator.String())
 	}
 	if sp.Status != sptypes.STATUS_IN_SERVICE {
 		return sptypes.ErrStorageProviderNotInService
 	}
 	if !sdk.MustAccAddressFromHex(sp.OperatorAddress).Equals(sdk.MustAccAddressFromHex(bucketInfo.PrimarySpAddress)) {
-		return errors.Wrapf(types.ErrAccessDenied, "Only allowed primary sp to do cancel create object")
+		return errors.Wrapf(types.ErrAccessDenied, "Only allowed primary SP to do cancel create object")
 	}
 
 	err := k.UnlockStoreFee(ctx, bucketInfo, objectInfo)
@@ -948,7 +948,7 @@ func (k Keeper) RejectSealObject(ctx sdk.Context, operator sdk.AccAddress, bucke
 func (k Keeper) DiscontinueObject(ctx sdk.Context, operator sdk.AccAddress, bucketName string, objectIds []sdkmath.Uint, reason string) error {
 	sp, found := k.spKeeper.GetStorageProviderByGcAddr(ctx, operator)
 	if !found {
-		return types.ErrNoSuchStorageProvider
+		return types.ErrNoSuchStorageProvider.Wrapf("SP operator address: %s", operator.String())
 	}
 	if sp.Status != sptypes.STATUS_IN_SERVICE {
 		return sptypes.ErrStorageProviderNotInService
@@ -1239,7 +1239,7 @@ func (k Keeper) UpdateGroupMember(ctx sdk.Context, operator sdk.AccAddress, grou
 func (k Keeper) VerifySPAndSignature(ctx sdk.Context, spAcc sdk.AccAddress, sigData []byte, signature []byte) error {
 	sp, found := k.spKeeper.GetStorageProvider(ctx, spAcc)
 	if !found {
-		return errors.Wrapf(types.ErrNoSuchStorageProvider, "spAddr: %s, status: %s", sp.OperatorAddress, sp.Status.String())
+		return errors.Wrapf(types.ErrNoSuchStorageProvider, "SP operator address: %s", spAcc.String())
 	}
 	if sp.Status != sptypes.STATUS_IN_SERVICE {
 		return sptypes.ErrStorageProviderNotInService


### PR DESCRIPTION
### Description

The returned error message encountered a null pointer access, which caused a panic.

### Rationale

panic error

### Example

NA

### Changes

Notable changes: 
* NA
