### PR TITLE
fix: fix challenge random issue

### DIFF
--- a/x/challenge/abci.go
+++ b/x/challenge/abci.go
@@ -75,7 +75,7 @@ func EndBlocker(ctx sdk.Context, keeper k.Keeper) {
 			}
 			spOperatorAddress = bucket.PrimarySpAddress
 		} else {
-			spOperatorAddress = objectInfo.SecondarySpAddresses[redundancyIndex]
+			spOperatorAddress = secondarySpAddresses[redundancyIndex]
 		}
 
 		spOperatorAddr, err := sdk.AccAddressFromHexUnsafe(spOperatorAddress)

--- a/x/challenge/keeper/helper.go
+++ b/x/challenge/keeper/helper.go
@@ -20,8 +20,7 @@ func SeedFromRandaoMix(randaoMix []byte, number uint64) []byte {
 	lowBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(lowBytes, number)
 
-	seedBytes := make([]byte, RandaoMixLength)
-
+	seedBytes := make([]byte, 0)
 	seedBytes = append(seedBytes, sdk.Keccak256(highBytes)...)
 	seedBytes = append(seedBytes, sdk.Keccak256(lowBytes)...)
 
@@ -54,7 +53,7 @@ func CalculateSegments(payloadSize, segmentSize uint64) uint64 {
 
 // RandomSegmentIndex generates a random segment index for challenge.
 func RandomSegmentIndex(seed []byte, segments uint64) uint32 {
-	number := new(big.Int).SetBytes(sdk.Keccak256(seed)[:32])
+	number := new(big.Int).SetBytes(sdk.Keccak256(seed[:32]))
 	number = new(big.Int).Abs(number)
 	index := new(big.Int).Mod(number, big.NewInt(int64(segments)))
 	return uint32(index.Uint64())
@@ -63,7 +62,7 @@ func RandomSegmentIndex(seed []byte, segments uint64) uint32 {
 // RandomRedundancyIndex generates a random redundancy index (storage provider) for challenge.
 // Be noted: RedundancyIndex starts from -1 (the primary sp).
 func RandomRedundancyIndex(seed []byte, sps uint64) int32 {
-	number := new(big.Int).SetBytes(sdk.Keccak256(seed)[32:])
+	number := new(big.Int).SetBytes(sdk.Keccak256(seed[32:]))
 	number = new(big.Int).Abs(number)
 	index := new(big.Int).Mod(number, big.NewInt(int64(sps)))
 	return int32(index.Uint64()) - 1

--- a/x/challenge/keeper/msg_server_test.go
+++ b/x/challenge/keeper/msg_server_test.go
@@ -40,6 +40,18 @@ func (s *TestSuite) SetupTest() {
 	encCfg := moduletestutil.MakeTestEncodingConfig(challenge.AppModuleBasic{})
 	key := storetypes.NewKVStoreKey(types.StoreKey)
 	testCtx := testutil.DefaultContextWithDB(s.T(), key, storetypes.NewTransientStoreKey("transient_test"))
+
+	// set mock randao mix
+	randaoMix := sdk.Keccak256([]byte{1})
+	randaoMix = append(randaoMix, sdk.Keccak256([]byte{2})...)
+	header := testCtx.Ctx.BlockHeader()
+	header.RandaoMix = randaoMix
+	testCtx = testutil.TestContext{
+		Ctx: sdk.NewContext(testCtx.CMS, header, false, nil, testCtx.Ctx.Logger()),
+		DB:  testCtx.DB,
+		CMS: testCtx.CMS,
+	}
+
 	s.ctx = testCtx.Ctx
 
 	ctrl := gomock.NewController(s.T())


### PR DESCRIPTION
### Description

This pr fixes a bug in challenge module.

The code 
```
number := new(big.Int).SetBytes(sdk.Keccak256(seed)[32:])
```
should be
```
number := new(big.Int).SetBytes(sdk.Keccak256(seed[32:]))
```

Otherwise, `number` will always be zero.

### Rationale

Bug fix

### Example

NA

### Changes

Notable changes: 
* NA
