### PR TITLE
release: draft release v0.2.0  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This release updates the greenfield-cosmos-sdk dependency. Please refer to the [
 * [#235](https://github.com/bnb-chain/greenfield/pull/235) feat: update dependency for the cosmos-sdk
 * [#236](https://github.com/bnb-chain/greenfield/pull/236) fix: update swagger file based on the latest cosmos-sdk
 * [#237](https://github.com/bnb-chain/greenfield/pull/237) swagger: replace gov v1beta1 by v1
+* [#242](https://github.com/bnb-chain/greenfield/pull/242) fix: replace github.com/gogo/protobuf with github.com/cosmos/gogoproto 
 
 ## v0.1.0
 * [\#141](https://github.com/bnb-chain/greenfield/pull/141) fix wrong comments for events.proto in storage (created_at field shows block timestamp instead of block number)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This release updates the greenfield-cosmos-sdk dependency. Please refer to the [
 * [#200](https://github.com/bnb-chain/greenfield/pull/200) feat: migrate challenge e2e tests
 * [#203](https://github.com/bnb-chain/greenfield/pull/203) chore: fix ante test
 * [#205](https://github.com/bnb-chain/greenfield/pull/205) ci: run ci jobs for every pull request
-* [#206](https://github.com/bnb-chain/greenfield/pull/206) fix init
+* [#206](https://github.com/bnb-chain/greenfield/pull/206) fix: migrate sdk fix to v0.47_latest
 * [#207](https://github.com/bnb-chain/greenfield/pull/207) fix: init app with upgrade handlers
 * [#208](https://github.com/bnb-chain/greenfield/pull/208) docs: fix localup scripts in document
 * [#210](https://github.com/bnb-chain/greenfield/pull/210) feat: remove amino dependencies for GetSignBytes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,39 @@
 # Changelog
 ## v0.2.0
-This release updates the greenfield-cosmos-sdk dependency. As the cosmos-sdk v0.47.2 is a huge breaking upgrade,
-we decide to cherry-pick the recent contributed commits and apply to the v0.47.2. The commit history previous
-releases are archived and the branch is backed up in the `master_back` branch on the [greenfield-cosmos-sdk repository](https://github.com/bnb-chain/greenfield-cosmos-sdk/).
-
-Notable breaking changes:
-1. The previous keyring is replaced by the new keyring. Please regenerate them, otherwise you will get error.
-
-Other notable changes, please refer to the [changelogs of cosmos-sdk v0.47.1](https://github.com/cosmos/cosmos-sdk/blob/v0.47.1/CHANGELOG.md)
-and [changelogs of cosmos-sdk v0.47.2](https://github.com/cosmos/cosmos-sdk/blob/v0.47.2/CHANGELOG.md).
-
+This release updates the greenfield-cosmos-sdk dependency. Please refer to the [greenfield-cosmos-sdk repository](https://github.com/bnb-chain/greenfield-cosmos-sdk/) for the update details.
+* [#188](https://github.com/bnb-chain/greenfield/pull/188) feat: integrate greenfield with cosmos sdk v0.47
+* [#190](https://github.com/bnb-chain/greenfield/pull/190) feat: add more fields to sp events
+* [#191](https://github.com/bnb-chain/greenfield/pull/191) feat: define the turn for submitting attestation
+* [#197](https://github.com/bnb-chain/greenfield/pull/197) fix: fix e2e issues due to km refactor
+* [#199](https://github.com/bnb-chain/greenfield/pull/199) feat: migrate challenge module to cosmos sdk v0.47
+* [#194](https://github.com/bnb-chain/greenfield/pull/194) feat: fix the issues of commands
+* [#200](https://github.com/bnb-chain/greenfield/pull/200) feat: migrate challenge e2e tests
+* [#203](https://github.com/bnb-chain/greenfield/pull/203) chore: fix ante test
+* [#205](https://github.com/bnb-chain/greenfield/pull/205) ci: run ci jobs for every pull request
+* [#206](https://github.com/bnb-chain/greenfield/pull/206) fix init
+* [#207](https://github.com/bnb-chain/greenfield/pull/207) fix: init app with upgrade handlers
+* [#208](https://github.com/bnb-chain/greenfield/pull/208) docs: fix localup scripts in document
+* [#210](https://github.com/bnb-chain/greenfield/pull/210) feat: remove amino dependencies for GetSignBytes
+* [#212](https://github.com/bnb-chain/greenfield/pull/212) feat: add export key for localup script
+* [#196](https://github.com/bnb-chain/greenfield/pull/196) feat: modify sp module & storage module & permission module to adapt cosmos sdk v0.47
+* [#214](https://github.com/bnb-chain/greenfield/pull/214) fix: fix e2e test for gashub
+* [#216](https://github.com/bnb-chain/greenfield/pull/216) feat: payment adapt to cosmos-sdk v0.47
+* [#215](https://github.com/bnb-chain/greenfield/pull/215) feat: add update-object-info for updateobject's visibility (cherry pick #138)
+* [#220](https://github.com/bnb-chain/greenfield/pull/220) feat: support empty operator for verifypermission
+* [#219](https://github.com/bnb-chain/greenfield/pull/219) fix: sp & storage & permission module's cli bug
+* [#217](https://github.com/bnb-chain/greenfield/pull/217) feat: remove dependency for params module
+* [#221](https://github.com/bnb-chain/greenfield/pull/221) fix: bring back the swagger server
+* [#225](https://github.com/bnb-chain/greenfield/pull/225) fix: fix the banner issue and sync a tiny pr
+* [#224](https://github.com/bnb-chain/greenfield/pull/224) feat: add support for EVM json-rpc request
+* [#226](https://github.com/bnb-chain/greenfield/pull/222) fix nil pointer panic
+* [#231](https://github.com/bnb-chain/greenfield/pull/231) Merge pull request
+* [#232](https://github.com/bnb-chain/greenfield/pull/232) fix: fix challenge random issue
+* [#218](https://github.com/bnb-chain/greenfield/pull/218) feat: support multi version params for storage module
+* [#234](https://github.com/bnb-chain/greenfield/pull/234) fix: sp staking ledger error when slash
+* [#223](https://github.com/bnb-chain/greenfield/pull/223) feat: enable stale permission GC
+* [#235](https://github.com/bnb-chain/greenfield/pull/235) feat: update dependency for the cosmos-sdk
+* [#236](https://github.com/bnb-chain/greenfield/pull/236) fix: update swagger file based on the latest cosmos-sdk
+* [#237](https://github.com/bnb-chain/greenfield/pull/237) swagger: replace gov v1beta1 by v1
 
 ## v0.1.0
 * [\#141](https://github.com/bnb-chain/greenfield/pull/141) fix wrong comments for events.proto in storage (created_at field shows block timestamp instead of block number)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
 # Changelog
+## v0.2.0
+This release updates the greenfield-cosmos-sdk dependency. As the cosmos-sdk v0.47.2 is a huge breaking upgrade,
+we decide to cherry-pick the recent contributed commits and apply to the v0.47.2. The commit history previous
+releases are archived and the branch is backed up in the `master_back` branch on the [greenfield-cosmos-sdk repository](https://github.com/bnb-chain/greenfield-cosmos-sdk/).
+
+Notable breaking changes:
+1. The previous keyring is replaced by the new keyring. Please regenerate them, otherwise you will get error.
+
+Other notable changes, please refer to the [changelogs of cosmos-sdk v0.47.1](https://github.com/cosmos/cosmos-sdk/blob/v0.47.1/CHANGELOG.md)
+and [changelogs of cosmos-sdk v0.47.2](https://github.com/cosmos/cosmos-sdk/blob/v0.47.2/CHANGELOG.md).
+
 
 ## v0.1.0
 * [\#141](https://github.com/bnb-chain/greenfield/pull/141) fix wrong comments for events.proto in storage (created_at field shows block timestamp instead of block number)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ This release updates the greenfield-cosmos-sdk dependency. Please refer to the [
 * [#225](https://github.com/bnb-chain/greenfield/pull/225) fix: fix the banner issue and sync a tiny pr
 * [#224](https://github.com/bnb-chain/greenfield/pull/224) feat: add support for EVM json-rpc request
 * [#226](https://github.com/bnb-chain/greenfield/pull/222) fix nil pointer panic
-* [#231](https://github.com/bnb-chain/greenfield/pull/231) Merge pull request
+* [#231](https://github.com/bnb-chain/greenfield/pull/231) feat: update cosmos sdk to v0.47.2  
 * [#232](https://github.com/bnb-chain/greenfield/pull/232) fix: fix challenge random issue
 * [#218](https://github.com/bnb-chain/greenfield/pull/218) feat: support multi version params for storage module
 * [#234](https://github.com/bnb-chain/greenfield/pull/234) fix: sp staking ledger error when slash

--- a/go.mod
+++ b/go.mod
@@ -176,6 +176,6 @@ replace (
 	github.com/btcsuite/btcd => github.com/btcsuite/btcd v0.23.0
 	github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v0.0.1
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v0.0.0-20230510062421-dc73c33bf3c7
+	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v0.2.0
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 )

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edY
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
 github.com/bnb-chain/greenfield-cometbft v0.0.1 h1:pX8S9oZKjWJCrxH07l6rbU3zee9txZ11+UwO9stsNMQ=
 github.com/bnb-chain/greenfield-cometbft v0.0.1/go.mod h1:9q11eHNRY9FDwFH+4pompzPNGv//Z3VcfvkELaHJPMs=
-github.com/bnb-chain/greenfield-cosmos-sdk v0.0.0-20230510062421-dc73c33bf3c7 h1:eBB+raLle+aDStFatjY15dglg0upmBpNEexRBKu4fng=
-github.com/bnb-chain/greenfield-cosmos-sdk v0.0.0-20230510062421-dc73c33bf3c7/go.mod h1:6pVENKv7drpk0k46nuyvAeD1SMnQUuXD9WY0tyc060A=
+github.com/bnb-chain/greenfield-cosmos-sdk v0.2.0 h1:HOxV6Tgi/pdSRfhcyWa/y55H6SV0+UuTauqtO+bBcSw=
+github.com/bnb-chain/greenfield-cosmos-sdk v0.2.0/go.mod h1:6pVENKv7drpk0k46nuyvAeD1SMnQUuXD9WY0tyc060A=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230425074444-eb5869b05fe9 h1:6fLpmmI0EZvDTfPvI0zy5dBaaTUboHnEkoC5/p/w8TQ=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230425074444-eb5869b05fe9/go.mod h1:rbc4o84RSEvhf09o2+4Qiazsv0snRJLiEZdk17HeIDw=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230425074444-eb5869b05fe9 h1:1ZdK+iR1Up02bOa2YTZCml7PBpP//kcdamOcK6aWO/s=


### PR DESCRIPTION
### Description

This release updates the greenfield-cosmos-sdk dependency. Please refer to the [greenfield-cosmos-sdk repository](https://github.com/bnb-chain/greenfield-cosmos-sdk/) for the update details.  

### Rationale
Change log:  
* [#188](https://github.com/bnb-chain/greenfield/pull/188) feat: integrate greenfield with cosmos sdk v0.47 
* [#190](https://github.com/bnb-chain/greenfield/pull/190) feat: add more fields to sp events 
* [#191](https://github.com/bnb-chain/greenfield/pull/191) feat: define the turn for submitting attestation 
* [#197](https://github.com/bnb-chain/greenfield/pull/197) fix: fix e2e issues due to km refactor 
* [#199](https://github.com/bnb-chain/greenfield/pull/199) feat: migrate challenge module to cosmos sdk v0.47 
* [#194](https://github.com/bnb-chain/greenfield/pull/194) feat: fix the issues of commands 
* [#200](https://github.com/bnb-chain/greenfield/pull/200) feat: migrate challenge e2e tests 
* [#203](https://github.com/bnb-chain/greenfield/pull/203) chore: fix ante test 
* [#205](https://github.com/bnb-chain/greenfield/pull/205) ci: run ci jobs for every pull request 
* [#206](https://github.com/bnb-chain/greenfield/pull/206) fix: migrate sdk fix to v0.47_latest  
* [#207](https://github.com/bnb-chain/greenfield/pull/207) fix: init app with upgrade handlers 
* [#208](https://github.com/bnb-chain/greenfield/pull/208) docs: fix localup scripts in document 
* [#210](https://github.com/bnb-chain/greenfield/pull/210) feat: remove amino dependencies for GetSignBytes 
* [#212](https://github.com/bnb-chain/greenfield/pull/212) feat: add export key for localup script 
* [#196](https://github.com/bnb-chain/greenfield/pull/196) feat: modify sp module & storage module & permission module to adapt cosmos sdk v0.47
* [#214](https://github.com/bnb-chain/greenfield/pull/214) fix: fix e2e test for gashub 
* [#216](https://github.com/bnb-chain/greenfield/pull/216) feat: payment adapt to cosmos-sdk v0.47 
* [#215](https://github.com/bnb-chain/greenfield/pull/215) feat: add update-object-info for updateobject's visibility (cherry pick #138)
* [#220](https://github.com/bnb-chain/greenfield/pull/220) feat: support empty operator for verifypermission 
* [#219](https://github.com/bnb-chain/greenfield/pull/219) fix: sp & storage & permission module's cli bug 
* [#217](https://github.com/bnb-chain/greenfield/pull/217) feat: remove dependency for params module 
* [#221](https://github.com/bnb-chain/greenfield/pull/221) fix: bring back the swagger server 
* [#225](https://github.com/bnb-chain/greenfield/pull/225) fix: fix the banner issue and sync a tiny pr 
* [#224](https://github.com/bnb-chain/greenfield/pull/224) feat: add support for EVM json-rpc request 
* [#226](https://github.com/bnb-chain/greenfield/pull/222) fix nil pointer panic 
* [#231](https://github.com/bnb-chain/greenfield/pull/231) Merge pull request
* [#232](https://github.com/bnb-chain/greenfield/pull/232) fix: fix challenge random issue 
* [#218](https://github.com/bnb-chain/greenfield/pull/218) feat: support multi version params for storage module 
* [#234](https://github.com/bnb-chain/greenfield/pull/234) fix: sp staking ledger error when slash 
* [#223](https://github.com/bnb-chain/greenfield/pull/223) feat: enable stale permission GC 
* [#235](https://github.com/bnb-chain/greenfield/pull/235) feat: update dependency for the cosmos-sdk 
* [#236](https://github.com/bnb-chain/greenfield/pull/236) fix: update swagger file based on the latest cosmos-sdk 
* [#237](https://github.com/bnb-chain/greenfield/pull/237) swagger: replace gov v1beta1 by v1 

### Example

Please refer to detailed PRs

### Changes

Notable changes: 
* There are no notable changes  
