### PR TITLE
docs: update testnet genesis to v0.1.2

### DIFF
--- a/asset/configs/testnet_config/config.toml
+++ b/asset/configs/testnet_config/config.toml
@@ -340,8 +340,8 @@ enable = true
 # For Cosmos SDK-based chains, trust_period should usually be about 2/3 of the unbonding time (~2
 # weeks) during which they can be financially punished (slashed) for misbehavior.
 rpc_servers = "https://gnfd-testnet-fullnode-tendermint-us.bnbchain.org:443,http://k8s-gnfdfull-gnfdfull-514c3179cd-d1c316adcbfbfd3c.elb.us-east-1.amazonaws.com:26657"
-trust_height = 300000
-trust_hash = "CAD3B7C4CDF76F963777C413EDBD65C6262B61CEDE5A64A983F08F1A720B0EB5"
+trust_height = 4000
+trust_hash = "7324698910D156A5C34CE358E475D412678F07CD8FB410D5032BE800E25BCEBF"
 trust_period = "2542085h0m0s"
 
 # Time to spend discovering snapshots before initiating a restore.

--- a/asset/configs/testnet_config/genesis.json
+++ b/asset/configs/testnet_config/genesis.json
@@ -1,5 +1,5 @@
 {
-  "genesis_time": "2023-03-16T10:23:16.05979Z",
+  "genesis_time": "2023-05-12T04:21:05.922812Z",
   "chain_id": "greenfield_5600-1",
   "initial_height": "1",
   "consensus_params": {
@@ -69,6 +69,34 @@
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "0x3b0CD23973F80A28e8847446C9b6550ab9D2c59e",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "0xddB077aD6963144B6B9aFA3A7eE6067bf00a6E68",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "0xE19C96249c33Da0362C327D79F9c8Fe0191bE001",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "0x295f6d11143DD5A0b69546015aFdc4D92c733f9B",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
           "address": "0xd3d8b58Fa0fb703bc3872F18CbEfC27260243198",
           "pub_key": null,
           "account_number": "0",
@@ -98,6 +126,34 @@
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
           "address": "0xc9c16BFF2A82282818fAe17E9722A3aD1E702eb7",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "0xc3884799494c0ca5acB4b8CB9030A4aCa31B878F",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "0x606EdA8300f6fA7C6AC8ce078FB6fFa747C08eb5",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "0x20E191479076E664905a1B1d281c42C1f86DdfAF",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "0x59dC4e6c6215B75E80209e6C28A68a03a6999eA8",
           "pub_key": null,
           "account_number": "0",
           "sequence": "0"
@@ -139,6 +195,34 @@
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "0x89020eFF618289BB8846CcE10640e016E4fDedF9",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "0x3620bA58B416FAa4F1607a0Db3A765a4884ecB20",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "0x3755e477A5dE3cB6ac3ac4d8EB5F7462fA8AcB99",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "0x08cA5C24988907849F143c5D06608A1A66fFBD2B",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
           "address": "0x33b22C9d21670f001fA430fe9f35239123978e79",
           "pub_key": null,
           "account_number": "0",
@@ -161,6 +245,13 @@
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
           "address": "0x9A68BD93f7D60fe351e4eB4d1578aEEbC46219Ef",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "0xd44E99b803d86812a729e7937A579B13dC775A31",
           "pub_key": null,
           "account_number": "0",
           "sequence": "0"
@@ -195,6 +286,13 @@
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "0x061cE7fE00EEe7fD5Ab63d6966C075e2c70027dB",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
           "address": "0xdc5dFFfa5Fc0Addf4A3c32F8DB6F39E1554ecbcf",
           "pub_key": null,
           "account_number": "0",
@@ -217,6 +315,13 @@
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
           "address": "0x48d80178240a967fd161d6FF2dC2D327a08cc577",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "0x26d45b86bd3BE15A81600B8657897c6F830b5ce2",
           "pub_key": null,
           "account_number": "0",
           "sequence": "0"
@@ -251,6 +356,13 @@
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "0xD3BE339F4F5A661256cCb2EC9aD1163825529D83",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
           "address": "0x169321fC04A12c16D0DaF30BBfD0c805D0223803",
           "pub_key": null,
           "account_number": "0",
@@ -273,6 +385,13 @@
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
           "address": "0x4f952415F13183233eDdD74F09B671798DF17391",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "0x5D40e970F30C529346C1C0D74E14e4397e27Ce4c",
           "pub_key": null,
           "account_number": "0",
           "sequence": "0"
@@ -307,6 +426,13 @@
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "0x2817e6027fD43b9f793322637d1Ba30886Abe5e9",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
           "address": "0x216B1EA22422F930E4A157d6f38F7b12206c2A39",
           "pub_key": null,
           "account_number": "0",
@@ -332,6 +458,13 @@
           "pub_key": null,
           "account_number": "0",
           "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "0xCB334C00a7402adF33B206fbf6Ae5007bC04d02C",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
         }
       ]
     },
@@ -350,6 +483,24 @@
             {
               "denom": "BNB",
               "amount": "3000000000000000000000"
+            }
+          ]
+        },
+        {
+          "address": "0x061cE7fE00EEe7fD5Ab63d6966C075e2c70027dB",
+          "coins": [
+            {
+              "denom": "BNB",
+              "amount": "2000000000000000000000"
+            }
+          ]
+        },
+        {
+          "address": "0x08cA5C24988907849F143c5D06608A1A66fFBD2B",
+          "coins": [
+            {
+              "denom": "BNB",
+              "amount": "2000000000000000000000"
             }
           ]
         },
@@ -381,6 +532,15 @@
           ]
         },
         {
+          "address": "0x20E191479076E664905a1B1d281c42C1f86DdfAF",
+          "coins": [
+            {
+              "denom": "BNB",
+              "amount": "2000000000000000000000"
+            }
+          ]
+        },
+        {
           "address": "0x21135C9052282D7f65E2d5769C0DBC9311741C09",
           "coins": [
             {
@@ -399,6 +559,33 @@
           ]
         },
         {
+          "address": "0x26d45b86bd3BE15A81600B8657897c6F830b5ce2",
+          "coins": [
+            {
+              "denom": "BNB",
+              "amount": "2000000000000000000000"
+            }
+          ]
+        },
+        {
+          "address": "0x2817e6027fD43b9f793322637d1Ba30886Abe5e9",
+          "coins": [
+            {
+              "denom": "BNB",
+              "amount": "2000000000000000000000"
+            }
+          ]
+        },
+        {
+          "address": "0x295f6d11143DD5A0b69546015aFdc4D92c733f9B",
+          "coins": [
+            {
+              "denom": "BNB",
+              "amount": "3000000000000000000000"
+            }
+          ]
+        },
+        {
           "address": "0x2e0d7c619b454F0C73756aE886eBfb2b37D62B96",
           "coins": [
             {
@@ -413,6 +600,33 @@
             {
               "denom": "BNB",
               "amount": "2000000000000000000000"
+            }
+          ]
+        },
+        {
+          "address": "0x3620bA58B416FAa4F1607a0Db3A765a4884ecB20",
+          "coins": [
+            {
+              "denom": "BNB",
+              "amount": "2000000000000000000000"
+            }
+          ]
+        },
+        {
+          "address": "0x3755e477A5dE3cB6ac3ac4d8EB5F7462fA8AcB99",
+          "coins": [
+            {
+              "denom": "BNB",
+              "amount": "2000000000000000000000"
+            }
+          ]
+        },
+        {
+          "address": "0x3b0CD23973F80A28e8847446C9b6550ab9D2c59e",
+          "coins": [
+            {
+              "denom": "BNB",
+              "amount": "3000000000000000000000"
             }
           ]
         },
@@ -462,7 +676,34 @@
           ]
         },
         {
+          "address": "0x59dC4e6c6215B75E80209e6C28A68a03a6999eA8",
+          "coins": [
+            {
+              "denom": "BNB",
+              "amount": "2000000000000000000000"
+            }
+          ]
+        },
+        {
+          "address": "0x5D40e970F30C529346C1C0D74E14e4397e27Ce4c",
+          "coins": [
+            {
+              "denom": "BNB",
+              "amount": "2000000000000000000000"
+            }
+          ]
+        },
+        {
           "address": "0x60564cea9D3d801f67A73F52728dd9f1A176B3cE",
+          "coins": [
+            {
+              "denom": "BNB",
+              "amount": "2000000000000000000000"
+            }
+          ]
+        },
+        {
+          "address": "0x606EdA8300f6fA7C6AC8ce078FB6fFa747C08eb5",
           "coins": [
             {
               "denom": "BNB",
@@ -526,6 +767,15 @@
         },
         {
           "address": "0x88caF9F167086855eA337d22f4B09f450AE92bf6",
+          "coins": [
+            {
+              "denom": "BNB",
+              "amount": "2000000000000000000000"
+            }
+          ]
+        },
+        {
+          "address": "0x89020eFF618289BB8846CcE10640e016E4fDedF9",
           "coins": [
             {
               "denom": "BNB",
@@ -606,6 +856,15 @@
           ]
         },
         {
+          "address": "0xc3884799494c0ca5acB4b8CB9030A4aCa31B878F",
+          "coins": [
+            {
+              "denom": "BNB",
+              "amount": "2000000000000000000000"
+            }
+          ]
+        },
+        {
           "address": "0xc4988282247053E89e8b2F4668d6ff02e2B530Bd",
           "coins": [
             {
@@ -616,6 +875,15 @@
         },
         {
           "address": "0xc9c16BFF2A82282818fAe17E9722A3aD1E702eb7",
+          "coins": [
+            {
+              "denom": "BNB",
+              "amount": "2000000000000000000000"
+            }
+          ]
+        },
+        {
+          "address": "0xCB334C00a7402adF33B206fbf6Ae5007bC04d02C",
           "coins": [
             {
               "denom": "BNB",
@@ -651,7 +919,25 @@
           ]
         },
         {
+          "address": "0xD3BE339F4F5A661256cCb2EC9aD1163825529D83",
+          "coins": [
+            {
+              "denom": "BNB",
+              "amount": "2000000000000000000000"
+            }
+          ]
+        },
+        {
           "address": "0xd3d8b58Fa0fb703bc3872F18CbEfC27260243198",
+          "coins": [
+            {
+              "denom": "BNB",
+              "amount": "2000000000000000000000"
+            }
+          ]
+        },
+        {
+          "address": "0xd44E99b803d86812a729e7937A579B13dC775A31",
           "coins": [
             {
               "denom": "BNB",
@@ -678,11 +964,29 @@
           ]
         },
         {
+          "address": "0xddB077aD6963144B6B9aFA3A7eE6067bf00a6E68",
+          "coins": [
+            {
+              "denom": "BNB",
+              "amount": "3000000000000000000000"
+            }
+          ]
+        },
+        {
           "address": "0xDF789020D4A44FE507cA3e1D75A6B18B1b99e356",
           "coins": [
             {
               "denom": "BNB",
               "amount": "2000000000000000000000"
+            }
+          ]
+        },
+        {
+          "address": "0xE19C96249c33Da0362C327D79F9c8Fe0191bE001",
+          "coins": [
+            {
+              "denom": "BNB",
+              "amount": "3000000000000000000000"
             }
           ]
         },
@@ -737,7 +1041,7 @@
     },
     "bridge": {
       "params": {
-        "transfer_out_relayer_fee": "1000000000000000",
+        "transfer_out_relayer_fee": "250000000000000",
         "transfer_out_ack_relayer_fee": "0"
       }
     },
@@ -752,12 +1056,14 @@
         "reward_validator_ratio": "0.900000000000000000",
         "reward_submitter_ratio": "0.001000000000000000",
         "reward_submitter_threshold": "1000000000000000",
-        "heartbeat_interval": "1000"
+        "heartbeat_interval": "1000",
+        "attestation_inturn_interval": "120",
+        "attestation_kept_count": "300"
       }
     },
     "crosschain": {
       "params": {
-        "init_module_balance": "1909000000000000000000000"
+        "init_module_balance": "1867000000000000000000000"
       }
     },
     "distribution": {
@@ -784,7 +1090,7 @@
     },
     "gashub": {
       "params": {
-        "max_tx_size": "32768",
+        "max_tx_size": "65536",
         "min_gas_per_byte": "5",
         "msg_gas_params_set": [
           {
@@ -998,6 +1304,24 @@
             }
           },
           {
+            "msg_type_url": "/bnbchain.greenfield.storage.MsgUpdateObjectInfo",
+            "fixed_type": {
+              "fixed_gas": "1200"
+            }
+          },
+          {
+            "msg_type_url": "/bnbchain.greenfield.storage.MsgDiscontinueObject",
+            "fixed_type": {
+              "fixed_gas": "2400"
+            }
+          },
+          {
+            "msg_type_url": "/bnbchain.greenfield.storage.MsgDiscontinueBucket",
+            "fixed_type": {
+              "fixed_gas": "2400"
+            }
+          },
+          {
             "msg_type_url": "/bnbchain.greenfield.storage.MsgCreateGroup",
             "fixed_type": {
               "fixed_gas": "2400"
@@ -1118,6 +1442,7 @@
                 "funding_address": "0x6cB45db5BB9663137b0Ea920001ef5D3014CFe04",
                 "seal_address": "0x88caF9F167086855eA337d22f4B09f450AE92bf6",
                 "approval_address": "0x9A68BD93f7D60fe351e4eB4d1578aEEbC46219Ef",
+                "gc_address": "0xd44E99b803d86812a729e7937A579B13dC775A31",
                 "endpoint": "https://gnfd-testnet-sp-1.bnbchain.org",
                 "deposit": {
                   "denom": "BNB",
@@ -1157,7 +1482,7 @@
             "tip": null
           },
           "signatures": [
-            "CBd8fbDolE1posPRkzxRnyna2RwnzbI2HCKYqsJIpcwU0LCc0qYCeIuELroF311Nk9goAWaw322/5+41SWIeigA="
+            "T2/TMbBb7i9+OMyKOmopi308M+4q630plyO+OccRlRhVR8rLaYbdk8TN3gtTTdeEEZgzViAw7FQZk3KtjBeM3QE="
           ]
         },
         {
@@ -1177,6 +1502,7 @@
                 "funding_address": "0x797b0BBd5508E80765AdA3BfA36443a5B3E2a9Ba",
                 "seal_address": "0x75B6665FD630fdC7dB0F9C63E1b94a053aE25CAd",
                 "approval_address": "0x61B4a7c119f1Bdc128FC2A1A85344E29Fe02C232",
+                "gc_address": "0x061cE7fE00EEe7fD5Ab63d6966C075e2c70027dB",
                 "endpoint": "https://gnfd-testnet-sp-2.bnbchain.org",
                 "deposit": {
                   "denom": "BNB",
@@ -1216,7 +1542,7 @@
             "tip": null
           },
           "signatures": [
-            "xg+op2/3FQa6oBB3OLhIDLtM8H6U6j8zN4yrqyxHLsM9PcV/mjxtFrSTuVbORrKPzLf5lIl5L1+k8BP0FIIAVwE="
+            "k5AEOvYLhkS+2g9y43WEvuX4ryQLfnvLT8zK4lKxu/ttrD+XtiRU6gfgx9VWEtgifWNQCDUqn+AIUt4RdEAUFAA="
           ]
         },
         {
@@ -1236,6 +1562,7 @@
                 "funding_address": "0x626930DD80D1E0e08EF64B1Ff2DD1D33dDc540A8",
                 "seal_address": "0x8c974E68F9a8F23A305996D999995E3DAEa890Bb",
                 "approval_address": "0x48d80178240a967fd161d6FF2dC2D327a08cc577",
+                "gc_address": "0x26d45b86bd3BE15A81600B8657897c6F830b5ce2",
                 "endpoint": "https://gnfd-testnet-sp-3.bnbchain.org",
                 "deposit": {
                   "denom": "BNB",
@@ -1275,7 +1602,7 @@
             "tip": null
           },
           "signatures": [
-            "rSPzicXaLFlr1hDpFyk1ujM5WcmhKDuKISM2WpnBQUx28ZmTNqV8bbMOLClkFHuiGrptMxqFw0fIND4k68637QE="
+            "xxCGeOwh2Fyqw3sJXR8veidvMkN2K4mNiW4EJ+OYWSILcPIQgS5d/hZONDwtWN2cYqYrWWJAW/6Jh4ucTlVRdQA="
           ]
         },
         {
@@ -1295,6 +1622,7 @@
                 "funding_address": "0xE4c1Fc497e87dDe26E452bbe9592617324c6a2Cd",
                 "seal_address": "0xc4988282247053E89e8b2F4668d6ff02e2B530Bd",
                 "approval_address": "0x60564cea9D3d801f67A73F52728dd9f1A176B3cE",
+                "gc_address": "0xD3BE339F4F5A661256cCb2EC9aD1163825529D83",
                 "endpoint": "https://gnfd-testnet-sp-4.bnbchain.org",
                 "deposit": {
                   "denom": "BNB",
@@ -1334,7 +1662,7 @@
             "tip": null
           },
           "signatures": [
-            "8JUbShjBYlcDfI4fWte7gXxBGMqpGqxHqWihtiHOQudT0mgGhvJS+CUZFiz2N2HTOsPZ599aHhWCkrUVNvGIRwA="
+            "VsTdzvAVTW5t2X3+qLi0om8Xf+WC7Nrm2bUNuOHs/XwUDIY/LckReUycuHVXMj7wxciwWgS5dk0P4+bjeku3iQA="
           ]
         },
         {
@@ -1354,6 +1682,7 @@
                 "funding_address": "0x7a62760D33725a7146148a18c6A6a110213d60f8",
                 "seal_address": "0xd188Ec975aF2749181d57F4015fc8FE8c093343A",
                 "approval_address": "0x4f952415F13183233eDdD74F09B671798DF17391",
+                "gc_address": "0x5D40e970F30C529346C1C0D74E14e4397e27Ce4c",
                 "endpoint": "https://gnfd-testnet-sp-5.bnbchain.org",
                 "deposit": {
                   "denom": "BNB",
@@ -1393,7 +1722,7 @@
             "tip": null
           },
           "signatures": [
-            "c/AvAwf4Iblpup8Wh3Bz5ZRwFMBnyxETh72R/4GYUphNb35rsS7txzcJQqAt66UfDLoklCFrcxNoiVbM88dhEgE="
+            "tR1eZNv0WxA4X17ua74nhFcHML4d/bKVX9iTna8Us0JTxwqFOe1A+fgoYYidvesIZ/a0/HMX+s16ICslL3Rm1wA="
           ]
         },
         {
@@ -1413,6 +1742,7 @@
                 "funding_address": "0xBFbfC60E1fabAF0e4a55bf8EaF9A46DDe5DeEeA7",
                 "seal_address": "0xe98346B03CD45Daf64A338F08Cc41551a98fF68c",
                 "approval_address": "0xF8Cd9D51040d1FB63c62b3739825d0F9F3cA31D8",
+                "gc_address": "0x2817e6027fD43b9f793322637d1Ba30886Abe5e9",
                 "endpoint": "https://gnfd-testnet-sp-6.bnbchain.org",
                 "deposit": {
                   "denom": "BNB",
@@ -1452,7 +1782,7 @@
             "tip": null
           },
           "signatures": [
-            "QmEuQZ28cV4Oquv8z7YKjZgis74GhFyeaHAlruu8UYJjGemiV9tlbCQeNoV/CFzKruaq6/6ElGYXmLbFva+ljwE="
+            "VT3rYOyAK7pRzCgHXDYcaTv37NtdZffBCmWXVPjT0LJLZYm/FS6kw/M/xctkFadEPPJmQ4xrt+VWCNWs+/vccQE="
           ]
         },
         {
@@ -1472,6 +1802,7 @@
                 "funding_address": "0x2e0d7c619b454F0C73756aE886eBfb2b37D62B96",
                 "seal_address": "0xDF789020D4A44FE507cA3e1D75A6B18B1b99e356",
                 "approval_address": "0x21135C9052282D7f65E2d5769C0DBC9311741C09",
+                "gc_address": "0xCB334C00a7402adF33B206fbf6Ae5007bC04d02C",
                 "endpoint": "https://gnfd-testnet-sp-7.bnbchain.org",
                 "deposit": {
                   "denom": "BNB",
@@ -1511,13 +1842,79 @@
             "tip": null
           },
           "signatures": [
-            "G9ZQZZyCc6UcEc/W3sMKJQC0+2EWFmnuiRU1bJLv2ElOVrsNGhE9yhaoibCQKrMt1MC7SBvH9V/NF+7x4jffqwE="
+            "UR9sG6Ja1Gnon+6jlpHFXHfi0rfkKYMc1CITYxPAqqJboeNq0DM0BOj6ga7GGobC0FB6wjvkv+xw8vuN4ChgvQE="
           ]
         }
       ]
     },
     "genutil": {
       "gen_txs": [
+        {
+          "body": {
+            "messages": [
+              {
+                "@type": "/cosmos.staking.v1beta1.MsgCreateValidator",
+                "description": {
+                  "moniker": "Alpha-5",
+                  "identity": "",
+                  "website": "",
+                  "security_contact": "",
+                  "details": "Alpha-5"
+                },
+                "commission": {
+                  "rate": "0.000000000000000000",
+                  "max_rate": "1.000000000000000000",
+                  "max_change_rate": "0.010000000000000000"
+                },
+                "min_self_delegation": "1000000000000000000000",
+                "delegator_address": "0x295f6d11143DD5A0b69546015aFdc4D92c733f9B",
+                "validator_address": "0x295f6d11143DD5A0b69546015aFdc4D92c733f9B",
+                "pubkey": {
+                  "@type": "/cosmos.crypto.ed25519.PubKey",
+                  "key": "xCGD9ymzgCoo/yKS32RnO/zSmXniyDrjr+71Qa1mrrM="
+                },
+                "value": {
+                  "denom": "BNB",
+                  "amount": "1000000000000000000000"
+                },
+                "from": "0x295f6d11143DD5A0b69546015aFdc4D92c733f9B",
+                "relayer_address": "0x59dC4e6c6215B75E80209e6C28A68a03a6999eA8",
+                "challenger_address": "0x08cA5C24988907849F143c5D06608A1A66fFBD2B",
+                "bls_key": "b5278db9a8f2612017322288349039eddc0312b11f7676bf05b83f699f122ac5ad74504893eca3cc6b0ab09b5601c864"
+              }
+            ],
+            "memo": "Alpha-5@127.0.0.1:26656",
+            "timeout_height": "0",
+            "extension_options": [],
+            "non_critical_extension_options": []
+          },
+          "auth_info": {
+            "signer_infos": [
+              {
+                "public_key": {
+                  "@type": "/ethermint.crypto.v1.ethsecp256k1.PubKey",
+                  "key": "AyhXi0O5VGkVkQ8bzrMNlShw2zqtj0zlf2twi2TtaeZT"
+                },
+                "mode_info": {
+                  "single": {
+                    "mode": "SIGN_MODE_EIP_712"
+                  }
+                },
+                "sequence": "0"
+              }
+            ],
+            "fee": {
+              "amount": [],
+              "gas_limit": "200000000",
+              "payer": "",
+              "granter": ""
+            },
+            "tip": null
+          },
+          "signatures": [
+            "rowRePD56ZDfuOsg+Bj9CdmPc/pu2L9omY1AqtufY6dYjntfAgO4C2uccpobenLO3QjihHZoEpz8VhmzS81l0wA="
+          ]
+        },
         {
           "body": {
             "messages": [
@@ -1540,7 +1937,7 @@
                 "validator_address": "0xCdd2cdEcEFAB9A1c7b9434DfD40B2D67A6C2082b",
                 "pubkey": {
                   "@type": "/cosmos.crypto.ed25519.PubKey",
-                  "key": "RRIbjSjMnvqAb99R9xbJyPzAids2wDLZwypmwfPirfs="
+                  "key": "dXUMboOxUGGHqCMFBAjDj65mpZH3JHLi1VZTVOqhkR4="
                 },
                 "value": {
                   "denom": "BNB",
@@ -1581,7 +1978,139 @@
             "tip": null
           },
           "signatures": [
-            "kuAnNW4xIDGT06TScA3L+bEgJt27SCTR8JHfobtdQ7wW4PRg+XSy1yqEwiJDH6aORHs9n2jNYp+X6fYzVnSJHgA="
+            "wNJnpXYYEfpUQ/9hwkxPcVQLt2o7E5d/5ZnsOhwpw6JWJ39p2Srgah4LU94sVrfi2eurm7LdvRk0MArZu3s/LwE="
+          ]
+        },
+        {
+          "body": {
+            "messages": [
+              {
+                "@type": "/cosmos.staking.v1beta1.MsgCreateValidator",
+                "description": {
+                  "moniker": "Gadgetron",
+                  "identity": "",
+                  "website": "",
+                  "security_contact": "",
+                  "details": "Gadgetron"
+                },
+                "commission": {
+                  "rate": "0.000000000000000000",
+                  "max_rate": "1.000000000000000000",
+                  "max_change_rate": "0.010000000000000000"
+                },
+                "min_self_delegation": "1000000000000000000000",
+                "delegator_address": "0x3b0CD23973F80A28e8847446C9b6550ab9D2c59e",
+                "validator_address": "0x3b0CD23973F80A28e8847446C9b6550ab9D2c59e",
+                "pubkey": {
+                  "@type": "/cosmos.crypto.ed25519.PubKey",
+                  "key": "xRGMDJxrqYhsZNuxcL7rpHmHd+Gk/iR4OwaP6y+Ykk8="
+                },
+                "value": {
+                  "denom": "BNB",
+                  "amount": "1000000000000000000000"
+                },
+                "from": "0x3b0CD23973F80A28e8847446C9b6550ab9D2c59e",
+                "relayer_address": "0xc3884799494c0ca5acB4b8CB9030A4aCa31B878F",
+                "challenger_address": "0x89020eFF618289BB8846CcE10640e016E4fDedF9",
+                "bls_key": "8e4db379d0f1baae0f6254842261913d785ed792488ddc052a8d2f676162c13c2f880ded00486bc8a9c462d744c3b838"
+              }
+            ],
+            "memo": "Gadgetron@127.0.0.1:26656",
+            "timeout_height": "0",
+            "extension_options": [],
+            "non_critical_extension_options": []
+          },
+          "auth_info": {
+            "signer_infos": [
+              {
+                "public_key": {
+                  "@type": "/ethermint.crypto.v1.ethsecp256k1.PubKey",
+                  "key": "AvnddDXkdadpWD8mfdp/A7E6V+08HmvYHKWlwgyDteZ6"
+                },
+                "mode_info": {
+                  "single": {
+                    "mode": "SIGN_MODE_EIP_712"
+                  }
+                },
+                "sequence": "0"
+              }
+            ],
+            "fee": {
+              "amount": [],
+              "gas_limit": "200000000",
+              "payer": "",
+              "granter": ""
+            },
+            "tip": null
+          },
+          "signatures": [
+            "wInJVikUcv7XnDyBdVz/eEilFqvI1UOPhW9lxSMEtEYdRhMAIQjFtOBu6OSgNEpXnCwCkOkNeoeCq8NjlGR4tgE="
+          ]
+        },
+        {
+          "body": {
+            "messages": [
+              {
+                "@type": "/cosmos.staking.v1beta1.MsgCreateValidator",
+                "description": {
+                  "moniker": "Lumibot",
+                  "identity": "",
+                  "website": "",
+                  "security_contact": "",
+                  "details": "Lumibot"
+                },
+                "commission": {
+                  "rate": "0.000000000000000000",
+                  "max_rate": "1.000000000000000000",
+                  "max_change_rate": "0.010000000000000000"
+                },
+                "min_self_delegation": "1000000000000000000000",
+                "delegator_address": "0xE19C96249c33Da0362C327D79F9c8Fe0191bE001",
+                "validator_address": "0xE19C96249c33Da0362C327D79F9c8Fe0191bE001",
+                "pubkey": {
+                  "@type": "/cosmos.crypto.ed25519.PubKey",
+                  "key": "Y0c6XqYoXiPf1GcaPz9FsgZwMmKjVsuG2168JYgC2bE="
+                },
+                "value": {
+                  "denom": "BNB",
+                  "amount": "1000000000000000000000"
+                },
+                "from": "0xE19C96249c33Da0362C327D79F9c8Fe0191bE001",
+                "relayer_address": "0x20E191479076E664905a1B1d281c42C1f86DdfAF",
+                "challenger_address": "0x3755e477A5dE3cB6ac3ac4d8EB5F7462fA8AcB99",
+                "bls_key": "9121d54a5ed8635ab47e974ec2c02a76914de750d91a1393215ac81ccf7ac78676dec2cdae8e3354ad0300396a4140f0"
+              }
+            ],
+            "memo": "Lumibot@127.0.0.1:26656",
+            "timeout_height": "0",
+            "extension_options": [],
+            "non_critical_extension_options": []
+          },
+          "auth_info": {
+            "signer_infos": [
+              {
+                "public_key": {
+                  "@type": "/ethermint.crypto.v1.ethsecp256k1.PubKey",
+                  "key": "AlS7qEjVvJna0mxo9SEHpZ321esFAMvE8/2XsNr8QIZY"
+                },
+                "mode_info": {
+                  "single": {
+                    "mode": "SIGN_MODE_EIP_712"
+                  }
+                },
+                "sequence": "0"
+              }
+            ],
+            "fee": {
+              "amount": [],
+              "gas_limit": "200000000",
+              "payer": "",
+              "granter": ""
+            },
+            "tip": null
+          },
+          "signatures": [
+            "oow+Y4n2C59Kz/Ay5r/1k/BMn6qSjkgXHa16vyqWikIuXIqk9yVO/j3OVF0whDkY+Z7Ri6/xQh3/KAGF3c2ghgA="
           ]
         },
         {
@@ -1606,7 +2135,7 @@
                 "validator_address": "0x56176c54151Ff8733cC9338DC022E116DDC5178D",
                 "pubkey": {
                   "@type": "/cosmos.crypto.ed25519.PubKey",
-                  "key": "fkD+PzBHZDNQustpKCIt9w2qtJXUn3vlrsN1r4qL+ps="
+                  "key": "zx/mpivv353kGu6jIG+y3rLH9R8plbE4BOnEvj4QKxE="
                 },
                 "value": {
                   "denom": "BNB",
@@ -1647,7 +2176,7 @@
             "tip": null
           },
           "signatures": [
-            "9R0FC5+v69BOd5gmWxNsx6sBLxxXyMiinEd5Tvel/kV6wXJoS8ESCbEVRHuuDub5F6ZLAg5Y+PcgJFpZFnraEgA="
+            "/PIBUVCTPzpFKqlKbHtFg8nBQG9Yu4k8u3El59irL11LxRolIY8SacpAuLJN9U3Zp0i26yysgsAUeCOwfmHP5gE="
           ]
         },
         {
@@ -1672,7 +2201,7 @@
                 "validator_address": "0x0C5318DdebB488c524A22313d51f44b64c192431",
                 "pubkey": {
                   "@type": "/cosmos.crypto.ed25519.PubKey",
-                  "key": "DRl4FKDnSnOBzlxJRT/YnTkyPc0GXsIYg7FSFG8Vwe0="
+                  "key": "Gy3Gvw6keuP6BMwRyl8VeBXTs8dfE+sTpGo+8ORMed0="
                 },
                 "value": {
                   "denom": "BNB",
@@ -1713,7 +2242,73 @@
             "tip": null
           },
           "signatures": [
-            "RpfxR8qOc0qO4D1P7BgdJbg8PEIrDxlQnlrSA8pteol8e64NlGERQiUE/gw25qAPF4roKBel0Co59fUwFTN52gE="
+            "1tlVttojRgbwzfD8kQEvxHZFh43OQx+O1gppdF4FRTAPvL3UD1AiC0ux9WDhhL6AerfSJgKLASjVPndhpMrddwA="
+          ]
+        },
+        {
+          "body": {
+            "messages": [
+              {
+                "@type": "/cosmos.staking.v1beta1.MsgCreateValidator",
+                "description": {
+                  "moniker": "Titan",
+                  "identity": "",
+                  "website": "",
+                  "security_contact": "",
+                  "details": "Titan"
+                },
+                "commission": {
+                  "rate": "0.000000000000000000",
+                  "max_rate": "1.000000000000000000",
+                  "max_change_rate": "0.010000000000000000"
+                },
+                "min_self_delegation": "1000000000000000000000",
+                "delegator_address": "0xddB077aD6963144B6B9aFA3A7eE6067bf00a6E68",
+                "validator_address": "0xddB077aD6963144B6B9aFA3A7eE6067bf00a6E68",
+                "pubkey": {
+                  "@type": "/cosmos.crypto.ed25519.PubKey",
+                  "key": "omFEuHleLZ1ALb5HEHgQRSTxksP9WN5otEOgrw3bb6E="
+                },
+                "value": {
+                  "denom": "BNB",
+                  "amount": "1000000000000000000000"
+                },
+                "from": "0xddB077aD6963144B6B9aFA3A7eE6067bf00a6E68",
+                "relayer_address": "0x606EdA8300f6fA7C6AC8ce078FB6fFa747C08eb5",
+                "challenger_address": "0x3620bA58B416FAa4F1607a0Db3A765a4884ecB20",
+                "bls_key": "96a40fffe92d20475e24419aafe5744cf301058b974fe1f6b2910d8c5cb36933d002d41b2ff43df553a54f1dcf4c3e4b"
+              }
+            ],
+            "memo": "Titan@127.0.0.1:26656",
+            "timeout_height": "0",
+            "extension_options": [],
+            "non_critical_extension_options": []
+          },
+          "auth_info": {
+            "signer_infos": [
+              {
+                "public_key": {
+                  "@type": "/ethermint.crypto.v1.ethsecp256k1.PubKey",
+                  "key": "A3yS8gDdZwX07WTvzgiWcSJriCiQo2SLdphfP5eQS288"
+                },
+                "mode_info": {
+                  "single": {
+                    "mode": "SIGN_MODE_EIP_712"
+                  }
+                },
+                "sequence": "0"
+              }
+            ],
+            "fee": {
+              "amount": [],
+              "gas_limit": "200000000",
+              "payer": "",
+              "granter": ""
+            },
+            "tip": null
+          },
+          "signatures": [
+            "3tmuUkLjhir+2OvnmuFi3h9rHiptDrybJqGFHhl3uhgAWMBXHQbqM7GXoBAKXVrhGJ04D5COiKamgiwTmOtm6AE="
           ]
         },
         {
@@ -1738,7 +2333,7 @@
                 "validator_address": "0xBA6f13563C6a064a4E137592867020d1a76f14F7",
                 "pubkey": {
                   "@type": "/cosmos.crypto.ed25519.PubKey",
-                  "key": "PkKZ107EuhoIvMZuM0mya8AcTwzUiZEz0s7jKA3CJTs="
+                  "key": "Bd8GCuVzAaCuZyNT9DWJSyb0E/NGPeS/nNIJLpPlFSE="
                 },
                 "value": {
                   "denom": "BNB",
@@ -1779,7 +2374,7 @@
             "tip": null
           },
           "signatures": [
-            "oqNTtFf9Rf2bLNOpZ+cyepiZKnhcDRMczs4vG+cyyhstgyBd6aSgYRMI5JqK02ycWUeOqNfHHTpqP9W5fr09KQA="
+            "wPIBNQV6A8DwHm+bu5hqQiKek2/n63730GQkVMyDa6lkNHvhu/Agx5jv0XF5UFk0IcgTar0WdB4KpQGgMOwKWQE="
           ]
         },
         {
@@ -1804,7 +2399,7 @@
                 "validator_address": "0x003b8EBE7B3f5C4E50B497c2f731722F17b1CBE8",
                 "pubkey": {
                   "@type": "/cosmos.crypto.ed25519.PubKey",
-                  "key": "vwgiK0q1AghHmrIB6Ge+PxvP3ZgIehjrB743jf1q6SU="
+                  "key": "0SZexT6hbUE9luTcL5rW2fb14nJuBr7+HG8KIltwPQM="
                 },
                 "value": {
                   "denom": "BNB",
@@ -1845,7 +2440,7 @@
             "tip": null
           },
           "signatures": [
-            "U8zkQcv9viwTIo5mW9nyvZ1NBqUV8o3E5uSFkoPRmrUCiavJwFIADRU3s/15DYmaATdcFJOw3DSNvdLU2NFQegA="
+            "ymovjQ4kZSIYfmPn0k2Fj2qtnrygZJksmTabMtkyATl9xiqMsDwlxs1M+LYXmYDDMS6aWpe3ilWdA/Lzg40LeQE="
           ]
         }
       ]
@@ -1859,16 +2454,16 @@
         "min_deposit": [
           {
             "denom": "BNB",
-            "amount": "10000000"
+            "amount": "1000000000000000000"
           }
         ],
-        "max_deposit_period": "86400s"
+        "max_deposit_period": "604800s"
       },
       "voting_params": {
         "voting_period": "86400s"
       },
       "tally_params": {
-        "quorum": "0.334000000000000000",
+        "quorum": "0.500000000000000000",
         "threshold": "0.500000000000000000",
         "veto_threshold": "0.334000000000000000"
       }
@@ -1916,7 +2511,7 @@
       "params": {
         "deposit_denom": "BNB",
         "min_deposit": "1000000000000000000000",
-        "secondary_sp_store_price_ratio": "0.800000000000000000"
+        "secondary_sp_store_price_ratio": "0.650000000000000000"
       },
       "storage_providers": [],
       "sp_storage_price_list": []
@@ -1946,13 +2541,18 @@
         "redundant_parity_chunk_num": 2,
         "max_payload_size": "2147483648",
         "min_charge_size": "1048576",
-        "mirror_bucket_relayer_fee": "1000000000000000",
-        "mirror_bucket_ack_relayer_fee": "0",
-        "mirror_object_relayer_fee": "1000000000000000",
-        "mirror_object_ack_relayer_fee": "0",
-        "mirror_group_relayer_fee": "1000000000000000",
-        "mirror_group_ack_relayer_fee": "0",
-        "max_buckets_per_account": 100
+        "mirror_bucket_relayer_fee": "250000000000000",
+        "mirror_bucket_ack_relayer_fee": "250000000000000",
+        "mirror_object_relayer_fee": "250000000000000",
+        "mirror_object_ack_relayer_fee": "250000000000000",
+        "mirror_group_relayer_fee": "250000000000000",
+        "mirror_group_ack_relayer_fee": "250000000000000",
+        "max_buckets_per_account": 100,
+        "discontinue_counting_window": "10000",
+        "discontinue_object_max": "18446744073709551615",
+        "discontinue_bucket_max": "18446744073709551615",
+        "discontinue_confirm_period": "604800",
+        "discontinue_deletion_max": "10000"
       }
     },
     "upgrade": {}


### PR DESCRIPTION
### Description

update testnet genesis to v0.1.2

### Rationale

Greenfield testnet has been reset and upgraded to v0.1.2 on 2023/5/12

### Example
n/a

### Changes

Notable changes: 
* testnet genesis
