### PR TITLE
ci: fix go version in release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build Release
     strategy:
       matrix:
-        go-version: [1.18.x]
+        go-version: [1.20.x]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
### Description

fix go version in the release flow

### Rationale

the go.mod require go1.19+
<img width="1067" alt="image" src="https://github.com/bnb-chain/greenfield/assets/25412254/f18a6d6d-e531-47d9-b191-35c56fa9448f">


### Example

n/a

### Changes

Notable changes: 
* ci/release
