### PR TITLE
fix: correct the counting of deleted objects

### DIFF
--- a/x/storage/keeper/keeper.go
+++ b/x/storage/keeper/keeper.go
@@ -242,6 +242,7 @@ func (k Keeper) ForceDeleteBucket(ctx sdk.Context, bucketId sdkmath.Uint, cap ui
 		if err := k.doDeleteObject(ctx, sp, bucketInfo, &objectInfo); err != nil {
 			return false, deleted, err
 		}
+		deleted++
 	}
 
 	if !iter.Valid() {


### PR DESCRIPTION
### Description

This pr fixes an issue - the deleted objects is not correctly counted in end block when deleting buckets.

### Rationale

Bug fix

### Example

NA

### Changes

Notable changes: 
* NA
