### PR TITLE
dep: bump cosmos-sdk to v0.2.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -176,6 +176,6 @@ replace (
 	github.com/btcsuite/btcd => github.com/btcsuite/btcd v0.23.0
 	github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v0.0.1
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v0.2.0
+	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v0.2.1
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 )

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edY
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
 github.com/bnb-chain/greenfield-cometbft v0.0.1 h1:pX8S9oZKjWJCrxH07l6rbU3zee9txZ11+UwO9stsNMQ=
 github.com/bnb-chain/greenfield-cometbft v0.0.1/go.mod h1:9q11eHNRY9FDwFH+4pompzPNGv//Z3VcfvkELaHJPMs=
-github.com/bnb-chain/greenfield-cosmos-sdk v0.2.0 h1:HOxV6Tgi/pdSRfhcyWa/y55H6SV0+UuTauqtO+bBcSw=
-github.com/bnb-chain/greenfield-cosmos-sdk v0.2.0/go.mod h1:6pVENKv7drpk0k46nuyvAeD1SMnQUuXD9WY0tyc060A=
+github.com/bnb-chain/greenfield-cosmos-sdk v0.2.1 h1:icJpJetpb1zs2kCRkD+rXI55uzGFroPMFDNT0NDPNL4=
+github.com/bnb-chain/greenfield-cosmos-sdk v0.2.1/go.mod h1:6pVENKv7drpk0k46nuyvAeD1SMnQUuXD9WY0tyc060A=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230425074444-eb5869b05fe9 h1:6fLpmmI0EZvDTfPvI0zy5dBaaTUboHnEkoC5/p/w8TQ=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230425074444-eb5869b05fe9/go.mod h1:rbc4o84RSEvhf09o2+4Qiazsv0snRJLiEZdk17HeIDw=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230425074444-eb5869b05fe9 h1:1ZdK+iR1Up02bOa2YTZCml7PBpP//kcdamOcK6aWO/s=


### PR DESCRIPTION
### Description
This is a hot fix release for v0.2.0

### Rationale
We need to upgrade the cosmos-sdk dep as the v0.2.0 get some issues regarding the fee calculator register.

### Example
None

### Changes
None
