### PR TITLE
fix: fix error msg when remove group member

### DIFF
--- a/x/permission/keeper/keeper.go
+++ b/x/permission/keeper/keeper.go
@@ -79,7 +79,7 @@ func (k Keeper) RemoveGroupMember(ctx sdk.Context, groupID math.Uint, member sdk
 	memberKey := types.GetGroupMemberKey(groupID, member)
 	bz := store.Get(memberKey)
 	if bz == nil {
-		return storagetypes.ErrNoSuchGroup
+		return storagetypes.ErrNoSuchGroupMember
 	}
 	store.Delete(memberKey)
 	store.Delete(types.GetGroupMemberByIDKey(sequence.DecodeSequence(bz)))


### PR DESCRIPTION
### Description

This pr fixes the error msg returned when removing a nonexisting group member.

### Rationale

Fix error msg when remove group member

### Example

N/A

### Changes

Notable changes: 
* fix error msg when remove group member
