### PR TITLE
fix: fix discontinued objects/buckets cannot be deleted issue

### DIFF
--- a/deployment/localup/localup.sh
+++ b/deployment/localup/localup.sh
@@ -148,6 +148,7 @@ function generate_genesis() {
         sed -i -e "s/\"heartbeat_interval\": \"1000\"/\"heartbeat_interval\": \"100\"/g" ${workspace}/.local/validator${i}/config/genesis.json
         sed -i -e "s/\"attestation_inturn_interval\": \"120\"/\"attestation_inturn_interval\": \"10\"/g" ${workspace}/.local/validator${i}/config/genesis.json
         sed -i -e "s/\"discontinue_confirm_period\": \"604800\"/\"discontinue_confirm_period\": \"15\"/g" ${workspace}/.local/validator${i}/config/genesis.json
+        sed -i -e "s/\"discontinue_deletion_max\": \"10000\"/\"discontinue_deletion_max\": \"1\"/g" ${workspace}/.local/validator${i}/config/genesis.json
         sed -i -e "s/\"voting_period\": \"30s\"/\"voting_period\": \"10s\"/g" ${workspace}/.local/validator${i}/config/genesis.json
     done
 

--- a/e2e/tests/challenge_test.go
+++ b/e2e/tests/challenge_test.go
@@ -251,7 +251,7 @@ func (s *ChallengeTestSuite) TestHeartbeatAttest() {
 		if len(events) > 0 {
 			s.T().Logf("current challenge id: %d", events[len(events)-1].ChallengeId)
 		}
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(200 * time.Millisecond)
 	}
 
 	valBitset := s.calculateValidatorBitSet(height, s.ValidatorBLS.PubKey().String())
@@ -308,7 +308,7 @@ func (s *ChallengeTestSuite) TestFailedAttest_ChallengeExpired() {
 
 	expiredHeight := event.ExpiredHeight
 	for {
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(200 * time.Millisecond)
 		statusRes, err := s.TmClient.TmClient.Status(context.Background())
 		s.Require().NoError(err)
 		height := statusRes.SyncInfo.LatestBlockHeight


### PR DESCRIPTION
### Description

Issue: new discontinued objects/buckets cannot be deleted due to the wrong deletion of storage keys.


### Rationale

Bug fix

### Example

NA

### Changes

Notable changes: 
* end block
