### PR TITLE
fix: QueryGetSecondarySpStorePriceByTime may wrong data

### DIFF
--- a/e2e/tests/sp_test.go
+++ b/e2e/tests/sp_test.go
@@ -252,6 +252,16 @@ func (s *StorageProviderTestSuite) TestSpStoragePrice() {
 	s.Require().Equal(newReadPrice, spStoragePrice2.SpStoragePrice.ReadPrice)
 	s.Require().Equal(newStorePrice, spStoragePrice2.SpStoragePrice.StorePrice)
 	s.CheckSecondarySpPrice()
+	// query sp storage price by time before it exists, expect error
+	_, err = s.Client.QueryGetSecondarySpStorePriceByTime(ctx, &sptypes.QueryGetSecondarySpStorePriceByTimeRequest{
+		Timestamp: 1,
+	})
+	s.Require().Error(err)
+	_, err = s.Client.QueryGetSpStoragePriceByTime(ctx, &sptypes.QueryGetSpStoragePriceByTimeRequest{
+		SpAddr:    spAddr,
+		Timestamp: 1,
+	})
+	s.Require().Error(err)
 }
 
 func (s *StorageProviderTestSuite) CheckSecondarySpPrice() {

--- a/x/sp/keeper/sp_storage_price.go
+++ b/x/sp/keeper/sp_storage_price.go
@@ -90,8 +90,11 @@ func (k Keeper) GetSpStoragePriceByTime(
 		return val, fmt.Errorf("no price found")
 	}
 
+	spAddrRes, UpdateTimeSec := types.ParseSpStoragePriceKey(iterator.Key())
+	if !spAddrRes.Equals(spAddr) {
+		return val, fmt.Errorf("no price found")
+	}
 	k.cdc.MustUnmarshal(iterator.Value(), &val)
-	_, UpdateTimeSec := types.ParseSpStoragePriceKey(iterator.Key())
 	val.SpAddress = spAddr.String()
 	val.UpdateTimeSec = UpdateTimeSec
 


### PR DESCRIPTION
### Description

Fix the bug that `QueryGetSecondarySpStorePriceByTime` interface may return wrong data.


### Rationale

The `QueryGetSecondarySpStorePriceByTime` API could previously return data from another SP when the timestamp was before the SP's creation time. This PR corrected the bug by comparing the SP address in the result key with the address in the parameter.

### Example

NA

### Changes

NA
