### PR TITLE
fix: fail to force delete when the payment addr is frozen

### DIFF
--- a/x/payment/types/types.go
+++ b/x/payment/types/types.go
@@ -10,3 +10,7 @@ var (
 	GovernanceAddress       = sdk.AccAddress(address.Module(ModuleName, []byte("governance"))[:sdk.EthAddressLength])
 	ValidatorTaxPoolAddress = sdk.AccAddress(address.Module(ModuleName, []byte("validator-tax-pool"))[:sdk.EthAddressLength])
 )
+
+const (
+	ForceUpdateFrozenStreamRecordKey = "force_update_frozen_stream_record"
+)

--- a/x/storage/abci.go
+++ b/x/storage/abci.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	paymenttypes "github.com/bnb-chain/greenfield/x/payment/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	k "github.com/bnb-chain/greenfield/x/storage/keeper"
@@ -22,6 +23,8 @@ func EndBlocker(ctx sdk.Context, keeper k.Keeper) {
 	}
 
 	blockTime := ctx.BlockTime().Unix()
+	// set ForceUpdateFrozenStreamRecordKey to true in context to force update frozen stream record
+	ctx = ctx.WithValue(paymenttypes.ForceUpdateFrozenStreamRecordKey, true)
 	// delete objects
 	deleted, err := keeper.DeleteDiscontinueObjectsUntil(ctx, blockTime, deletionMax)
 	if err != nil {

--- a/x/storage/keeper/payment_test.go
+++ b/x/storage/keeper/payment_test.go
@@ -1,9 +1,10 @@
 package keeper_test
 
 import (
-	paymenttypes "github.com/bnb-chain/greenfield/x/payment/types"
 	"testing"
 	"time"
+
+	paymenttypes "github.com/bnb-chain/greenfield/x/payment/types"
 
 	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"

--- a/x/storage/keeper/payment_test.go
+++ b/x/storage/keeper/payment_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	paymenttypes "github.com/bnb-chain/greenfield/x/payment/types"
 	"testing"
 	"time"
 
@@ -137,6 +138,21 @@ func (s *IntegrationTestSuiteWithoutMock) TestCreateCreateBucket_Payment() {
 	readRate := primaryStorePriceRes.ReadPrice.MulInt(sdk.NewIntFromUint64(ChargedReadQuota)).TruncateInt()
 	s.T().Logf("primarySpRateDiff: %s, expectedRate: %s, readRate: %s", primarySpRateDiff, expectedRate, readRate)
 	s.Require().Equal(expectedRate.String(), primarySpRateDiff.String())
+
+	// force delete
+	err = s.depKeepers.PaymentKeeper.ForceSettle(ctx, userStreamRecordSealObject)
+	s.Require().NoError(err)
+	s.depKeepers.PaymentKeeper.SetStreamRecord(ctx, userStreamRecordSealObject)
+	userStreamRecordSealObject, found = s.depKeepers.PaymentKeeper.GetStreamRecord(ctx, s.UserAddr)
+	s.Require().True(found)
+	s.T().Logf("userStreamRecordSealObject: %+v", userStreamRecordSealObject)
+	s.Require().Equal(userStreamRecordSealObject.Status, paymenttypes.STREAM_ACCOUNT_STATUS_FROZEN)
+	bucket.ChargedReadQuota += 100000000
+	err = s.keeper.ChargeDeleteObject(ctx, &bucket, &object)
+	s.Require().ErrorContains(err, "is frozen")
+	ctx = ctx.WithValue(paymenttypes.ForceUpdateFrozenStreamRecordKey, true)
+	err = s.keeper.ChargeDeleteObject(ctx, &bucket, &object)
+	s.Require().NoError(err)
 }
 
 func TestKeeperTestSuiteWithoutMock(t *testing.T) {


### PR DESCRIPTION
### Description

Fix the bug that force delete will fail when the payment address is frozen.

### Rationale

Previously, if an account was frozen, any changes to the stream would fail. To prevent this scenario, where an SP might force delete objects or buckets, we added a flag to the context, allowing this action in this specific instance.

### Example

NA

### Changes

NA
