### PR TITLE
fix: fail to force delete when the payment addr is frozen

### DIFF
--- a/x/payment/types/types.go
+++ b/x/payment/types/types.go
@@ -10,3 +10,7 @@ var (
 	GovernanceAddress       = sdk.AccAddress(address.Module(ModuleName, []byte("governance"))[:sdk.EthAddressLength])
 	ValidatorTaxPoolAddress = sdk.AccAddress(address.Module(ModuleName, []byte("validator-tax-pool"))[:sdk.EthAddressLength])
 )
+
+const (
+	ForceUpdateFrozenStreamRecordKey = "force_update_frozen_stream_record"
+)

--- a/x/storage/abci.go
+++ b/x/storage/abci.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	paymenttypes "github.com/bnb-chain/greenfield/x/payment/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	k "github.com/bnb-chain/greenfield/x/storage/keeper"
@@ -22,6 +23,8 @@ func EndBlocker(ctx sdk.Context, keeper k.Keeper) {
 	}
 
 	blockTime := ctx.BlockTime().Unix()
+	// set ForceUpdateFrozenStreamRecordKey to true in context to force update frozen stream record
+	ctx = ctx.WithValue(paymenttypes.ForceUpdateFrozenStreamRecordKey, true)
 	// delete objects
 	deleted, err := keeper.DeleteDiscontinueObjectsUntil(ctx, blockTime, deletionMax)
 	if err != nil {


### PR DESCRIPTION
### Description

This pr merges develop to master, to fix an issue: https://github.com/bnb-chain/greenfield/pull/264

### Rationale

Bug fix, for more information, please refer to https://github.com/bnb-chain/greenfield/pull/264

### Example

NA

### Changes

Notable changes: 
* frozen account deletion
