### PR TITLE
fix: check every module's Msg

### DIFF
--- a/x/bridge/types/codec.go
+++ b/x/bridge/types/codec.go
@@ -16,6 +16,9 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 	registry.RegisterImplementations((*sdk.Msg)(nil),
 		&MsgTransferOut{},
 	)
+	registry.RegisterImplementations((*sdk.Msg)(nil),
+		&MsgUpdateParams{},
+	)
 	// this line is used by starport scaffolding # 3
 
 	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)

--- a/x/challenge/types/codec.go
+++ b/x/challenge/types/codec.go
@@ -20,6 +20,9 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 	registry.RegisterImplementations((*sdk.Msg)(nil),
 		&MsgAttest{},
 	)
+	registry.RegisterImplementations((*sdk.Msg)(nil),
+		&MsgUpdateParams{},
+	)
 	// this line is used by starport scaffolding # 3
 
 	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)

--- a/x/payment/types/codec.go
+++ b/x/payment/types/codec.go
@@ -28,6 +28,9 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 	registry.RegisterImplementations((*sdk.Msg)(nil),
 		&MsgDisableRefund{},
 	)
+	registry.RegisterImplementations((*sdk.Msg)(nil),
+		&MsgUpdateParams{},
+	)
 	// this line is used by starport scaffolding # 3
 
 	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)

--- a/x/permission/types/codec.go
+++ b/x/permission/types/codec.go
@@ -3,6 +3,7 @@ package types
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 )
 
@@ -12,6 +13,9 @@ func RegisterCodec(cdc *codec.LegacyAmino) {
 
 func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 	// this line is used by starport scaffolding # 3
+	registry.RegisterImplementations((*sdk.Msg)(nil),
+		&MsgUpdateParams{},
+	)
 
 	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)
 }

--- a/x/sp/types/codec.go
+++ b/x/sp/types/codec.go
@@ -14,7 +14,6 @@ func RegisterCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(&MsgEditStorageProvider{}, "sp/EditStorageProvider", nil)
 	cdc.RegisterConcrete(&MsgUpdateSpStoragePrice{}, "sp/UpdateSpStoragePrice", nil)
 	cdc.RegisterConcrete(&DepositAuthorization{}, "sp/DepositAuthorization", nil)
-	cdc.RegisterConcrete(&MsgUpdateParams{}, "sp/MsgUpdateParams", nil)
 	// this line is used by starport scaffolding # 2
 }
 

--- a/x/sp/types/codec.go
+++ b/x/sp/types/codec.go
@@ -30,6 +30,10 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 	registry.RegisterImplementations((*sdk.Msg)(nil),
 		&MsgUpdateSpStoragePrice{},
 	)
+	registry.RegisterImplementations((*sdk.Msg)(nil),
+		&MsgUpdateParams{},
+	)
+
 	registry.RegisterImplementations(
 		(*authz.Authorization)(nil),
 		&DepositAuthorization{},

--- a/x/sp/types/codec.go
+++ b/x/sp/types/codec.go
@@ -14,6 +14,7 @@ func RegisterCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(&MsgEditStorageProvider{}, "sp/EditStorageProvider", nil)
 	cdc.RegisterConcrete(&MsgUpdateSpStoragePrice{}, "sp/UpdateSpStoragePrice", nil)
 	cdc.RegisterConcrete(&DepositAuthorization{}, "sp/DepositAuthorization", nil)
+	cdc.RegisterConcrete(&MsgUpdateParams{}, "sp/MsgUpdateParams", nil)
 	// this line is used by starport scaffolding # 2
 }
 

--- a/x/sp/types/message.go
+++ b/x/sp/types/message.go
@@ -15,9 +15,11 @@ const (
 
 var (
 	_ sdk.Msg = &MsgCreateStorageProvider{}
-	_ sdk.Msg = &MsgEditStorageProvider{}
 	_ sdk.Msg = &MsgDeposit{}
+
+	_ sdk.Msg = &MsgEditStorageProvider{}
 	_ sdk.Msg = &MsgUpdateSpStoragePrice{}
+	_ sdk.Msg = &MsgUpdateParams{}
 )
 
 // NewMsgCreateStorageProvider creates a new MsgCreateStorageProvider instance.

--- a/x/storage/types/codec.go
+++ b/x/storage/types/codec.go
@@ -72,6 +72,10 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 	registry.RegisterImplementations((*sdk.Msg)(nil),
 		&MsgDeletePolicy{},
 	)
+
+	registry.RegisterImplementations((*sdk.Msg)(nil),
+		&MsgUpdateParams{},
+	)
 	// this line is used by starport scaffolding # 3
 
 	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)

--- a/x/storage/types/codec.go
+++ b/x/storage/types/codec.go
@@ -34,6 +34,16 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 		&MsgDeleteBucket{},
 	)
 	registry.RegisterImplementations((*sdk.Msg)(nil),
+		&MsgUpdateBucketInfo{},
+	)
+	registry.RegisterImplementations((*sdk.Msg)(nil),
+		&MsgMirrorBucket{},
+	)
+	registry.RegisterImplementations((*sdk.Msg)(nil),
+		&MsgDiscontinueBucket{},
+	)
+
+	registry.RegisterImplementations((*sdk.Msg)(nil),
 		&MsgCreateObject{},
 	)
 	registry.RegisterImplementations((*sdk.Msg)(nil),
@@ -43,8 +53,24 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 		&MsgRejectSealObject{},
 	)
 	registry.RegisterImplementations((*sdk.Msg)(nil),
+		&MsgCopyObject{},
+	)
+	registry.RegisterImplementations((*sdk.Msg)(nil),
 		&MsgDeleteObject{},
 	)
+	registry.RegisterImplementations((*sdk.Msg)(nil),
+		&MsgCancelCreateObject{},
+	)
+	registry.RegisterImplementations((*sdk.Msg)(nil),
+		&MsgMirrorObject{},
+	)
+	registry.RegisterImplementations((*sdk.Msg)(nil),
+		&MsgDiscontinueObject{},
+	)
+	registry.RegisterImplementations((*sdk.Msg)(nil),
+		&MsgUpdateObjectInfo{},
+	)
+
 	registry.RegisterImplementations((*sdk.Msg)(nil),
 		&MsgCreateGroup{},
 	)
@@ -61,13 +87,11 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 		&MsgLeaveGroup{},
 	)
 	registry.RegisterImplementations((*sdk.Msg)(nil),
-		&MsgCopyObject{},
+		&MsgMirrorGroup{},
 	)
+
 	registry.RegisterImplementations((*sdk.Msg)(nil),
-		&MsgUpdateBucketInfo{},
-	)
-	registry.RegisterImplementations((*sdk.Msg)(nil),
-		&MsgCancelCreateObject{},
+		&MsgPutPolicy{},
 	)
 	registry.RegisterImplementations((*sdk.Msg)(nil),
 		&MsgDeletePolicy{},

--- a/x/storage/types/codec.go
+++ b/x/storage/types/codec.go
@@ -23,6 +23,7 @@ func RegisterCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(&MsgUpdateBucketInfo{}, "storage/UpdateBucketInfo", nil)
 	cdc.RegisterConcrete(&MsgCancelCreateObject{}, "storage/CancelCreateObject", nil)
 	cdc.RegisterConcrete(&MsgDeletePolicy{}, "storage/DeletePolicy", nil)
+	cdc.RegisterConcrete(&MsgUpdateParams{}, "storage/MsgUpdateParams", nil)
 	// this line is used by starport scaffolding # 2
 }
 

--- a/x/storage/types/codec.go
+++ b/x/storage/types/codec.go
@@ -23,7 +23,6 @@ func RegisterCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(&MsgUpdateBucketInfo{}, "storage/UpdateBucketInfo", nil)
 	cdc.RegisterConcrete(&MsgCancelCreateObject{}, "storage/CancelCreateObject", nil)
 	cdc.RegisterConcrete(&MsgDeletePolicy{}, "storage/DeletePolicy", nil)
-	cdc.RegisterConcrete(&MsgUpdateParams{}, "storage/MsgUpdateParams", nil)
 	// this line is used by starport scaffolding # 2
 }
 

--- a/x/storage/types/message.go
+++ b/x/storage/types/message.go
@@ -64,22 +64,25 @@ var (
 	_ sdk.Msg = &MsgDeleteBucket{}
 	_ sdk.Msg = &MsgUpdateBucketInfo{}
 	_ sdk.Msg = &MsgMirrorBucket{}
+	_ sdk.Msg = &MsgDiscontinueBucket{}
 
 	// For object
 	_ sdk.Msg = &MsgCreateObject{}
-	_ sdk.Msg = &MsgDeleteObject{}
 	_ sdk.Msg = &MsgSealObject{}
-	_ sdk.Msg = &MsgCopyObject{}
 	_ sdk.Msg = &MsgRejectSealObject{}
+	_ sdk.Msg = &MsgCopyObject{}
+	_ sdk.Msg = &MsgDeleteObject{}
 	_ sdk.Msg = &MsgCancelCreateObject{}
 	_ sdk.Msg = &MsgMirrorObject{}
+	_ sdk.Msg = &MsgDiscontinueObject{}
+	_ sdk.Msg = &MsgUpdateObjectInfo{}
 
 	// For group
 	_ sdk.Msg = &MsgCreateGroup{}
 	_ sdk.Msg = &MsgDeleteGroup{}
-	_ sdk.Msg = &MsgLeaveGroup{}
 	_ sdk.Msg = &MsgUpdateGroupMember{}
 	_ sdk.Msg = &MsgUpdateGroupExtra{}
+	_ sdk.Msg = &MsgLeaveGroup{}
 	_ sdk.Msg = &MsgMirrorGroup{}
 
 	// For permission policy


### PR DESCRIPTION
### Description

check every module‘s Msg implementation:

- Whether msg is added to the `RegisterInterfaces` method
- `RegisterCodec` is obsolete and has not been processed yet
- Check that all msgs implement the interface of `sdk.Msg`


### Rationale

they were used by GreenfieldScan.

### Example

NA

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
