### PR TITLE
feat: allow user to pass keyManager into Txopt

### DIFF
--- a/e2e/core/basesuite.go
+++ b/e2e/core/basesuite.go
@@ -8,13 +8,14 @@ import (
 	"time"
 
 	"cosmossdk.io/math"
-	"github.com/bnb-chain/greenfield/sdk/client"
-	"github.com/bnb-chain/greenfield/sdk/keys"
-	"github.com/bnb-chain/greenfield/sdk/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/tx"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/bnb-chain/greenfield/sdk/client"
+	"github.com/bnb-chain/greenfield/sdk/keys"
+	"github.com/bnb-chain/greenfield/sdk/types"
 )
 
 type SPKeyManagers struct {

--- a/e2e/tests/eip712_test.go
+++ b/e2e/tests/eip712_test.go
@@ -5,10 +5,11 @@ import (
 	"math"
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/bnb-chain/greenfield/e2e/core"
 	storageutils "github.com/bnb-chain/greenfield/testutil/storage"
 	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
-	"github.com/stretchr/testify/suite"
 )
 
 type Eip712TestSuite struct {

--- a/sdk/client/tx.go
+++ b/sdk/client/tx.go
@@ -131,9 +131,9 @@ func (c *GreenfieldClient) signTx(ctx context.Context, txConfig client.TxConfig,
 	} else {
 		if hasOverrideAccount {
 			account, err = c.getAccountByAddr(km.GetAddr())
-		}
-		if err != nil {
-			return nil, err
+			if err != nil {
+				return nil, err
+			}
 		}
 		nonce = account.GetSequence()
 	}

--- a/sdk/client/tx.go
+++ b/sdk/client/tx.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"github.com/bnb-chain/greenfield/sdk/keys"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	clitx "github.com/cosmos/cosmos-sdk/client/tx"
@@ -14,6 +13,7 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"google.golang.org/grpc"
 
+	"github.com/bnb-chain/greenfield/sdk/keys"
 	"github.com/bnb-chain/greenfield/sdk/types"
 )
 

--- a/sdk/client/tx.go
+++ b/sdk/client/tx.go
@@ -260,7 +260,11 @@ func (c *GreenfieldClient) constructTxWithGasInfo(ctx context.Context, msgs []sd
 }
 
 func (c *GreenfieldClient) GetNonce() (uint64, error) {
-	account, err := c.GetAccountByAddr(c.keyManager.GetAddr())
+	km, err := c.GetKeyManager()
+	if err != nil {
+		return 0, err
+	}
+	account, err := c.GetAccountByAddr(km.GetAddr())
 	if err != nil {
 		return 0, err
 	}

--- a/sdk/client/tx.go
+++ b/sdk/client/tx.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+
 	"github.com/bnb-chain/greenfield/sdk/keys"
 
 	"github.com/cosmos/cosmos-sdk/client"

--- a/sdk/client/tx_test.go
+++ b/sdk/client/tx_test.go
@@ -161,19 +161,14 @@ func TestSendTokenWithOverrideAccount(t *testing.T) {
 	assert.NoError(t, err)
 	mode := tx.BroadcastMode_BROADCAST_MODE_SYNC
 	feeAmt := sdk.NewCoins(sdk.NewCoin("BNB", sdk.NewInt(int64(10000000000000)))) // gasPrice * gasLimit
-	accountNum := uint64(1)
-	acct := types.Account{
-		Num: &accountNum,
-		Km:  &km2,
-	}
 	txOpt := &types.TxOption{
-		Mode:            &mode,
-		NoSimulate:      true,
-		GasLimit:        2000,
-		Memo:            "test",
-		FeePayer:        payerAddr,
-		FeeAmount:       feeAmt, // 2000 * 5000000000
-		OverrideAccount: &acct,
+		Mode:               &mode,
+		NoSimulate:         true,
+		GasLimit:           2000,
+		Memo:               "test",
+		FeePayer:           payerAddr,
+		FeeAmount:          feeAmt, // 2000 * 5000000000
+		OverrideKeyManager: &km2,
 	}
 	response, err := gnfdCli.BroadcastTx(context.Background(), []sdk.Msg{transfer}, txOpt)
 	assert.NoError(t, err)

--- a/sdk/client/tx_test.go
+++ b/sdk/client/tx_test.go
@@ -141,3 +141,41 @@ func TestSendTxWithGrpcConn(t *testing.T) {
 	assert.Equal(t, uint32(0), response.TxResponse.Code)
 	t.Log(response.TxResponse.String())
 }
+
+func TestSendTokenWithOverrideAccount(t *testing.T) {
+
+	// which is not being used to send tx
+	km, err := keys.NewPrivateKeyManager("2a3f0f19fbcb057e053696879207324c24f601ab47db92676cc4958ea9089761")
+	assert.NoError(t, err)
+	gnfdCli, err := NewGreenfieldClient(test.TEST_RPC_ADDR, test.TEST_CHAIN_ID, WithKeyManager(km))
+
+	km2, err := keys.NewPrivateKeyManager(test.TEST_PRIVATE_KEY)
+	assert.NoError(t, err)
+
+	assert.NoError(t, err)
+	to, err := sdk.AccAddressFromHexUnsafe(test.TEST_ADDR)
+	assert.NoError(t, err)
+	transfer := banktypes.NewMsgSend(km2.GetAddr(), to, sdk.NewCoins(sdk.NewInt64Coin(test.TEST_TOKEN_NAME, 100)))
+	payerAddr, err := sdk.AccAddressFromHexUnsafe(km2.GetAddr().String())
+	assert.NoError(t, err)
+	mode := tx.BroadcastMode_BROADCAST_MODE_SYNC
+	feeAmt := sdk.NewCoins(sdk.NewCoin("BNB", sdk.NewInt(int64(10000000000000)))) // gasPrice * gasLimit
+	accountNum := uint64(1)
+	acct := types.Account{
+		Num: &accountNum,
+		Km:  &km2,
+	}
+	txOpt := &types.TxOption{
+		Mode:            &mode,
+		NoSimulate:      true,
+		GasLimit:        2000,
+		Memo:            "test",
+		FeePayer:        payerAddr,
+		FeeAmount:       feeAmt, // 2000 * 5000000000
+		OverrideAccount: &acct,
+	}
+	response, err := gnfdCli.BroadcastTx(context.Background(), []sdk.Msg{transfer}, txOpt)
+	assert.NoError(t, err)
+	assert.Equal(t, uint32(0), response.TxResponse.Code)
+	t.Log(response.TxResponse.String())
+}

--- a/sdk/client/tx_test.go
+++ b/sdk/client/tx_test.go
@@ -148,6 +148,7 @@ func TestSendTokenWithOverrideAccount(t *testing.T) {
 	km, err := keys.NewPrivateKeyManager("2a3f0f19fbcb057e053696879207324c24f601ab47db92676cc4958ea9089761")
 	assert.NoError(t, err)
 	gnfdCli, err := NewGreenfieldClient(test.TEST_RPC_ADDR, test.TEST_CHAIN_ID, WithKeyManager(km))
+	assert.NoError(t, err)
 
 	km2, err := keys.NewPrivateKeyManager(test.TEST_PRIVATE_KEY)
 	assert.NoError(t, err)

--- a/sdk/types/types.go
+++ b/sdk/types/types.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"github.com/bnb-chain/greenfield/sdk/keys"
 	"math/big"
 
 	sdkmath "cosmossdk.io/math"
@@ -19,15 +20,21 @@ const (
 )
 
 type TxOption struct {
-	Mode       *tx.BroadcastMode
-	NoSimulate bool
-	GasLimit   uint64
-	FeeAmount  sdk.Coins
-	Nonce      uint64
-	FeePayer   sdk.AccAddress
-	FeeGranter sdk.AccAddress
-	Tip        *tx.Tip
-	Memo       string
+	Mode            *tx.BroadcastMode
+	NoSimulate      bool
+	GasLimit        uint64
+	FeeAmount       sdk.Coins
+	Nonce           uint64
+	FeePayer        sdk.AccAddress
+	FeeGranter      sdk.AccAddress
+	Tip             *tx.Tip
+	Memo            string
+	OverrideAccount *Account
+}
+
+type Account struct {
+	Num *uint64
+	Km  *keys.KeyManager
 }
 
 func NewIntFromInt64WithDecimal(amount int64, decimal int64) sdkmath.Int {

--- a/sdk/types/types.go
+++ b/sdk/types/types.go
@@ -21,21 +21,16 @@ const (
 )
 
 type TxOption struct {
-	Mode            *tx.BroadcastMode
-	NoSimulate      bool
-	GasLimit        uint64
-	FeeAmount       sdk.Coins
-	Nonce           uint64
-	FeePayer        sdk.AccAddress
-	FeeGranter      sdk.AccAddress
-	Tip             *tx.Tip
-	Memo            string
-	OverrideAccount *Account
-}
-
-type Account struct {
-	Num *uint64
-	Km  *keys.KeyManager
+	Mode               *tx.BroadcastMode
+	NoSimulate         bool
+	GasLimit           uint64
+	FeeAmount          sdk.Coins
+	Nonce              uint64
+	FeePayer           sdk.AccAddress
+	FeeGranter         sdk.AccAddress
+	Tip                *tx.Tip
+	Memo               string
+	OverrideKeyManager *keys.KeyManager
 }
 
 func NewIntFromInt64WithDecimal(amount int64, decimal int64) sdkmath.Int {

--- a/sdk/types/types.go
+++ b/sdk/types/types.go
@@ -1,12 +1,13 @@
 package types
 
 import (
-	"github.com/bnb-chain/greenfield/sdk/keys"
 	"math/big"
 
 	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/tx"
+
+	"github.com/bnb-chain/greenfield/sdk/keys"
 )
 
 const (

--- a/x/storage/abci.go
+++ b/x/storage/abci.go
@@ -1,9 +1,9 @@
 package storage
 
 import (
-	paymenttypes "github.com/bnb-chain/greenfield/x/payment/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	paymenttypes "github.com/bnb-chain/greenfield/x/payment/types"
 	k "github.com/bnb-chain/greenfield/x/storage/keeper"
 )
 

--- a/x/storage/keeper/payment_test.go
+++ b/x/storage/keeper/payment_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 	"time"
 
-	paymenttypes "github.com/bnb-chain/greenfield/x/payment/types"
-
 	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -14,6 +12,7 @@ import (
 
 	keepertest "github.com/bnb-chain/greenfield/testutil/keeper"
 	"github.com/bnb-chain/greenfield/testutil/sample"
+	paymenttypes "github.com/bnb-chain/greenfield/x/payment/types"
 	sptypes "github.com/bnb-chain/greenfield/x/sp/types"
 	"github.com/bnb-chain/greenfield/x/storage/keeper"
 	"github.com/bnb-chain/greenfield/x/storage/types"


### PR DESCRIPTION
### Description

add `keyManager` into txOpt, so that allow large batch of txs sent by single client

### Rationale

batch tx sending when switching account

### Example

NA

### Changes

Notable changes: 
* NA
