### PR TITLE
fix: update storage discontinue param's default value

### DIFF
--- a/x/storage/keeper/keeper.go
+++ b/x/storage/keeper/keeper.go
@@ -1455,7 +1455,7 @@ func (k Keeper) appendDiscontinueBucketIds(ctx sdk.Context, timestamp int64, buc
 	store.Set(key, k.cdc.MustMarshal(&types.Ids{Id: bucketIds}))
 }
 
-func (k Keeper) DeleteDiscontinueBucketsUntil(ctx sdk.Context, timestamp int64, maxObjectsToDelete uint64) (uint64, error) {
+func (k Keeper) DeleteDiscontinueBucketsUntil(ctx sdk.Context, timestamp int64, maxToDelete uint64) (uint64, error) {
 	store := ctx.KVStore(k.storeKey)
 	key := types.GetDiscontinueBucketIdsKey(timestamp)
 	iterator := store.Iterator(types.DiscontinueBucketIdsPrefix, storetypes.InclusiveEndBytes(key))
@@ -1463,7 +1463,7 @@ func (k Keeper) DeleteDiscontinueBucketsUntil(ctx sdk.Context, timestamp int64, 
 
 	deleted := uint64(0)
 	for ; iterator.Valid(); iterator.Next() {
-		if deleted >= maxObjectsToDelete {
+		if deleted >= maxToDelete {
 			break
 		}
 		var ids types.Ids
@@ -1471,12 +1471,12 @@ func (k Keeper) DeleteDiscontinueBucketsUntil(ctx sdk.Context, timestamp int64, 
 
 		left := make([]types.Uint, 0)
 		for _, id := range ids.Id {
-			if deleted >= maxObjectsToDelete {
+			if deleted >= maxToDelete {
 				left = append(left, id)
 				continue
 			}
 
-			bucketDeleted, objectDeleted, err := k.ForceDeleteBucket(ctx, id, maxObjectsToDelete-deleted)
+			bucketDeleted, objectDeleted, err := k.ForceDeleteBucket(ctx, id, maxToDelete-deleted)
 			if err != nil {
 				ctx.Logger().Error("force delete bucket error", "err", err)
 				return deleted, err
@@ -1485,6 +1485,8 @@ func (k Keeper) DeleteDiscontinueBucketsUntil(ctx sdk.Context, timestamp int64, 
 
 			if !bucketDeleted {
 				left = append(left, id)
+			} else {
+				deleted++
 			}
 		}
 		if len(left) > 0 {

--- a/x/storage/types/params.go
+++ b/x/storage/types/params.go
@@ -21,7 +21,7 @@ const (
 	DefaultDiscontinueObjectMax      uint64 = math.MaxUint64
 	DefaultDiscontinueBucketMax      uint64 = math.MaxUint64
 	DefaultDiscontinueConfirmPeriod  int64  = 604800 // 7 days (in second)
-	DefaultDiscontinueDeletionMax    uint64 = 10000
+	DefaultDiscontinueDeletionMax    uint64 = 100
 	DefaultStalePolicyCleanupMax     uint64 = 200
 
 	DefaultMirrorBucketRelayerFee    = "250000000000000" // 0.00025


### PR DESCRIPTION
### Description

Update the default value for the parameter `DiscontinueDeletionMax`, which stands for the max objects can be deleted in one block for stop serving.

### Rationale

The previous is too big, considering the content of payment/deletion events is too big.

### Example

NA
### Changes

Notable changes: 
* parameter
