### PR TITLE
feat: replace rlp with abi.encode in cross-chain transfer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -181,6 +181,6 @@ replace (
 	github.com/btcsuite/btcd => github.com/btcsuite/btcd v0.23.0
 	github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v0.0.1
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3-alpha.1
+	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3-alpha.1.0.20230705070958-bd8637d81e30
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 )

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,8 @@ github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edY
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
 github.com/bnb-chain/greenfield-cometbft v0.0.1 h1:pX8S9oZKjWJCrxH07l6rbU3zee9txZ11+UwO9stsNMQ=
 github.com/bnb-chain/greenfield-cometbft v0.0.1/go.mod h1:9q11eHNRY9FDwFH+4pompzPNGv//Z3VcfvkELaHJPMs=
-github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3-alpha.1 h1:woVNr3N+h/dY7sTZaKscTHARJv4RHLh0+qhniqkF734=
-github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3-alpha.1/go.mod h1:ePxSdTXosDo5YE9TRxqzmXv8T0PH7AVqTfofRf81aRo=
+github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3-alpha.1.0.20230705070958-bd8637d81e30 h1:EXzLVm9zERcbCJOnhBaJ+S4UJbwUi4iAyfgbBQdO9K0=
+github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3-alpha.1.0.20230705070958-bd8637d81e30/go.mod h1:ePxSdTXosDo5YE9TRxqzmXv8T0PH7AVqTfofRf81aRo=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230425074444-eb5869b05fe9 h1:6fLpmmI0EZvDTfPvI0zy5dBaaTUboHnEkoC5/p/w8TQ=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230425074444-eb5869b05fe9/go.mod h1:rbc4o84RSEvhf09o2+4Qiazsv0snRJLiEZdk17HeIDw=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230425074444-eb5869b05fe9 h1:1ZdK+iR1Up02bOa2YTZCml7PBpP//kcdamOcK6aWO/s=

--- a/x/bridge/keeper/cross_app_test.go
+++ b/x/bridge/keeper/cross_app_test.go
@@ -5,7 +5,6 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/cosmos/cosmos-sdk/bsc/rlp"
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -72,7 +71,7 @@ func (s *TestSuite) TestTransferOutAck() {
 		RefundReason: 1,
 	}
 
-	packageBytes, err := rlp.EncodeToBytes(&refundPackage)
+	packageBytes, err := refundPackage.Serialize()
 	s.Require().Nil(err, "encode refund package error")
 
 	transferOutApp := keeper.NewTransferOutApp(*s.bridgeKeeper)
@@ -94,7 +93,7 @@ func (s *TestSuite) TestTransferOutFailAck() {
 		RefundAddress: addr1,
 	}
 
-	packageBytes, err := rlp.EncodeToBytes(&synPackage)
+	packageBytes, err := synPackage.Serialize()
 	s.Require().Nil(err, "encode refund package error")
 
 	transferOutApp := keeper.NewTransferOutApp(*s.bridgeKeeper)
@@ -172,7 +171,7 @@ func (s *TestSuite) TestTransferInSyn() {
 		RefundAddress:   sdk.AccAddress{1},
 	}
 
-	packageBytes, err := rlp.EncodeToBytes(&transferInSynPackage)
+	packageBytes, err := transferInSynPackage.Serialize()
 	s.Require().Nil(err, "encode refund package error")
 
 	transferInApp := keeper.NewTransferInApp(*s.bridgeKeeper)

--- a/x/bridge/keeper/keeper.go
+++ b/x/bridge/keeper/keeper.go
@@ -5,7 +5,6 @@ import (
 
 	"cosmossdk.io/errors"
 	"github.com/cometbft/cometbft/libs/log"
-	"github.com/cosmos/cosmos-sdk/bsc/rlp"
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -59,7 +58,7 @@ func (k Keeper) GetRefundTransferInPayload(transferInClaim *types.TransferInSynP
 		RefundReason:  refundReason,
 	}
 
-	encodedBytes, err := rlp.EncodeToBytes(refundPackage)
+	encodedBytes, err := refundPackage.Serialize()
 	if err != nil {
 		return nil, errors.Wrapf(types.ErrInvalidPackage, "encode refund package error")
 	}

--- a/x/bridge/keeper/msg_server_transfer_out.go
+++ b/x/bridge/keeper/msg_server_transfer_out.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"cosmossdk.io/errors"
-	"github.com/cosmos/cosmos-sdk/bsc/rlp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	crosschaintypes "github.com/cosmos/cosmos-sdk/x/crosschain/types"
 
@@ -42,7 +41,7 @@ func (k msgServer) TransferOut(goCtx context.Context, msg *types.MsgTransferOut)
 		Amount:        msg.Amount.Amount.BigInt(),
 	}
 
-	encodedPackage, err := rlp.EncodeToBytes(transferPackage)
+	encodedPackage, err := transferPackage.Serialize()
 	if err != nil {
 		return nil, errors.Wrapf(types.ErrInvalidPackage, "encode transfer out package error")
 	}

--- a/x/bridge/types/types.go
+++ b/x/bridge/types/types.go
@@ -19,6 +19,13 @@ const (
 	SyncParamsChannelID                = types.SyncParamsChannelID
 )
 
+func SafeBigInt(input *big.Int) *big.Int {
+	if input == nil {
+		return big.NewInt(0)
+	}
+	return input
+}
+
 type TransferOutSynPackage struct {
 	Amount        *big.Int
 	Recipient     sdk.AccAddress
@@ -45,7 +52,7 @@ var (
 
 func (pkg *TransferOutSynPackage) Serialize() ([]byte, error) {
 	return transferOutSynPackageArgs.Pack(&TransferOutSynPackageStruct{
-		pkg.Amount,
+		SafeBigInt(pkg.Amount),
 		common.BytesToAddress(pkg.Recipient),
 		common.BytesToAddress(pkg.RefundAddress),
 	})
@@ -97,7 +104,7 @@ var (
 
 func (pkg *TransferOutRefundPackage) Serialize() ([]byte, error) {
 	return transferOutRefundPackageArgs.Pack(&TransferOutRefundPackageStruct{
-		pkg.RefundAmount,
+		SafeBigInt(pkg.RefundAmount),
 		common.BytesToAddress(pkg.RefundAddr),
 		pkg.RefundReason,
 	})
@@ -149,7 +156,7 @@ var (
 
 func (pkg *TransferInSynPackage) Serialize() ([]byte, error) {
 	return transferInSynPackageArgs.Pack(&TransferInSynPackageStruct{
-		pkg.Amount,
+		SafeBigInt(pkg.Amount),
 		common.BytesToAddress(pkg.ReceiverAddress),
 		common.BytesToAddress(pkg.RefundAddress),
 	})
@@ -201,7 +208,7 @@ var (
 
 func (pkg *TransferInRefundPackage) Serialize() ([]byte, error) {
 	return transferInRefundPackageArgs.Pack(&TransferInRefundPackageStruct{
-		pkg.RefundAmount,
+		SafeBigInt(pkg.RefundAmount),
 		common.BytesToAddress(pkg.RefundAddress),
 		pkg.RefundReason,
 	})

--- a/x/bridge/types/types.go
+++ b/x/bridge/types/types.go
@@ -4,9 +4,10 @@ import (
 	"math/big"
 
 	"cosmossdk.io/errors"
-	"github.com/cosmos/cosmos-sdk/bsc/rlp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/gov/types"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 const (
@@ -24,11 +25,48 @@ type TransferOutSynPackage struct {
 	RefundAddress sdk.AccAddress
 }
 
+type TransferOutSynPackageStruct struct {
+	Amount        *big.Int
+	Recipient     common.Address
+	RefundAddress common.Address
+}
+
+var (
+	transferOutSynPackageType, _ = abi.NewType("tuple", "", []abi.ArgumentMarshaling{
+		{Name: "Amount", Type: "uint256"},
+		{Name: "Recipient", Type: "address"},
+		{Name: "RefundAddress", Type: "address"},
+	})
+
+	transferOutSynPackageArgs = abi.Arguments{
+		{Type: transferOutSynPackageType},
+	}
+)
+
+func (pkg *TransferOutSynPackage) Serialize() ([]byte, error) {
+	return transferOutSynPackageArgs.Pack(&TransferOutSynPackageStruct{
+		pkg.Amount,
+		common.BytesToAddress(pkg.Recipient),
+		common.BytesToAddress(pkg.RefundAddress),
+	})
+}
+
 func DeserializeTransferOutSynPackage(serializedPackage []byte) (*TransferOutSynPackage, error) {
-	var tp TransferOutSynPackage
-	err := rlp.DecodeBytes(serializedPackage, &tp)
+	unpacked, err := transferOutSynPackageArgs.Unpack(serializedPackage)
 	if err != nil {
-		return nil, errors.Wrapf(ErrInvalidPackage, "deserialize transfer out package failed")
+		return nil, errors.Wrapf(ErrInvalidPackage, "deserialize transfer out sync package failed")
+	}
+
+	unpackedStruct := abi.ConvertType(unpacked[0], TransferOutSynPackageStruct{})
+	pkgStruct, ok := unpackedStruct.(TransferOutSynPackageStruct)
+	if !ok {
+		return nil, errors.Wrapf(ErrInvalidPackage, "reflect transfer out sync package failed")
+	}
+
+	tp := TransferOutSynPackage{
+		pkgStruct.Amount,
+		pkgStruct.Recipient.Bytes(),
+		pkgStruct.RefundAddress.Bytes(),
 	}
 	return &tp, nil
 }
@@ -39,11 +77,48 @@ type TransferOutRefundPackage struct {
 	RefundReason uint32
 }
 
+type TransferOutRefundPackageStruct struct {
+	RefundAmount *big.Int
+	RefundAddr   common.Address
+	RefundReason uint32
+}
+
+var (
+	transferOutRefundPackageType, _ = abi.NewType("tuple", "", []abi.ArgumentMarshaling{
+		{Name: "RefundAmount", Type: "uint256"},
+		{Name: "RefundAddr", Type: "address"},
+		{Name: "RefundReason", Type: "uint32"},
+	})
+
+	transferOutRefundPackageArgs = abi.Arguments{
+		{Type: transferOutRefundPackageType},
+	}
+)
+
+func (pkg *TransferOutRefundPackage) Serialize() ([]byte, error) {
+	return transferOutRefundPackageArgs.Pack(&TransferOutRefundPackageStruct{
+		pkg.RefundAmount,
+		common.BytesToAddress(pkg.RefundAddr),
+		pkg.RefundReason,
+	})
+}
+
 func DeserializeTransferOutRefundPackage(serializedPackage []byte) (*TransferOutRefundPackage, error) {
-	var tp TransferOutRefundPackage
-	err := rlp.DecodeBytes(serializedPackage, &tp)
+	unpacked, err := transferOutRefundPackageArgs.Unpack(serializedPackage)
 	if err != nil {
 		return nil, errors.Wrapf(ErrInvalidPackage, "deserialize transfer out refund package failed")
+	}
+
+	unpackedStruct := abi.ConvertType(unpacked[0], TransferOutRefundPackageStruct{})
+	pkgStruct, ok := unpackedStruct.(TransferOutRefundPackageStruct)
+	if !ok {
+		return nil, errors.Wrapf(ErrInvalidPackage, "reflect transfer out refund package failed")
+	}
+
+	tp := TransferOutRefundPackage{
+		pkgStruct.RefundAmount,
+		pkgStruct.RefundAddr.Bytes(),
+		pkgStruct.RefundReason,
 	}
 	return &tp, nil
 }
@@ -54,12 +129,48 @@ type TransferInSynPackage struct {
 	RefundAddress   sdk.AccAddress
 }
 
-func DeserializeTransferInSynPackage(serializedPackage []byte) (*TransferInSynPackage, error) {
-	var tp TransferInSynPackage
-	err := rlp.DecodeBytes(serializedPackage, &tp)
-	if err != nil {
-		return nil, errors.Wrapf(ErrInvalidPackage, "deserialize transfer in package failed")
+type TransferInSynPackageStruct struct {
+	Amount          *big.Int
+	ReceiverAddress common.Address
+	RefundAddress   common.Address
+}
 
+var (
+	transferInSynPackageType, _ = abi.NewType("tuple", "", []abi.ArgumentMarshaling{
+		{Name: "Amount", Type: "uint256"},
+		{Name: "ReceiverAddress", Type: "address"},
+		{Name: "RefundAddress", Type: "address"},
+	})
+
+	transferInSynPackageArgs = abi.Arguments{
+		{Type: transferInSynPackageType},
+	}
+)
+
+func (pkg *TransferInSynPackage) Serialize() ([]byte, error) {
+	return transferInSynPackageArgs.Pack(&TransferInSynPackageStruct{
+		pkg.Amount,
+		common.BytesToAddress(pkg.ReceiverAddress),
+		common.BytesToAddress(pkg.RefundAddress),
+	})
+}
+
+func DeserializeTransferInSynPackage(serializedPackage []byte) (*TransferInSynPackage, error) {
+	unpacked, err := transferInSynPackageArgs.Unpack(serializedPackage)
+	if err != nil {
+		return nil, errors.Wrapf(ErrInvalidPackage, "deserialize transfer in sync package failed")
+	}
+
+	unpackedStruct := abi.ConvertType(unpacked[0], TransferInSynPackageStruct{})
+	pkgStruct, ok := unpackedStruct.(TransferInSynPackageStruct)
+	if !ok {
+		return nil, errors.Wrapf(ErrInvalidPackage, "reflect transfer in sync package failed")
+	}
+
+	tp := TransferInSynPackage{
+		pkgStruct.Amount,
+		pkgStruct.ReceiverAddress.Bytes(),
+		pkgStruct.RefundAddress.Bytes(),
 	}
 	return &tp, nil
 }
@@ -68,4 +179,30 @@ type TransferInRefundPackage struct {
 	RefundAmount  *big.Int
 	RefundAddress sdk.AccAddress
 	RefundReason  uint32
+}
+
+type TransferInRefundPackageStruct struct {
+	RefundAmount  *big.Int
+	RefundAddress common.Address
+	RefundReason  uint32
+}
+
+var (
+	transferInRefundPackageType, _ = abi.NewType("tuple", "", []abi.ArgumentMarshaling{
+		{Name: "RefundAmount", Type: "uint256"},
+		{Name: "RefundAddr", Type: "address"},
+		{Name: "RefundReason", Type: "uint32"},
+	})
+
+	transferInRefundPackageArgs = abi.Arguments{
+		{Type: transferInRefundPackageType},
+	}
+)
+
+func (pkg *TransferInRefundPackage) Serialize() ([]byte, error) {
+	return transferInRefundPackageArgs.Pack(&TransferInRefundPackageStruct{
+		pkg.RefundAmount,
+		common.BytesToAddress(pkg.RefundAddress),
+		pkg.RefundReason,
+	})
 }

--- a/x/permission/types/common.go
+++ b/x/permission/types/common.go
@@ -1,10 +1,10 @@
 package types
 
 import (
-	"github.com/bnb-chain/greenfield/types"
-
 	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/bnb-chain/greenfield/types"
 )
 
 func NewPrincipalWithAccount(addr sdk.AccAddress) *Principal {

--- a/x/storage/keeper/cross_app_bucket.go
+++ b/x/storage/keeper/cross_app_bucket.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 
 	"cosmossdk.io/math"
-	"github.com/cosmos/cosmos-sdk/bsc/rlp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/bnb-chain/greenfield/x/storage/types"
@@ -50,11 +49,7 @@ func (app *BucketApp) ExecuteAckPackage(ctx sdk.Context, appCtx *sdk.CrossChainA
 			OperationType: operationType,
 			Package:       result.Payload,
 		}
-		wrapPayloadBts, err := rlp.EncodeToBytes(wrapPayload)
-		if err != nil {
-			panic(err)
-		}
-		result.Payload = wrapPayloadBts
+		result.Payload = wrapPayload.MustSerialize()
 	}
 
 	return result
@@ -88,11 +83,7 @@ func (app *BucketApp) ExecuteFailAckPackage(ctx sdk.Context, appCtx *sdk.CrossCh
 			OperationType: operationType,
 			Package:       result.Payload,
 		}
-		wrapPayloadBts, err := rlp.EncodeToBytes(wrapPayload)
-		if err != nil {
-			panic(err)
-		}
-		result.Payload = wrapPayloadBts
+		result.Payload = wrapPayload.MustSerialize()
 	}
 
 	return result
@@ -126,11 +117,7 @@ func (app *BucketApp) ExecuteSynPackage(ctx sdk.Context, appCtx *sdk.CrossChainA
 			OperationType: operationType,
 			Package:       result.Payload,
 		}
-		wrapPayloadBts, err := rlp.EncodeToBytes(wrapPayload)
-		if err != nil {
-			panic(err)
-		}
-		result.Payload = wrapPayloadBts
+		result.Payload = wrapPayload.MustSerialize()
 	}
 
 	return result

--- a/x/storage/keeper/cross_app_group.go
+++ b/x/storage/keeper/cross_app_group.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 
 	"cosmossdk.io/math"
-	"github.com/cosmos/cosmos-sdk/bsc/rlp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/bnb-chain/greenfield/x/storage/types"
@@ -53,11 +52,7 @@ func (app *GroupApp) ExecuteAckPackage(ctx sdk.Context, appCtx *sdk.CrossChainAp
 			OperationType: operationType,
 			Package:       result.Payload,
 		}
-		wrapPayloadBts, err := rlp.EncodeToBytes(wrapPayload)
-		if err != nil {
-			panic(err)
-		}
-		result.Payload = wrapPayloadBts
+		result.Payload = wrapPayload.MustSerialize()
 	}
 
 	return result
@@ -94,11 +89,7 @@ func (app *GroupApp) ExecuteFailAckPackage(ctx sdk.Context, appCtx *sdk.CrossCha
 			OperationType: operationType,
 			Package:       result.Payload,
 		}
-		wrapPayloadBts, err := rlp.EncodeToBytes(wrapPayload)
-		if err != nil {
-			panic(err)
-		}
-		result.Payload = wrapPayloadBts
+		result.Payload = wrapPayload.MustSerialize()
 	}
 
 	return result
@@ -137,11 +128,7 @@ func (app *GroupApp) ExecuteSynPackage(ctx sdk.Context, appCtx *sdk.CrossChainAp
 			OperationType: operationType,
 			Package:       result.Payload,
 		}
-		wrapPayloadBts, err := rlp.EncodeToBytes(wrapPayload)
-		if err != nil {
-			panic(err)
-		}
-		result.Payload = wrapPayloadBts
+		result.Payload = wrapPayload.MustSerialize()
 	}
 
 	return result

--- a/x/storage/keeper/cross_app_object.go
+++ b/x/storage/keeper/cross_app_object.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 
 	"cosmossdk.io/math"
-	"github.com/cosmos/cosmos-sdk/bsc/rlp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/bnb-chain/greenfield/x/storage/types"
@@ -48,11 +47,7 @@ func (app *ObjectApp) ExecuteAckPackage(ctx sdk.Context, appCtx *sdk.CrossChainA
 			OperationType: operationType,
 			Package:       result.Payload,
 		}
-		wrapPayloadBts, err := rlp.EncodeToBytes(wrapPayload)
-		if err != nil {
-			panic(err)
-		}
-		result.Payload = wrapPayloadBts
+		result.Payload = wrapPayload.MustSerialize()
 	}
 
 	return result
@@ -83,11 +78,7 @@ func (app *ObjectApp) ExecuteFailAckPackage(ctx sdk.Context, appCtx *sdk.CrossCh
 			OperationType: operationType,
 			Package:       result.Payload,
 		}
-		wrapPayloadBts, err := rlp.EncodeToBytes(wrapPayload)
-		if err != nil {
-			panic(err)
-		}
-		result.Payload = wrapPayloadBts
+		result.Payload = wrapPayload.MustSerialize()
 	}
 
 	return result
@@ -119,11 +110,7 @@ func (app *ObjectApp) ExecuteSynPackage(ctx sdk.Context, appCtx *sdk.CrossChainA
 			OperationType: operationType,
 			Package:       result.Payload,
 		}
-		wrapPayloadBts, err := rlp.EncodeToBytes(wrapPayload)
-		if err != nil {
-			panic(err)
-		}
-		result.Payload = wrapPayloadBts
+		result.Payload = wrapPayload.MustSerialize()
 	}
 
 	return result

--- a/x/storage/keeper/msg_server.go
+++ b/x/storage/keeper/msg_server.go
@@ -5,7 +5,6 @@ import (
 
 	"cosmossdk.io/errors"
 	errorsmod "cosmossdk.io/errors"
-	"github.com/cosmos/cosmos-sdk/bsc/rlp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
@@ -411,7 +410,7 @@ func (k msgServer) MirrorObject(goCtx context.Context, msg *types.MsgMirrorObjec
 		Owner: owner,
 	}
 
-	encodedPackage, err := rlp.EncodeToBytes(mirrorPackage)
+	encodedPackage, err := mirrorPackage.Serialize()
 	if err != nil {
 		return nil, types.ErrInvalidCrossChainPackage
 	}
@@ -420,10 +419,7 @@ func (k msgServer) MirrorObject(goCtx context.Context, msg *types.MsgMirrorObjec
 		OperationType: types.OperationMirrorObject,
 		Package:       encodedPackage,
 	}
-	encodedWrapPackage, err := rlp.EncodeToBytes(wrapPackage)
-	if err != nil {
-		return nil, types.ErrInvalidCrossChainPackage
-	}
+	encodedWrapPackage := wrapPackage.MustSerialize()
 
 	relayerFee := k.Keeper.MirrorObjectRelayerFee(ctx)
 	ackRelayerFee := k.Keeper.MirrorObjectAckRelayerFee(ctx)
@@ -483,7 +479,7 @@ func (k msgServer) MirrorBucket(goCtx context.Context, msg *types.MsgMirrorBucke
 		Owner: owner,
 	}
 
-	encodedPackage, err := rlp.EncodeToBytes(mirrorPackage)
+	encodedPackage, err := mirrorPackage.Serialize()
 	if err != nil {
 		return nil, types.ErrInvalidCrossChainPackage
 	}
@@ -492,10 +488,7 @@ func (k msgServer) MirrorBucket(goCtx context.Context, msg *types.MsgMirrorBucke
 		OperationType: types.OperationMirrorBucket,
 		Package:       encodedPackage,
 	}
-	encodedWrapPackage, err := rlp.EncodeToBytes(wrapPackage)
-	if err != nil {
-		return nil, types.ErrInvalidCrossChainPackage
-	}
+	encodedWrapPackage := wrapPackage.MustSerialize()
 
 	relayerFee := k.Keeper.MirrorBucketRelayerFee(ctx)
 	ackRelayerFee := k.Keeper.MirrorBucketAckRelayerFee(ctx)
@@ -550,7 +543,7 @@ func (k msgServer) MirrorGroup(goCtx context.Context, msg *types.MsgMirrorGroup)
 		Owner: operator,
 	}
 
-	encodedPackage, err := rlp.EncodeToBytes(mirrorPackage)
+	encodedPackage, err := mirrorPackage.Serialize()
 	if err != nil {
 		return nil, types.ErrInvalidCrossChainPackage
 	}
@@ -559,10 +552,7 @@ func (k msgServer) MirrorGroup(goCtx context.Context, msg *types.MsgMirrorGroup)
 		OperationType: types.OperationMirrorGroup,
 		Package:       encodedPackage,
 	}
-	encodedWrapPackage, err := rlp.EncodeToBytes(wrapPackage)
-	if err != nil {
-		return nil, types.ErrInvalidCrossChainPackage
-	}
+	encodedWrapPackage := wrapPackage.MustSerialize()
 
 	relayerFee := k.Keeper.MirrorGroupRelayerFee(ctx)
 	ackRelayerFee := k.Keeper.MirrorGroupAckRelayerFee(ctx)

--- a/x/storage/types/crosschain.go
+++ b/x/storage/types/crosschain.go
@@ -39,6 +39,13 @@ const (
 	OperationUpdateGroupMember uint8 = 4
 )
 
+func SafeBigInt(input *big.Int) *big.Int {
+	if input == nil {
+		return big.NewInt(0)
+	}
+	return input
+}
+
 type CrossChainPackage struct {
 	OperationType uint8
 	Package       []byte
@@ -172,7 +179,7 @@ var (
 
 func (pkg *MirrorBucketSynPackage) Serialize() ([]byte, error) {
 	return generalMirrorSynPackageArgs.Pack(&GeneralMirrorSynPackageStruct{
-		pkg.Id,
+		SafeBigInt(pkg.Id),
 		common.BytesToAddress(pkg.Owner),
 	})
 }
@@ -205,7 +212,10 @@ func DeserializeMirrorBucketSynPackage(serializedPackage []byte) (interface{}, e
 }
 
 func (pkg *MirrorBucketAckPackage) Serialize() ([]byte, error) {
-	return generalMirrorAckPackageArgs.Pack(pkg)
+	return generalMirrorAckPackageArgs.Pack(&MirrorBucketAckPackage{
+		pkg.Status,
+		SafeBigInt(pkg.Id),
+	})
 }
 
 func DeserializeMirrorBucketAckPackage(serializedPackage []byte) (interface{}, error) {
@@ -235,7 +245,7 @@ type MirrorObjectAckPackage struct {
 
 func (pkg *MirrorObjectSynPackage) Serialize() ([]byte, error) {
 	return generalMirrorSynPackageArgs.Pack(&GeneralMirrorSynPackageStruct{
-		pkg.Id,
+		SafeBigInt(pkg.Id),
 		common.BytesToAddress(pkg.Owner),
 	})
 }
@@ -254,7 +264,10 @@ func DeserializeMirrorObjectSynPackage(serializedPackage []byte) (interface{}, e
 }
 
 func (pkg *MirrorObjectAckPackage) Serialize() ([]byte, error) {
-	return generalMirrorAckPackageArgs.Pack(pkg)
+	return generalMirrorAckPackageArgs.Pack(&MirrorObjectAckPackage{
+		pkg.Status,
+		SafeBigInt(pkg.Id),
+	})
 }
 
 func DeserializeMirrorObjectAckPackage(serializedPackage []byte) (interface{}, error) {
@@ -284,7 +297,7 @@ type MirrorGroupAckPackage struct {
 
 func (pkg *MirrorGroupSynPackage) Serialize() ([]byte, error) {
 	return generalMirrorSynPackageArgs.Pack(&GeneralMirrorSynPackageStruct{
-		pkg.Id,
+		SafeBigInt(pkg.Id),
 		common.BytesToAddress(pkg.Owner),
 	})
 }
@@ -303,7 +316,10 @@ func DeserializeMirrorGroupSynPackage(serializedPackage []byte) (interface{}, er
 }
 
 func (pkg *MirrorGroupAckPackage) Serialize() ([]byte, error) {
-	return generalMirrorAckPackageArgs.Pack(pkg)
+	return generalMirrorAckPackageArgs.Pack(&MirrorGroupAckPackage{
+		pkg.Status,
+		SafeBigInt(pkg.Id),
+	})
 }
 
 func DeserializeMirrorGroupAckPackage(serializedPackage []byte) (interface{}, error) {
@@ -452,7 +468,7 @@ var (
 func (p CreateBucketAckPackage) MustSerialize() []byte {
 	encodedBytes, err := generalCreateAckPackageArgs.Pack(&GeneralCreateAckPackageStruct{
 		Status:    p.Status,
-		Id:        p.Id,
+		Id:        SafeBigInt(p.Id),
 		Creator:   common.BytesToAddress(p.Creator),
 		ExtraData: p.ExtraData,
 	})
@@ -556,7 +572,11 @@ var (
 )
 
 func (p DeleteBucketAckPackage) MustSerialize() []byte {
-	encodedBytes, err := generalCreateAckPackageArgs.Pack(&p)
+	encodedBytes, err := generalCreateAckPackageArgs.Pack(&DeleteBucketAckPackage{
+		p.Status,
+		SafeBigInt(p.Id),
+		p.ExtraData,
+	})
 	if err != nil {
 		panic("encode delete bucket ack package error")
 	}
@@ -639,7 +659,7 @@ type CreateGroupAckPackage struct {
 func (p CreateGroupAckPackage) MustSerialize() []byte {
 	encodedBytes, err := generalCreateAckPackageArgs.Pack(&GeneralCreateAckPackageStruct{
 		Status:    p.Status,
-		Id:        p.Id,
+		Id:        SafeBigInt(p.Id),
 		Creator:   common.BytesToAddress(p.Creator),
 		ExtraData: p.ExtraData,
 	})
@@ -713,7 +733,11 @@ type DeleteObjectAckPackage struct {
 }
 
 func (p DeleteObjectAckPackage) MustSerialize() []byte {
-	encodedBytes, err := generalDeleteAckPackageArgs.Pack(&p)
+	encodedBytes, err := generalDeleteAckPackageArgs.Pack(&DeleteObjectAckPackage{
+		p.Status,
+		SafeBigInt(p.Id),
+		p.ExtraData,
+	})
 	if err != nil {
 		panic("encode delete object ack package error")
 	}
@@ -791,7 +815,11 @@ func DeserializeDeleteGroupAckPackage(serializedPackage []byte) (interface{}, er
 }
 
 func (p DeleteGroupAckPackage) MustSerialize() []byte {
-	encodedBytes, err := generalDeleteAckPackageArgs.Pack(&p)
+	encodedBytes, err := generalDeleteAckPackageArgs.Pack(&DeleteGroupAckPackage{
+		p.Status,
+		SafeBigInt(p.Id),
+		p.ExtraData,
+	})
 	if err != nil {
 		panic("encode delete group ack package error")
 	}
@@ -958,7 +986,7 @@ func (p UpdateGroupMemberAckPackage) MustSerialize() []byte {
 
 	encodedBytes, err := updateGroupMemberAckPackageArgs.Pack(&UpdateGroupMemberAckPackageStruct{
 		p.Status,
-		p.Id,
+		SafeBigInt(p.Id),
 		common.BytesToAddress(p.Operator),
 		p.OperationType,
 		members,

--- a/x/storage/types/crosschain.go
+++ b/x/storage/types/crosschain.go
@@ -44,38 +44,16 @@ type CrossChainPackage struct {
 	Package       []byte
 }
 
-var (
-	crossChainPackageType, _ = abi.NewType("tuple", "", []abi.ArgumentMarshaling{
-		{Name: "OperationType", Type: "uint8"},
-		{Name: "Package", Type: "bytes"},
-	})
-
-	crossChainPackageArgs = abi.Arguments{
-		{Type: crossChainPackageType},
-	}
-)
-
 func (p CrossChainPackage) MustSerialize() []byte {
-	encodedBytes, err := crossChainPackageArgs.Pack(&p)
-	if err != nil {
-		panic("encode delete cross chain package error")
-	}
-	return encodedBytes
+	return append([]byte{p.OperationType}, p.Package...)
 }
 
 func DeserializeRawCrossChainPackage(serializedPackage []byte) (*CrossChainPackage, error) {
-	unpacked, err := crossChainPackageArgs.Unpack(serializedPackage)
-	if err != nil {
-		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "deserialize raw cross chain package failed")
+	tp := CrossChainPackage{
+		OperationType: serializedPackage[0],
+		Package:       serializedPackage[1:],
 	}
-
-	unpackedStruct := abi.ConvertType(unpacked[0], CrossChainPackage{})
-	pkgStruct, ok := unpackedStruct.(CrossChainPackage)
-	if !ok {
-		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "reflect raw cross chain package failed")
-	}
-
-	return &pkgStruct, nil
+	return &tp, nil
 }
 
 type DeserializeFunc func(serializedPackage []byte) (interface{}, error)

--- a/x/storage/types/crosschain.go
+++ b/x/storage/types/crosschain.go
@@ -4,9 +4,10 @@ import (
 	"math/big"
 
 	"cosmossdk.io/errors"
-	"github.com/cosmos/cosmos-sdk/bsc/rlp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 const (
@@ -43,8 +44,19 @@ type CrossChainPackage struct {
 	Package       []byte
 }
 
+var (
+	crossChainPackageType, _ = abi.NewType("tuple", "", []abi.ArgumentMarshaling{
+		{Name: "OperationType", Type: "uint8"},
+		{Name: "Package", Type: "bytes"},
+	})
+
+	crossChainPackageArgs = abi.Arguments{
+		{Type: crossChainPackageType},
+	}
+)
+
 func (p CrossChainPackage) MustSerialize() []byte {
-	encodedBytes, err := rlp.EncodeToBytes(p)
+	encodedBytes, err := crossChainPackageArgs.Pack(&p)
 	if err != nil {
 		panic("encode delete cross chain package error")
 	}
@@ -52,12 +64,18 @@ func (p CrossChainPackage) MustSerialize() []byte {
 }
 
 func DeserializeRawCrossChainPackage(serializedPackage []byte) (*CrossChainPackage, error) {
-	var tp CrossChainPackage
-	err := rlp.DecodeBytes(serializedPackage, &tp)
+	unpacked, err := crossChainPackageArgs.Unpack(serializedPackage)
 	if err != nil {
 		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "deserialize raw cross chain package failed")
 	}
-	return &tp, nil
+
+	unpackedStruct := abi.ConvertType(unpacked[0], CrossChainPackage{})
+	pkgStruct, ok := unpackedStruct.(CrossChainPackage)
+	if !ok {
+		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "reflect raw cross chain package failed")
+	}
+
+	return &pkgStruct, nil
 }
 
 type DeserializeFunc func(serializedPackage []byte) (interface{}, error)
@@ -144,26 +162,86 @@ type MirrorBucketSynPackage struct {
 	Owner sdk.AccAddress
 }
 
+type GeneralMirrorSynPackageStruct struct {
+	Id    *big.Int
+	Owner common.Address
+}
+
 type MirrorBucketAckPackage struct {
 	Status uint8
 	Id     *big.Int
 }
 
-func DeserializeMirrorBucketSynPackage(serializedPackage []byte) (interface{}, error) {
-	var tp MirrorBucketSynPackage
-	err := rlp.DecodeBytes(serializedPackage, &tp)
+var (
+	generalMirrorSynPackageStructType, _ = abi.NewType("tuple", "", []abi.ArgumentMarshaling{
+		{Name: "Id", Type: "uint256"},
+		{Name: "Owner", Type: "address"},
+	})
+
+	generalMirrorSynPackageArgs = abi.Arguments{
+		{Type: generalMirrorSynPackageStructType},
+	}
+
+	generalMirrorAckPackageType, _ = abi.NewType("tuple", "", []abi.ArgumentMarshaling{
+		{Name: "Status", Type: "uint8"},
+		{Name: "Id", Type: "uint256"},
+	})
+
+	generalMirrorAckPackageArgs = abi.Arguments{
+		{Type: generalMirrorAckPackageType},
+	}
+)
+
+func (pkg *MirrorBucketSynPackage) Serialize() ([]byte, error) {
+	return generalMirrorSynPackageArgs.Pack(&GeneralMirrorSynPackageStruct{
+		pkg.Id,
+		common.BytesToAddress(pkg.Owner),
+	})
+}
+
+func deserializeMirrorSynPackage(serializedPackage []byte) (*GeneralMirrorSynPackageStruct, error) {
+	unpacked, err := generalMirrorSynPackageArgs.Unpack(serializedPackage)
 	if err != nil {
-		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "deserialize mirror bucket syn package failed")
+		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "deserialize mirror syn package failed")
+	}
+
+	unpackedStruct := abi.ConvertType(unpacked[0], GeneralMirrorSynPackageStruct{})
+	pkgStruct, ok := unpackedStruct.(GeneralMirrorSynPackageStruct)
+	if !ok {
+		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "reflect mirror syn package failed")
+	}
+	return &pkgStruct, nil
+}
+
+func DeserializeMirrorBucketSynPackage(serializedPackage []byte) (interface{}, error) {
+	pkgStruct, err := deserializeMirrorSynPackage(serializedPackage)
+	if err != nil {
+		return nil, err
+	}
+
+	tp := MirrorBucketSynPackage{
+		pkgStruct.Id,
+		pkgStruct.Owner.Bytes(),
 	}
 	return &tp, nil
 }
 
+func (pkg *MirrorBucketAckPackage) Serialize() ([]byte, error) {
+	return generalMirrorAckPackageArgs.Pack(pkg)
+}
+
 func DeserializeMirrorBucketAckPackage(serializedPackage []byte) (interface{}, error) {
-	var tp MirrorBucketAckPackage
-	err := rlp.DecodeBytes(serializedPackage, &tp)
+	unpacked, err := generalMirrorAckPackageArgs.Unpack(serializedPackage)
 	if err != nil {
 		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "deserialize mirror bucket ack package failed")
 	}
+
+	unpackedStruct := abi.ConvertType(unpacked[0], MirrorBucketAckPackage{})
+	tp, ok := unpackedStruct.(MirrorBucketAckPackage)
+	if !ok {
+		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "reflect mirror bucket ack package failed")
+	}
+
 	return &tp, nil
 }
 
@@ -177,21 +255,42 @@ type MirrorObjectAckPackage struct {
 	Id     *big.Int
 }
 
+func (pkg *MirrorObjectSynPackage) Serialize() ([]byte, error) {
+	return generalMirrorSynPackageArgs.Pack(&GeneralMirrorSynPackageStruct{
+		pkg.Id,
+		common.BytesToAddress(pkg.Owner),
+	})
+}
+
 func DeserializeMirrorObjectSynPackage(serializedPackage []byte) (interface{}, error) {
-	var tp MirrorObjectSynPackage
-	err := rlp.DecodeBytes(serializedPackage, &tp)
+	pkgStruct, err := deserializeMirrorSynPackage(serializedPackage)
 	if err != nil {
-		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "deserialize mirror object syn package failed")
+		return nil, err
+	}
+
+	tp := MirrorObjectSynPackage{
+		pkgStruct.Id,
+		pkgStruct.Owner.Bytes(),
 	}
 	return &tp, nil
 }
 
+func (pkg *MirrorObjectAckPackage) Serialize() ([]byte, error) {
+	return generalMirrorAckPackageArgs.Pack(pkg)
+}
+
 func DeserializeMirrorObjectAckPackage(serializedPackage []byte) (interface{}, error) {
-	var tp MirrorObjectAckPackage
-	err := rlp.DecodeBytes(serializedPackage, &tp)
+	unpacked, err := generalMirrorAckPackageArgs.Unpack(serializedPackage)
 	if err != nil {
 		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "deserialize mirror object ack package failed")
 	}
+
+	unpackedStruct := abi.ConvertType(unpacked[0], MirrorObjectAckPackage{})
+	tp, ok := unpackedStruct.(MirrorObjectAckPackage)
+	if !ok {
+		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "reflect mirror object ack package failed")
+	}
+
 	return &tp, nil
 }
 
@@ -205,21 +304,42 @@ type MirrorGroupAckPackage struct {
 	Id     *big.Int
 }
 
+func (pkg *MirrorGroupSynPackage) Serialize() ([]byte, error) {
+	return generalMirrorSynPackageArgs.Pack(&GeneralMirrorSynPackageStruct{
+		pkg.Id,
+		common.BytesToAddress(pkg.Owner),
+	})
+}
+
 func DeserializeMirrorGroupSynPackage(serializedPackage []byte) (interface{}, error) {
-	var tp MirrorGroupSynPackage
-	err := rlp.DecodeBytes(serializedPackage, &tp)
+	pkgStruct, err := deserializeMirrorSynPackage(serializedPackage)
 	if err != nil {
-		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "deserialize mirror group syn package failed")
+		return nil, err
+	}
+
+	tp := MirrorGroupSynPackage{
+		pkgStruct.Id,
+		pkgStruct.Owner.Bytes(),
 	}
 	return &tp, nil
 }
 
+func (pkg *MirrorGroupAckPackage) Serialize() ([]byte, error) {
+	return generalMirrorAckPackageArgs.Pack(pkg)
+}
+
 func DeserializeMirrorGroupAckPackage(serializedPackage []byte) (interface{}, error) {
-	var tp MirrorGroupAckPackage
-	err := rlp.DecodeBytes(serializedPackage, &tp)
+	unpacked, err := generalMirrorAckPackageArgs.Unpack(serializedPackage)
 	if err != nil {
 		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "deserialize mirror group ack package failed")
 	}
+
+	unpackedStruct := abi.ConvertType(unpacked[0], MirrorGroupAckPackage{})
+	tp, ok := unpackedStruct.(MirrorGroupAckPackage)
+	if !ok {
+		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "reflect mirror group ack package failed")
+	}
+
 	return &tp, nil
 }
 
@@ -234,6 +354,36 @@ type CreateBucketSynPackage struct {
 	ChargedReadQuota               uint64
 	ExtraData                      []byte
 }
+
+type CreateBucketSynPackageStruct struct {
+	Creator                        common.Address
+	BucketName                     string
+	Visibility                     uint32
+	PaymentAddress                 common.Address
+	PrimarySpAddress               common.Address
+	PrimarySpApprovalExpiredHeight uint64
+	PrimarySpApprovalSignature     []byte
+	ChargedReadQuota               uint64
+	ExtraData                      []byte
+}
+
+var (
+	createBucketSynPackageStructType, _ = abi.NewType("tuple", "", []abi.ArgumentMarshaling{
+		{Name: "Creator", Type: "address"},
+		{Name: "BucketName", Type: "string"},
+		{Name: "Visibility", Type: "uint32"},
+		{Name: "PaymentAddress", Type: "address"},
+		{Name: "PrimarySpAddress", Type: "address"},
+		{Name: "PrimarySpApprovalExpiredHeight", Type: "uint64"},
+		{Name: "PrimarySpApprovalSignature", Type: "bytes"},
+		{Name: "ChargedReadQuota", Type: "uint64"},
+		{Name: "ExtraData", Type: "bytes"},
+	})
+
+	createBucketSynPackageStructArgs = abi.Arguments{
+		{Type: createBucketSynPackageStructType},
+	}
+)
 
 func (p CreateBucketSynPackage) ValidateBasic() error {
 	msg := MsgCreateBucket{
@@ -269,10 +419,27 @@ func (p CreateBucketSynPackage) GetApprovalBytes() []byte {
 }
 
 func DeserializeCreateBucketSynPackage(serializedPackage []byte) (interface{}, error) {
-	var tp CreateBucketSynPackage
-	err := rlp.DecodeBytes(serializedPackage, &tp)
+	unpacked, err := createBucketSynPackageStructArgs.Unpack(serializedPackage)
 	if err != nil {
 		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "deserialize create bucket syn package failed")
+	}
+
+	unpackedStruct := abi.ConvertType(unpacked[0], CreateBucketSynPackageStruct{})
+	pkgStruct, ok := unpackedStruct.(CreateBucketSynPackageStruct)
+	if !ok {
+		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "reflect create bucket syn package failed")
+	}
+
+	tp := CreateBucketSynPackage{
+		pkgStruct.Creator.Bytes(),
+		pkgStruct.BucketName,
+		pkgStruct.Visibility,
+		pkgStruct.PaymentAddress.Bytes(),
+		pkgStruct.PrimarySpAddress.Bytes(),
+		pkgStruct.PrimarySpApprovalExpiredHeight,
+		pkgStruct.PrimarySpApprovalSignature,
+		pkgStruct.ChargedReadQuota,
+		pkgStruct.ExtraData,
 	}
 	return &tp, nil
 }
@@ -284,8 +451,33 @@ type CreateBucketAckPackage struct {
 	ExtraData []byte
 }
 
+type GeneralCreateAckPackageStruct struct {
+	Status    uint8
+	Id        *big.Int
+	Creator   common.Address
+	ExtraData []byte
+}
+
+var (
+	generalCreateAckPackageType, _ = abi.NewType("tuple", "", []abi.ArgumentMarshaling{
+		{Name: "Status", Type: "uint8"},
+		{Name: "Id", Type: "uint256"},
+		{Name: "Creator", Type: "address"},
+		{Name: "ExtraData", Type: "bytes"},
+	})
+
+	generalCreateAckPackageArgs = abi.Arguments{
+		{Type: generalCreateAckPackageType},
+	}
+)
+
 func (p CreateBucketAckPackage) MustSerialize() []byte {
-	encodedBytes, err := rlp.EncodeToBytes(p)
+	encodedBytes, err := generalCreateAckPackageArgs.Pack(&GeneralCreateAckPackageStruct{
+		Status:    p.Status,
+		Id:        p.Id,
+		Creator:   common.BytesToAddress(p.Creator),
+		ExtraData: p.ExtraData,
+	})
 	if err != nil {
 		panic("encode create bucket ack package error")
 	}
@@ -293,10 +485,22 @@ func (p CreateBucketAckPackage) MustSerialize() []byte {
 }
 
 func DeserializeCreateBucketAckPackage(serializedPackage []byte) (interface{}, error) {
-	var tp CreateBucketAckPackage
-	err := rlp.DecodeBytes(serializedPackage, &tp)
+	unpacked, err := generalCreateAckPackageArgs.Unpack(serializedPackage)
 	if err != nil {
 		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "deserialize create bucket ack package failed")
+	}
+
+	unpackedStruct := abi.ConvertType(unpacked[0], GeneralCreateAckPackageStruct{})
+	pkgStruct, ok := unpackedStruct.(GeneralCreateAckPackageStruct)
+	if !ok {
+		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "reflect create bucket ack package failed")
+	}
+
+	tp := CreateBucketAckPackage{
+		Status:    pkgStruct.Status,
+		Id:        pkgStruct.Id,
+		Creator:   pkgStruct.Creator.Bytes(),
+		ExtraData: pkgStruct.ExtraData,
 	}
 	return &tp, nil
 }
@@ -306,6 +510,24 @@ type DeleteBucketSynPackage struct {
 	Id        *big.Int
 	ExtraData []byte
 }
+
+type GeneralDeleteSynPackageStruct struct {
+	Operator  common.Address
+	Id        *big.Int
+	ExtraData []byte
+}
+
+var (
+	generalDeleteSynPackageType, _ = abi.NewType("tuple", "", []abi.ArgumentMarshaling{
+		{Name: "Operator", Type: "address"},
+		{Name: "Id", Type: "uint256"},
+		{Name: "ExtraData", Type: "bytes"},
+	})
+
+	generalDeleteSynPackageArgs = abi.Arguments{
+		{Type: generalDeleteSynPackageType},
+	}
+)
 
 func (p DeleteBucketSynPackage) ValidateBasic() error {
 	if p.Operator.Empty() {
@@ -318,10 +540,21 @@ func (p DeleteBucketSynPackage) ValidateBasic() error {
 }
 
 func DeserializeDeleteBucketSynPackage(serializedPackage []byte) (interface{}, error) {
-	var tp DeleteBucketSynPackage
-	err := rlp.DecodeBytes(serializedPackage, &tp)
+	unpacked, err := generalDeleteSynPackageArgs.Unpack(serializedPackage)
 	if err != nil {
 		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "deserialize delete bucket syn package failed")
+	}
+
+	unpackedStruct := abi.ConvertType(unpacked[0], GeneralDeleteSynPackageStruct{})
+	pkgStruct, ok := unpackedStruct.(GeneralDeleteSynPackageStruct)
+	if !ok {
+		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "reflect delete bucket syn package failed")
+	}
+
+	tp := DeleteBucketSynPackage{
+		Operator:  pkgStruct.Operator.Bytes(),
+		Id:        pkgStruct.Id,
+		ExtraData: pkgStruct.ExtraData,
 	}
 	return &tp, nil
 }
@@ -332,8 +565,20 @@ type DeleteBucketAckPackage struct {
 	ExtraData []byte
 }
 
+var (
+	generalDeleteAckPackageType, _ = abi.NewType("tuple", "", []abi.ArgumentMarshaling{
+		{Name: "Status", Type: "uint8"},
+		{Name: "Id", Type: "uint256"},
+		{Name: "ExtraData", Type: "bytes"},
+	})
+
+	generalDeleteAckPackageArgs = abi.Arguments{
+		{Type: generalDeleteAckPackageType},
+	}
+)
+
 func (p DeleteBucketAckPackage) MustSerialize() []byte {
-	encodedBytes, err := rlp.EncodeToBytes(p)
+	encodedBytes, err := generalCreateAckPackageArgs.Pack(&p)
 	if err != nil {
 		panic("encode delete bucket ack package error")
 	}
@@ -341,10 +586,15 @@ func (p DeleteBucketAckPackage) MustSerialize() []byte {
 }
 
 func DeserializeDeleteBucketAckPackage(serializedPackage []byte) (interface{}, error) {
-	var tp DeleteBucketAckPackage
-	err := rlp.DecodeBytes(serializedPackage, &tp)
+	unpacked, err := generalDeleteAckPackageArgs.Unpack(serializedPackage)
 	if err != nil {
 		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "deserialize delete bucket ack package failed")
+	}
+
+	unpackedStruct := abi.ConvertType(unpacked[0], DeleteBucketAckPackage{})
+	tp, ok := unpackedStruct.(DeleteBucketAckPackage)
+	if !ok {
+		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "reflect delete bucket ack package failed")
 	}
 	return &tp, nil
 }
@@ -355,6 +605,24 @@ type CreateGroupSynPackage struct {
 	ExtraData []byte
 }
 
+type CreateGroupSynPackageStruct struct {
+	Creator   common.Address
+	GroupName string
+	ExtraData []byte
+}
+
+var (
+	createGroupSynPackageType, _ = abi.NewType("tuple", "", []abi.ArgumentMarshaling{
+		{Name: "Creator", Type: "address"},
+		{Name: "GroupName", Type: "string"},
+		{Name: "ExtraData", Type: "bytes"},
+	})
+
+	createGroupSynPackageArgs = abi.Arguments{
+		{Type: createGroupSynPackageType},
+	}
+)
+
 func (p CreateGroupSynPackage) ValidateBasic() error {
 	msg := MsgCreateGroup{
 		Creator:   p.Creator.String(),
@@ -364,10 +632,21 @@ func (p CreateGroupSynPackage) ValidateBasic() error {
 }
 
 func DeserializeCreateGroupSynPackage(serializedPackage []byte) (interface{}, error) {
-	var tp CreateGroupSynPackage
-	err := rlp.DecodeBytes(serializedPackage, &tp)
+	unpacked, err := createGroupSynPackageArgs.Unpack(serializedPackage)
 	if err != nil {
 		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "deserialize create group syn package failed")
+	}
+
+	unpackedStruct := abi.ConvertType(unpacked[0], CreateGroupSynPackageStruct{})
+	pkgStruct, ok := unpackedStruct.(CreateGroupSynPackageStruct)
+	if !ok {
+		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "reflect create group syn package failed")
+	}
+
+	tp := CreateGroupSynPackage{
+		pkgStruct.Creator.Bytes(),
+		pkgStruct.GroupName,
+		pkgStruct.ExtraData,
 	}
 	return &tp, nil
 }
@@ -380,7 +659,12 @@ type CreateGroupAckPackage struct {
 }
 
 func (p CreateGroupAckPackage) MustSerialize() []byte {
-	encodedBytes, err := rlp.EncodeToBytes(p)
+	encodedBytes, err := generalCreateAckPackageArgs.Pack(&GeneralCreateAckPackageStruct{
+		Status:    p.Status,
+		Id:        p.Id,
+		Creator:   common.BytesToAddress(p.Creator),
+		ExtraData: p.ExtraData,
+	})
 	if err != nil {
 		panic("encode create group ack package error")
 	}
@@ -388,10 +672,22 @@ func (p CreateGroupAckPackage) MustSerialize() []byte {
 }
 
 func DeserializeCreateGroupAckPackage(serializedPackage []byte) (interface{}, error) {
-	var tp CreateGroupAckPackage
-	err := rlp.DecodeBytes(serializedPackage, &tp)
+	unpacked, err := generalCreateAckPackageArgs.Unpack(serializedPackage)
 	if err != nil {
 		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "deserialize create group ack package failed")
+	}
+
+	unpackedStruct := abi.ConvertType(unpacked[0], GeneralCreateAckPackageStruct{})
+	pkgStruct, ok := unpackedStruct.(GeneralCreateAckPackageStruct)
+	if !ok {
+		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "reflect create group ack package failed")
+	}
+
+	tp := CreateGroupAckPackage{
+		Status:    pkgStruct.Status,
+		Id:        pkgStruct.Id,
+		Creator:   pkgStruct.Creator.Bytes(),
+		ExtraData: pkgStruct.ExtraData,
 	}
 	return &tp, nil
 }
@@ -413,10 +709,21 @@ func (p DeleteObjectSynPackage) ValidateBasic() error {
 }
 
 func DeserializeDeleteObjectSynPackage(serializedPackage []byte) (interface{}, error) {
-	var tp DeleteObjectSynPackage
-	err := rlp.DecodeBytes(serializedPackage, &tp)
+	unpacked, err := generalDeleteSynPackageArgs.Unpack(serializedPackage)
 	if err != nil {
 		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "deserialize delete object syn package failed")
+	}
+
+	unpackedStruct := abi.ConvertType(unpacked[0], GeneralDeleteSynPackageStruct{})
+	pkgStruct, ok := unpackedStruct.(GeneralDeleteSynPackageStruct)
+	if !ok {
+		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "reflect delete object syn package failed")
+	}
+
+	tp := DeleteObjectSynPackage{
+		Operator:  pkgStruct.Operator.Bytes(),
+		Id:        pkgStruct.Id,
+		ExtraData: pkgStruct.ExtraData,
 	}
 	return &tp, nil
 }
@@ -428,7 +735,7 @@ type DeleteObjectAckPackage struct {
 }
 
 func (p DeleteObjectAckPackage) MustSerialize() []byte {
-	encodedBytes, err := rlp.EncodeToBytes(p)
+	encodedBytes, err := generalDeleteAckPackageArgs.Pack(&p)
 	if err != nil {
 		panic("encode delete object ack package error")
 	}
@@ -436,10 +743,15 @@ func (p DeleteObjectAckPackage) MustSerialize() []byte {
 }
 
 func DeserializeDeleteObjectAckPackage(serializedPackage []byte) (interface{}, error) {
-	var tp DeleteObjectAckPackage
-	err := rlp.DecodeBytes(serializedPackage, &tp)
+	unpacked, err := generalDeleteAckPackageArgs.Unpack(serializedPackage)
 	if err != nil {
-		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "deserialize delete object syn package failed")
+		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "deserialize delete object ack package failed")
+	}
+
+	unpackedStruct := abi.ConvertType(unpacked[0], DeleteObjectAckPackage{})
+	tp, ok := unpackedStruct.(DeleteObjectAckPackage)
+	if !ok {
+		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "reflect delete object ack package failed")
 	}
 	return &tp, nil
 }
@@ -461,10 +773,21 @@ func (p DeleteGroupSynPackage) ValidateBasic() error {
 }
 
 func DeserializeDeleteGroupSynPackage(serializedPackage []byte) (interface{}, error) {
-	var tp DeleteGroupSynPackage
-	err := rlp.DecodeBytes(serializedPackage, &tp)
+	unpacked, err := generalDeleteSynPackageArgs.Unpack(serializedPackage)
 	if err != nil {
 		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "deserialize delete group syn package failed")
+	}
+
+	unpackedStruct := abi.ConvertType(unpacked[0], GeneralDeleteSynPackageStruct{})
+	pkgStruct, ok := unpackedStruct.(GeneralDeleteSynPackageStruct)
+	if !ok {
+		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "reflect delete group syn package failed")
+	}
+
+	tp := DeleteGroupSynPackage{
+		Operator:  pkgStruct.Operator.Bytes(),
+		Id:        pkgStruct.Id,
+		ExtraData: pkgStruct.ExtraData,
 	}
 	return &tp, nil
 }
@@ -476,16 +799,21 @@ type DeleteGroupAckPackage struct {
 }
 
 func DeserializeDeleteGroupAckPackage(serializedPackage []byte) (interface{}, error) {
-	var tp DeleteGroupAckPackage
-	err := rlp.DecodeBytes(serializedPackage, &tp)
+	unpacked, err := generalDeleteAckPackageArgs.Unpack(serializedPackage)
 	if err != nil {
 		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "deserialize delete group ack package failed")
+	}
+
+	unpackedStruct := abi.ConvertType(unpacked[0], DeleteGroupAckPackage{})
+	tp, ok := unpackedStruct.(DeleteGroupAckPackage)
+	if !ok {
+		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "reflect delete group ack package failed")
 	}
 	return &tp, nil
 }
 
 func (p DeleteGroupAckPackage) MustSerialize() []byte {
-	encodedBytes, err := rlp.EncodeToBytes(p)
+	encodedBytes, err := generalDeleteAckPackageArgs.Pack(&p)
 	if err != nil {
 		panic("encode delete group ack package error")
 	}
@@ -504,6 +832,28 @@ type UpdateGroupMemberSynPackage struct {
 	Members       []sdk.AccAddress
 	ExtraData     []byte
 }
+
+type UpdateGroupMemberSynPackageStruct struct {
+	Operator      common.Address
+	GroupId       *big.Int
+	OperationType uint8
+	Members       []common.Address
+	ExtraData     []byte
+}
+
+var (
+	updateGroupMemberSynPackageType, _ = abi.NewType("tuple", "", []abi.ArgumentMarshaling{
+		{Name: "Operator", Type: "address"},
+		{Name: "GroupId", Type: "uint256"},
+		{Name: "OperationType", Type: "uint8"},
+		{Name: "Members", Type: "address[]"},
+		{Name: "ExtraData", Type: "bytes"},
+	})
+
+	updateGroupMemberSynPackageArgs = abi.Arguments{
+		{Type: updateGroupMemberSynPackageType},
+	}
+)
 
 func (p UpdateGroupMemberSynPackage) GetMembers() []string {
 	members := make([]string, 0, len(p.Members))
@@ -534,10 +884,28 @@ func (p UpdateGroupMemberSynPackage) ValidateBasic() error {
 }
 
 func DeserializeUpdateGroupMemberSynPackage(serializedPackage []byte) (interface{}, error) {
-	var tp UpdateGroupMemberSynPackage
-	err := rlp.DecodeBytes(serializedPackage, &tp)
+	unpacked, err := updateGroupMemberSynPackageArgs.Unpack(serializedPackage)
 	if err != nil {
-		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "deserialize update group member syn package failed")
+		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "deserialize delete bucket ack package failed")
+	}
+
+	unpackedStruct := abi.ConvertType(unpacked[0], UpdateGroupMemberSynPackageStruct{})
+	pkgStruct, ok := unpackedStruct.(UpdateGroupMemberSynPackageStruct)
+	if !ok {
+		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "reflect delete bucket ack package failed")
+	}
+
+	totalMember := len(pkgStruct.Members)
+	members := make([]sdk.AccAddress, totalMember)
+	for i, member := range pkgStruct.Members {
+		members[i] = member.Bytes()
+	}
+	tp := UpdateGroupMemberSynPackage{
+		pkgStruct.Operator.Bytes(),
+		pkgStruct.GroupId,
+		pkgStruct.OperationType,
+		members,
+		pkgStruct.ExtraData,
 	}
 	return &tp, nil
 }
@@ -551,17 +919,73 @@ type UpdateGroupMemberAckPackage struct {
 	ExtraData     []byte
 }
 
+type UpdateGroupMemberAckPackageStruct struct {
+	Status        uint8
+	Id            *big.Int
+	Operator      common.Address
+	OperationType uint8
+	Members       []common.Address
+	ExtraData     []byte
+}
+
+var (
+	updateGroupMemberAckPackageType, _ = abi.NewType("tuple", "", []abi.ArgumentMarshaling{
+		{Name: "Status", Type: "uint8"},
+		{Name: "Id", Type: "uint256"},
+		{Name: "Operator", Type: "address"},
+		{Name: "OperationType", Type: "uint8"},
+		{Name: "Members", Type: "address[]"},
+		{Name: "ExtraData", Type: "bytes"},
+	})
+
+	updateGroupMemberAckPackageArgs = abi.Arguments{
+		{Type: updateGroupMemberAckPackageType},
+	}
+)
+
 func DeserializeUpdateGroupMemberAckPackage(serializedPackage []byte) (interface{}, error) {
-	var tp UpdateGroupMemberAckPackage
-	err := rlp.DecodeBytes(serializedPackage, &tp)
+	unpacked, err := updateGroupMemberAckPackageArgs.Unpack(serializedPackage)
 	if err != nil {
 		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "deserialize update group member ack package failed")
+	}
+
+	unpackedStruct := abi.ConvertType(unpacked[0], UpdateGroupMemberAckPackageStruct{})
+	pkgStruct, ok := unpackedStruct.(UpdateGroupMemberAckPackageStruct)
+	if !ok {
+		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "reflect update group member ack package failed")
+	}
+
+	totalMember := len(pkgStruct.Members)
+	members := make([]sdk.AccAddress, totalMember)
+	for i, member := range pkgStruct.Members {
+		members[i] = member.Bytes()
+	}
+	tp := UpdateGroupMemberAckPackage{
+		pkgStruct.Status,
+		pkgStruct.Id,
+		pkgStruct.Operator.Bytes(),
+		pkgStruct.OperationType,
+		members,
+		pkgStruct.ExtraData,
 	}
 	return &tp, nil
 }
 
 func (p UpdateGroupMemberAckPackage) MustSerialize() []byte {
-	encodedBytes, err := rlp.EncodeToBytes(p)
+	totalMember := len(p.Members)
+	members := make([]common.Address, totalMember)
+	for i, member := range p.Members {
+		members[i] = common.BytesToAddress(member)
+	}
+
+	encodedBytes, err := updateGroupMemberAckPackageArgs.Pack(&UpdateGroupMemberAckPackageStruct{
+		p.Status,
+		p.Id,
+		common.BytesToAddress(p.Operator),
+		p.OperationType,
+		members,
+		p.ExtraData,
+	})
 	if err != nil {
 		panic("encode delete group ack package error")
 	}


### PR DESCRIPTION
### Description

replace rlp with ethereum `abi.encode/decode` in cross-chain transfer

### Rationale

for gas optimization

### Changes

Notable changes: 
* replace rlp with ethereum `abi.encode/decode` in cross-chain transferIn and transferOut
* ...
