### PR TITLE
docs: update testnet assets to v0.2.2

### DIFF
--- a/asset/configs/testnet_config/config.toml
+++ b/asset/configs/testnet_config/config.toml
@@ -215,7 +215,7 @@ external_address = ""
 seeds = ""
 
 # Comma separated list of nodes to keep persistent connections to
-persistent_peers = "0217308d88a87af875f8545d568e1b78d702da4e@k8s-gnfdfull-gnfdfull-5caecaf140-3641960911e9b27b.elb.ap-northeast-1.amazonaws.com:26656,70931d2c33094a824c9a95496deaf79ee7999787@k8s-gnfdfull-gnfdfull-915e53c8f7-bca52664efa2d3fe.elb.us-east-1.amazonaws.com:26656"
+persistent_peers = "f35d1c0920d3b42f313f682907ff996f3ab08cd9@k8s-gnfdfull-gnfdfull-5caecaf140-3641960911e9b27b.elb.ap-northeast-1.amazonaws.com:26656,071fc182cda17d93d1a086060898bfb405418dc7@k8s-gnfdfull-gnfdfull-915e53c8f7-bca52664efa2d3fe.elb.us-east-1.amazonaws.com:26656"
 
 # UPNP port forwarding
 upnp = false

--- a/asset/configs/testnet_config/genesis.json
+++ b/asset/configs/testnet_config/genesis.json
@@ -1,5 +1,5 @@
 {
-  "genesis_time": "2023-05-23T08:45:51.25656Z",
+  "genesis_time": "2023-06-25T02:42:08.762425Z",
   "chain_id": "greenfield_5600-1",
   "initial_height": "1",
   "consensus_params": {
@@ -223,247 +223,254 @@
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0x7715d0680fE84cA6d7eaEF6e8A7CAcE29a4C0064",
+          "address": "0xc6c47b723a00cFa0FDA7759a8c75a433b01887fe",
           "pub_key": null,
           "account_number": "27",
           "sequence": "0"
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0x34C78a5BCC1b0fD7F58E4f36393d29A356603698",
+          "address": "0x7715d0680fE84cA6d7eaEF6e8A7CAcE29a4C0064",
           "pub_key": null,
           "account_number": "28",
           "sequence": "0"
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0x735851c190f6999826f2a128dD53b9cA02F32C25",
+          "address": "0x34C78a5BCC1b0fD7F58E4f36393d29A356603698",
           "pub_key": null,
           "account_number": "29",
           "sequence": "0"
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0x2489613b7AA789e7e6f5f6713D95154AEdF4A9DC",
+          "address": "0x735851c190f6999826f2a128dD53b9cA02F32C25",
           "pub_key": null,
           "account_number": "30",
           "sequence": "0"
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0x35Bb57d2b84E363a293F918f273975B8dfAE8201",
+          "address": "0x2489613b7AA789e7e6f5f6713D95154AEdF4A9DC",
           "pub_key": null,
           "account_number": "31",
           "sequence": "0"
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0x22804504786F44289D4156E7317142e25B92c00e",
+          "address": "0x35Bb57d2b84E363a293F918f273975B8dfAE8201",
           "pub_key": null,
           "account_number": "32",
           "sequence": "0"
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0xd641C35f947Eb60676f0e0793691bB174256C651",
+          "address": "0x22804504786F44289D4156E7317142e25B92c00e",
           "pub_key": null,
           "account_number": "33",
           "sequence": "0"
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0xE4F1Ac4B9312724D2819347c5c91252b650C4AEb",
+          "address": "0xd641C35f947Eb60676f0e0793691bB174256C651",
           "pub_key": null,
           "account_number": "34",
           "sequence": "0"
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0xaF07AdBb21029adf12FB6E4515Ed8dA0A7e252a2",
+          "address": "0xE4F1Ac4B9312724D2819347c5c91252b650C4AEb",
           "pub_key": null,
           "account_number": "35",
           "sequence": "0"
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0xfF755134416a0Ebc4A614f951163a2Ecf48C069b",
+          "address": "0xaF07AdBb21029adf12FB6E4515Ed8dA0A7e252a2",
           "pub_key": null,
           "account_number": "36",
           "sequence": "0"
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0xE42B5AD90AfF1e8Ad90F76e02541A71Ca9D41A11",
+          "address": "0xfF755134416a0Ebc4A614f951163a2Ecf48C069b",
           "pub_key": null,
           "account_number": "37",
           "sequence": "0"
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0x05e10816F92aB9aE545733db2f73bB858F9DC1fa",
+          "address": "0xE42B5AD90AfF1e8Ad90F76e02541A71Ca9D41A11",
           "pub_key": null,
           "account_number": "38",
           "sequence": "0"
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0x47B07B9dBA6117F800b4f7D2e31B0C4b32127A90",
+          "address": "0x05e10816F92aB9aE545733db2f73bB858F9DC1fa",
           "pub_key": null,
           "account_number": "39",
           "sequence": "0"
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0xAe51dE302F70A7a2ff9d04B3c372e90de1518329",
+          "address": "0x47B07B9dBA6117F800b4f7D2e31B0C4b32127A90",
           "pub_key": null,
           "account_number": "40",
           "sequence": "0"
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0xC0B4285E54981011853197b535DF27Dfb24eEde5",
+          "address": "0xAe51dE302F70A7a2ff9d04B3c372e90de1518329",
           "pub_key": null,
           "account_number": "41",
           "sequence": "0"
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0x5E340C0721bD5f49627e7E34eb94bedfA575E993",
+          "address": "0xC0B4285E54981011853197b535DF27Dfb24eEde5",
           "pub_key": null,
           "account_number": "42",
           "sequence": "0"
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0xD3af86C62D53dA3aD7FD3eaF867D91E1Ba9c61AC",
+          "address": "0x5E340C0721bD5f49627e7E34eb94bedfA575E993",
           "pub_key": null,
           "account_number": "43",
           "sequence": "0"
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0xFCE3084e2AC67E1f698926b7FbcbD2204bFa7F92",
+          "address": "0xD3af86C62D53dA3aD7FD3eaF867D91E1Ba9c61AC",
           "pub_key": null,
           "account_number": "44",
           "sequence": "0"
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0xbc01dE0Cc6D7F23822De6352c570d7E4798070f7",
+          "address": "0xFCE3084e2AC67E1f698926b7FbcbD2204bFa7F92",
           "pub_key": null,
           "account_number": "45",
           "sequence": "0"
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0x61FcD913b09894fa53d926bEFc2ED92EF3F014b2",
+          "address": "0xbc01dE0Cc6D7F23822De6352c570d7E4798070f7",
           "pub_key": null,
           "account_number": "46",
           "sequence": "0"
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0xC6fA3F3640e3b594335efAb349abdD4A82C83736",
+          "address": "0x61FcD913b09894fa53d926bEFc2ED92EF3F014b2",
           "pub_key": null,
           "account_number": "47",
           "sequence": "0"
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0x8FeD9Ba853B685c2e482DEba08cE30F6942A9F2f",
+          "address": "0xC6fA3F3640e3b594335efAb349abdD4A82C83736",
           "pub_key": null,
           "account_number": "48",
           "sequence": "0"
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0x3f92219ef03F8aF218F9DA601Eaf254DB022f13D",
+          "address": "0x8FeD9Ba853B685c2e482DEba08cE30F6942A9F2f",
           "pub_key": null,
           "account_number": "49",
           "sequence": "0"
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0x4ea8378e4c64a41e417750E8f7fBa0F264AD379A",
+          "address": "0x3f92219ef03F8aF218F9DA601Eaf254DB022f13D",
           "pub_key": null,
           "account_number": "50",
           "sequence": "0"
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0x431EA58C86Abd737e0606cEa0f332115a4E1F5c1",
+          "address": "0x4ea8378e4c64a41e417750E8f7fBa0F264AD379A",
           "pub_key": null,
           "account_number": "51",
           "sequence": "0"
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0x3CFC8b2095DA8F0722412Dc16f8A067942d2c697",
+          "address": "0x431EA58C86Abd737e0606cEa0f332115a4E1F5c1",
           "pub_key": null,
           "account_number": "52",
           "sequence": "0"
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0xE44c4e725598CCa7Da3c506869d658a84e599983",
+          "address": "0x3CFC8b2095DA8F0722412Dc16f8A067942d2c697",
           "pub_key": null,
           "account_number": "53",
           "sequence": "0"
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0x43416fd2Dd08Bc6F2004B9a5fA53686B7F541d58",
+          "address": "0xE44c4e725598CCa7Da3c506869d658a84e599983",
           "pub_key": null,
           "account_number": "54",
           "sequence": "0"
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0x0DC08D602aaAAAA7e2fD604f9f96DdD2cD67FE51",
+          "address": "0x43416fd2Dd08Bc6F2004B9a5fA53686B7F541d58",
           "pub_key": null,
           "account_number": "55",
           "sequence": "0"
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0xD27faC13b0C38f57ce1840Fc55e7B8b66dEBB342",
+          "address": "0x0DC08D602aaAAAA7e2fD604f9f96DdD2cD67FE51",
           "pub_key": null,
           "account_number": "56",
           "sequence": "0"
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0xB573F5c174f33aF0CA033c8A287061C1538fb130",
+          "address": "0xD27faC13b0C38f57ce1840Fc55e7B8b66dEBB342",
           "pub_key": null,
           "account_number": "57",
           "sequence": "0"
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0x4B956d53E466a53d5FdE86781F1f547B44a19260",
+          "address": "0xB573F5c174f33aF0CA033c8A287061C1538fb130",
           "pub_key": null,
           "account_number": "58",
           "sequence": "0"
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0x674d969927AbA4eE9Cd05e5079655BB099D83d85",
+          "address": "0x4B956d53E466a53d5FdE86781F1f547B44a19260",
           "pub_key": null,
           "account_number": "59",
           "sequence": "0"
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0x648848d33938Ab930Da70cC71eda2Bd0175f7150",
+          "address": "0x674d969927AbA4eE9Cd05e5079655BB099D83d85",
           "pub_key": null,
           "account_number": "60",
           "sequence": "0"
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "0xc5f1910AF4771720395f33f2FBBe782233215b4B",
+          "address": "0x648848d33938Ab930Da70cC71eda2Bd0175f7150",
           "pub_key": null,
           "account_number": "61",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "0xc5f1910AF4771720395f33f2FBBe782233215b4B",
+          "pub_key": null,
+          "account_number": "62",
           "sequence": "0"
         }
       ]
@@ -870,6 +877,15 @@
             {
               "denom": "BNB",
               "amount": "2000000000000000000000"
+            }
+          ]
+        },
+        {
+          "address": "0xc6c47b723a00cFa0FDA7759a8c75a433b01887fe",
+          "coins": [
+            {
+              "denom": "BNB",
+              "amount": "1867000000000000000000000"
             }
           ]
         },
@@ -1592,7 +1608,7 @@
             "tip": null
           },
           "signatures": [
-            "iwVG5q9/jwcjKRKrY6wFsOdBEc1jopdjUB+MlFYOQHMVE043GA33Imji2tTF68YDw6rfIn2y5pjwo6JBx9YLIAA="
+            "Gf4lnUS7zgQ/7cmnLm8KsakHdzIoaaalgMG+PyFHyC53b4bFnCaBOfRM/q7MQMWxPOEGKlXd+xpFxpWHDy0jOAA="
           ]
         },
         {
@@ -1652,7 +1668,7 @@
             "tip": null
           },
           "signatures": [
-            "6Gnv56xDA6Yvdd3QN64z197Jp6R79d4ixp3klzo/aoA1p33AmTUuMTbaBMj13qStGGnw8lInOI/Ts/hS0rfkeAA="
+            "ihRW+L8DGll+3rNlss1+tocZyHctSg2OhS+37AXpR6RpszXVG7IUfLK1mV6njpJ+neQMxDCb3UWYhTMsFHKBHwA="
           ]
         },
         {
@@ -1712,7 +1728,7 @@
             "tip": null
           },
           "signatures": [
-            "i+jfvjcEWh8mwmL3vkNy8qQ8RycXk4JtEmyzzdRUCCNFmjctqwejIt41pfGF9ttDNfkYfYY9xqUVKQjpuzA5ZwA="
+            "0QUvcSHboDtmCSimZ7BHqlZ38zVSpD0EhxkIi6IG3HcVG3CLDe64Dnhw2Tr6g53eGwjWbHftF4GywSL8EJ9lwQA="
           ]
         },
         {
@@ -1772,7 +1788,7 @@
             "tip": null
           },
           "signatures": [
-            "A+opEOQj2RdQLuQ+uFqYhTcZYVzYNX/INU9AFMd8MBRpXuxg8UXmlcAoXpKZWyLxWx9EJyo0ut8eU6Bx20FI3gA="
+            "58kUVJ7/JHGVXvdnyknOH+BgJVmO/hCOgk4kAA1NPwZabMd8Wwx9UzArtLlYlm0JZ0DwJ4lbKtXKwQ7clY7MjgE="
           ]
         },
         {
@@ -1832,7 +1848,7 @@
             "tip": null
           },
           "signatures": [
-            "UAxMf0ZrLMYWtIk2qcrgPV/FGpFurgN1Z6Rfw4YveKUZhI6VYQjlCNjOexvGNKhyJjiZqbNaFrbjeHQpVkWAWwA="
+            "+l+uzaRoEU4fAefmoMj99Rg3CJGQ+Yy7GV8p07PZZpQyLjYOlgN6hoTiWQAoJO+NktHNPkXMD2bT54zqtiaEywA="
           ]
         },
         {
@@ -1892,7 +1908,7 @@
             "tip": null
           },
           "signatures": [
-            "YXajDqPECk+IU4NOJbBzNwpCJ3hh/S9oZ39jx8unkXkbVTc/Jd4YCyZ9gT2U1ivRn34ulASwnFfgm1AU/2GLKQA="
+            "pvkSZ8j0fdY4MqG30FhjspB3FwBy3vfotAFs9Mmga1h9uVnn1SUk2POeEf5SfEzqrCON8oRUBY7rCLgVA8v5UAA="
           ]
         },
         {
@@ -1952,7 +1968,7 @@
             "tip": null
           },
           "signatures": [
-            "sUiHMR8x53Uq9zgEl+zIZIPi2wW32kPGOm5QIKwCupJ2vTNuGLoymvLDaF/sHx3s+9AgBMQJJ71Hs+iiuw0DDAE="
+            "/XyFUVzylXr2B6NXLZJCl1VAID6EMZT7+F5iP8L8CcsyS9B0Gya3x0fLHmIC+t+0zqwUCVgzIbzWif6+MxbeBgE="
           ]
         }
       ]
@@ -1981,7 +1997,7 @@
                 "validator_address": "0xd232339d21D20673CAb8c7EA2b7e96B1Ceb702C5",
                 "pubkey": {
                   "@type": "/cosmos.crypto.ed25519.PubKey",
-                  "key": "nubnuHaqTv1k3rJ1IIEhX/XUQP55OE4F0HecJ8P2K6w="
+                  "key": "h3HfJh6R8nAMKVw1Lmp19B0qSZhnthqyErmLG0gm1nI="
                 },
                 "value": {
                   "denom": "BNB",
@@ -2022,7 +2038,7 @@
             "tip": null
           },
           "signatures": [
-            "N6ieaqotrBwJvmKU8tU5I5VJ9fqGBsnQ/rNzkgUmtgVBEDIT5jGnoLdcDEuRzqYNeXJadlUfN7pu+iWFqZF34gA="
+            "xNERDpPkdQoz2G4aF6KbaATjg6xOjyNJzhLRVEmVvbtsCbC5+zrtCXkeRQQ5JqYK02ZO6izARPSa7LFnvN5ImgA="
           ]
         },
         {
@@ -2047,7 +2063,7 @@
                 "validator_address": "0x89b7f5dBAde74CB8c2c78Af26B3841cFF8182945",
                 "pubkey": {
                   "@type": "/cosmos.crypto.ed25519.PubKey",
-                  "key": "HxU9OsGxRZu/MOoTPpVdPdFjDEfGBkAsxLmB4lJ8fec="
+                  "key": "ICaj8d7fAXwHDcYY16uvR5Tz6CHWU1H1ET8piZ/pEvE="
                 },
                 "value": {
                   "denom": "BNB",
@@ -2088,7 +2104,7 @@
             "tip": null
           },
           "signatures": [
-            "quFe25Zo/6ntvaoh3aBXY/X/TE3UT8IiOvMxH0FDSQFn0rRXBaWbz28Z1GXHwFStbFU6ym9eSPnDLnndiOwb+gA="
+            "L0LwZRdRk491vq3NKRQwG2db2pzUPKDgdL5V1sYb8eQmHtyB/T7yXhOAJcXRW7l5uG04tTp+stTuLyEYtP3H7gE="
           ]
         },
         {
@@ -2113,7 +2129,7 @@
                 "validator_address": "0x3a1422D7d1466aA95302F20eE45236258b8C2472",
                 "pubkey": {
                   "@type": "/cosmos.crypto.ed25519.PubKey",
-                  "key": "FJFu3lybBZPv/d7LIE8troFOsf0MwLKlotDOdvUzCMU="
+                  "key": "oem0oUWZhOc1dFzOnQLvH+EO382NV+hmzX8rORfPazk="
                 },
                 "value": {
                   "denom": "BNB",
@@ -2154,7 +2170,7 @@
             "tip": null
           },
           "signatures": [
-            "8I5iFpwoI9wFXnM/gRd0HHJSjXLpE76O46CZvL3Nh1ox2t/ZyxKFAjUghPOJqEWt2xMHzzhJJSEbqaZ1SH9S+gE="
+            "1aVqi6t+XcmTrsi7L3VV5s6AMfugV+c5t0wPZDqGrWxGlRFsX7r44WMUzlzcoRhL/FdjQQMidDjoazAn3W41lwE="
           ]
         },
         {
@@ -2179,7 +2195,7 @@
                 "validator_address": "0x5fd2786474F9785725CfD617B733ecfCB1A09142",
                 "pubkey": {
                   "@type": "/cosmos.crypto.ed25519.PubKey",
-                  "key": "RrHywWnmWirudqQS9i2Ib6j6U24e10lS9YhIlv2ZKi4="
+                  "key": "++Lj2Oae050eQXk2nDsWIEhLfk+XrSGhZFNZmMrEkcM="
                 },
                 "value": {
                   "denom": "BNB",
@@ -2220,7 +2236,7 @@
             "tip": null
           },
           "signatures": [
-            "63x5SVQTcimJwNQpUlC78xh18Gdbay29nhLAY73U/XYFKjkXbRwlmMgm4Rsq3XJ9cryxzqvWdkHPICEHhBGs3QA="
+            "sszkT9frikRRBccjgcg4F6z4Kk56h3wB0ZYkTG/tUhIfrNu+r77q6hXxxu1r96fdqOx1jMsjo9xl4aWxutdsIQE="
           ]
         },
         {
@@ -2245,7 +2261,7 @@
                 "validator_address": "0x9D37729D08A346A5548a58Bf69Ec629d5B51A9b5",
                 "pubkey": {
                   "@type": "/cosmos.crypto.ed25519.PubKey",
-                  "key": "GsB5Ayn1DpF80LVSvpaOAk9+LYxQOofH970LybJyuzE="
+                  "key": "rku2fNplE8ujo2Rgo8vrozr8MGzXH0Jh8/5Wr9916LE="
                 },
                 "value": {
                   "denom": "BNB",
@@ -2286,7 +2302,7 @@
             "tip": null
           },
           "signatures": [
-            "2sJP8Ec5ZG52vdP1zPuPVtJDD7Y7UILl2BWzvaaCZVN7QML+oxOu1Md+v1VGUCEuJse82jU+xcKt18OwjTh2zQA="
+            "vl/jZIgb8hhYKKM+C/3ENv0dpP0Th15nYlkT5+gDm1BtMM0qd1KTPYhOM1bqwBabXClhU3+ppvcLBRPDTOQqqQE="
           ]
         },
         {
@@ -2311,7 +2327,7 @@
                 "validator_address": "0xcA3168c36ceaC3ED7eE7C6097B031f94A2C62094",
                 "pubkey": {
                   "@type": "/cosmos.crypto.ed25519.PubKey",
-                  "key": "u+EMofqxvdLCMyWnZQ12wLXi56kTzp6sM5z+jF9Z3b4="
+                  "key": "7GUJOWkNEtWNAx7VaaqHixUpggOawDmV9OSpS0dHS/A="
                 },
                 "value": {
                   "denom": "BNB",
@@ -2352,7 +2368,7 @@
             "tip": null
           },
           "signatures": [
-            "Gl/ny/mzPzfDHrfOdMw8QU0cTAW6o2vyLwDew3+v4YIhVvi6esOTvhySWs4JLL/vYgNrGlvLryr2lBr3k+8pZAE="
+            "zNrdrsytssDidILOapzVnBYHB/gvsauVbfxguiJD8+JxvPGgoBCB1Mqf3UJ0Mi4qMVvuifvgnqcinHtQdAiLpQE="
           ]
         },
         {
@@ -2377,7 +2393,7 @@
                 "validator_address": "0xcB22c3FcdDd5Ee57639b0f053ce50C7516eC1fBF",
                 "pubkey": {
                   "@type": "/cosmos.crypto.ed25519.PubKey",
-                  "key": "smIJMUKvEwPbr4KPCjj2fHlCMNGVRZWqrhgNU5hPUVc="
+                  "key": "FqpzmaybkftYJ4ADUOkgN96rQhSsRAExEF1lw4SwRc0="
                 },
                 "value": {
                   "denom": "BNB",
@@ -2418,7 +2434,7 @@
             "tip": null
           },
           "signatures": [
-            "+HZD966/Y8Tbmf1CIoy+5DXqo1uv11T98cGsXI2O2LoPopsMv1xW/lk1iznTTPaCsYhKLglaR2s7wIrYRNJivgE="
+            "+8WHqrHry1jB5SJ+zeFNjD+iUgZC6DC5XNme8h0ngrBP6BGajwDiwwzNQ6VYaD0IdIXAKTkMhCa2LivZGtTOLgE="
           ]
         },
         {
@@ -2443,7 +2459,7 @@
                 "validator_address": "0x14ed904094a90cE2E8274E64a8D70F59cEDAdBdF",
                 "pubkey": {
                   "@type": "/cosmos.crypto.ed25519.PubKey",
-                  "key": "PipGYkXTAw2ACQwA95ibgih6IA99Nq5YtojMz52JL+s="
+                  "key": "VFwx84EbKTsWYSwotDN3+qTrlMF79pc22BxxNTIo+68="
                 },
                 "value": {
                   "denom": "BNB",
@@ -2484,7 +2500,7 @@
             "tip": null
           },
           "signatures": [
-            "ybWUj45G7VK3BKj8sWG97Nz4A6pnoQPaH+8DHIRgpc1LHLVxniGdqOK+qTApXzcOQirWGqTedblVSH4YkWALFAE="
+            "WUVv9XQPg2MWMFlORPRiZ2WvVEePPLmT4wPDULlx2a05Wnfa0H1tT/FBbS0lnCkA/II4HxieHGlzv8omb59IYQE="
           ]
         },
         {
@@ -2509,7 +2525,7 @@
                 "validator_address": "0x1CA8e333a58b292d0e12Dd01F3314cAbB52e3975",
                 "pubkey": {
                   "@type": "/cosmos.crypto.ed25519.PubKey",
-                  "key": "hbnQKt/qHf2Y7d+C11gYsj6u/CninBAKXxyVZeoRAB8="
+                  "key": "dtoCUymxEF+aU6cNllCdutNI+wGQ/gY5c8lZqOCSJpE="
                 },
                 "value": {
                   "denom": "BNB",
@@ -2550,7 +2566,7 @@
             "tip": null
           },
           "signatures": [
-            "LD10S2LQS7iBDbDjC8XH9U3hYXH7txHxH3bJWCic9O9gNhvPuE1A4d1soRjh/4yU8d+6trjBEKS1KnATpbOqbQA="
+            "2geg1DC6hM74Av/7XZffTO8BHws+IQHN29CH7ru5nnxoq/iycrPWbE5wPdB99z9XSAtUFMHA71vQKcKWhWxHeAA="
           ]
         }
       ]
@@ -2667,7 +2683,7 @@
         "discontinue_object_max": "18446744073709551615",
         "discontinue_bucket_max": "18446744073709551615",
         "discontinue_confirm_period": "604800",
-        "discontinue_deletion_max": "10000",
+        "discontinue_deletion_max": "100",
         "stale_policy_cleanup_max": "200"
       }
     },


### PR DESCRIPTION
### Description

update testnet genesis to v0.2.2

### Rationale

Greenfield testnet has been reset and upgraded to v0.2.2 on 2023/6/25

### Example
n/a

### Changes

Notable changes: 
* testnet genesis
