### PR TITLE
feat: refine payment and update default parameter

### DIFF
--- a/x/sp/types/params.go
+++ b/x/sp/types/params.go
@@ -14,15 +14,15 @@ import (
 
 // SP params default values
 const (
-	// Dafault deposit denom
+	// Default deposit denom
 	DefaultDepositDenom = "BNB"
 )
 
 var (
 	// DefaultMinDeposit defines the minimum deposit amount for all storage provider
 	DefaultMinDeposit = math.NewIntFromBigInt(new(big.Int).Mul(big.NewInt(10000), big.NewInt(1e18)))
-	// DefaultSecondarySpStorePriceRatio is 65%
-	DefaultSecondarySpStorePriceRatio = sdk.NewDecFromIntWithPrec(sdk.NewInt(65), 2)
+	// DefaultSecondarySpStorePriceRatio is 12%
+	DefaultSecondarySpStorePriceRatio = sdk.NewDecFromIntWithPrec(sdk.NewInt(12), 2)
 )
 
 var (

--- a/x/storage/keeper/keeper.go
+++ b/x/storage/keeper/keeper.go
@@ -457,10 +457,13 @@ func (k Keeper) CreateObject(
 		return sdkmath.ZeroUint(), errors.Wrapf(types.ErrInvalidApproval, "The approval of sp is expired.")
 	}
 
-	err := k.VerifySPAndSignature(ctx, sdk.MustAccAddressFromHex(bucketInfo.PrimarySpAddress), opts.ApprovalMsgBytes,
-		opts.PrimarySpApproval.Sig)
-	if err != nil {
-		return sdkmath.ZeroUint(), err
+	var err error
+	if !ctx.IsCheckTx() { // no signature verification for simulation
+		err = k.VerifySPAndSignature(ctx, sdk.MustAccAddressFromHex(bucketInfo.PrimarySpAddress), opts.ApprovalMsgBytes,
+			opts.PrimarySpApproval.Sig)
+		if err != nil {
+			return sdkmath.ZeroUint(), err
+		}
 	}
 
 	objectKey := types.GetObjectKey(bucketName, objectName)
@@ -515,7 +518,7 @@ func (k Keeper) CreateObject(
 	store.Set(objectKey, sequence.EncodeSequence(objectInfo.Id))
 	store.Set(types.GetObjectByIDKey(objectInfo.Id), obz)
 
-	if err := ctx.EventManager().EmitTypedEvents(&types.EventCreateObject{
+	if err = ctx.EventManager().EmitTypedEvents(&types.EventCreateObject{
 		Creator:          operator.String(),
 		Owner:            objectInfo.Owner,
 		BucketName:       bucketInfo.BucketName,

--- a/x/storage/keeper/payment.go
+++ b/x/storage/keeper/payment.go
@@ -311,7 +311,8 @@ func (k Keeper) GetObjectLockFee(ctx sdk.Context, primarySpAddress string, price
 	if err != nil {
 		return amount, fmt.Errorf("get charge size error: %w", err)
 	}
-	rate := price.PrimaryStorePrice.Add(price.SecondaryStorePrice.MulInt64(storagetypes.SecondarySPNum)).MulInt(sdkmath.NewIntFromUint64(chargeSize)).TruncateInt()
+	secondarySPNum := int64(k.GetExpectSecondarySPNumForECObject(ctx))
+	rate := price.PrimaryStorePrice.Add(price.SecondaryStorePrice.MulInt64(secondarySPNum)).MulInt(sdkmath.NewIntFromUint64(chargeSize)).TruncateInt()
 	versionedParams, err := k.paymentKeeper.GetVersionedParamsWithTs(ctx, priceTime)
 	if err != nil {
 		return amount, fmt.Errorf("get versioned reserve time error: %w", err)

--- a/x/storage/types/types.go
+++ b/x/storage/types/types.go
@@ -7,12 +7,6 @@ import (
 	sdkmath "cosmossdk.io/math"
 )
 
-const (
-	SecondarySPNum = 6
-	// MinChargeSize is the minimum size to charge for a storage object
-	MinChargeSize = 1024
-)
-
 type (
 	Int  = sdkmath.Int
 	Uint = sdkmath.Uint


### PR DESCRIPTION
### Description

This pr tries to refine the payment code in following aspects:
* update default SecondarySpStorePriceRatio to 0.12
* fix the calculation of secondary sp number for a object (versioned parameter will be further implemented https://github.com/bnb-chain/greenfield/pull/284)
* when simulating object creation, will not check the approval

### Rationale

Make the parameter more sense and fix issues

### Example

NA

### Changes

Notable changes: 
* parameter SecondarySpStorePriceRatio
