### PR TITLE
release: draft release for v0.2.3-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Features
 * [#287](https://github.com/bnb-chain/greenfield/pull/287) feat: use median store price for secondary sp price 
 * [#292](https://github.com/bnb-chain/greenfield/pull/292) feat: allows for setting a custom http client when NewGreenfieldClient 
 * [#288](https://github.com/bnb-chain/greenfield/pull/288) feat: limit the interval for updating quota
+* [#297](https://github.com/bnb-chain/greenfield/pull/297) feat: refine payment and update default parameter     
 
 Bugfixes  
 * [#279](https://github.com/bnb-chain/greenfield/pull/279) fix: fix the security issues 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## v0.2.3-alpha.1
+* [#279](https://github.com/bnb-chain/greenfield/pull/279) fix: fix the security issues 
+* [#280](https://github.com/bnb-chain/greenfield/pull/280) fix: update go.mod to be compatible with ignite 
+* [#281](https://github.com/bnb-chain/greenfield/pull/281) feat: add versioned parameters to payment module 
+* [#286](https://github.com/bnb-chain/greenfield/pull/286) fix: update storage discontinue param's default value 
+* [#287](https://github.com/bnb-chain/greenfield/pull/287) feat: use median store price for secondary sp price 
+* [#295](https://github.com/bnb-chain/greenfield/pull/295) add missing field to event 
+* [#292](https://github.com/bnb-chain/greenfield/pull/292) feat: allows for setting a custom http client when NewGreenfieldClient 
+* [#285](https://github.com/bnb-chain/greenfield/pull/285) fix: ACTION_UPDATE_OBJECT_INFO not allowed to be used on object's bug 
+* [#288](https://github.com/bnb-chain/greenfield/pull/288) feat: limit the interval for updating quota 
+
+## v0.2.2
+This release enables several features and some bugfix:
+
+Features
+* [#249](https://github.com/bnb-chain/greenfield/pull/249) feat: support multiple messages in single tx for EIP712
+* [#250](https://github.com/bnb-chain/greenfield/pull/250) feat: allow mirror bucket/object/group using name
+* [#268](https://github.com/bnb-chain/greenfield/pull/268) feat: record challenge attestation result
+* [#276](https://github.com/bnb-chain/greenfield/pull/276) feat: allow user to pass keyManager into Txopt
+
+Bugfix
+* [#248](https://github.com/bnb-chain/greenfield/pull/248) fix: add versioned params e2e's test
+* [#252](https://github.com/bnb-chain/greenfield/pull/252) fix: remove paramsclient from sdk and swagger
+* [#254](https://github.com/bnb-chain/greenfield/pull/254) fix: fix potential int64 multiplication overflow
+* [#255](https://github.com/bnb-chain/greenfield/pull/255) fix: verify permission openapi params
+* [#263](https://github.com/bnb-chain/greenfield/pull/263) fix: QueryGetSecondarySpStorePriceByTime may wrong data
+* [#267](https://github.com/bnb-chain/greenfield/pull/267) chore: update swagger
+* [#271](https://github.com/bnb-chain/greenfield/pull/271) fix: check every module's Msg
+* [#270](https://github.com/bnb-chain/greenfield/pull/270) fix: sp check when reject seal object
+* [#269](https://github.com/bnb-chain/greenfield/pull/269) fix: fix wrong link in readme
+* [#274](https://github.com/bnb-chain/greenfield/pull/274) fix: add sp address check when deposit
+
 ## v0.2.2-alpha.2
 
 This release enables 2 features:
@@ -16,7 +48,7 @@ This release enables 2 features:
 
 ## v0.2.1-alpha.1
 
-This release enable two features:
+This release[CHANGELOG.md](CHANGELOG.md) enable two features:
 - support multiple messages in single tx
 - allow mirror bucket/object/group using name
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,20 @@
 # Changelog
 
 ## v0.2.3-alpha.1
+This release enables several features and bugfixes:
+
+Features
+* [#281](https://github.com/bnb-chain/greenfield/pull/281) feat: add versioned parameters to payment module 
+* [#287](https://github.com/bnb-chain/greenfield/pull/287) feat: use median store price for secondary sp price 
+* [#292](https://github.com/bnb-chain/greenfield/pull/292) feat: allows for setting a custom http client when NewGreenfieldClient 
+* [#288](https://github.com/bnb-chain/greenfield/pull/288) feat: limit the interval for updating quota
+
+Bugfixes  
 * [#279](https://github.com/bnb-chain/greenfield/pull/279) fix: fix the security issues 
 * [#280](https://github.com/bnb-chain/greenfield/pull/280) fix: update go.mod to be compatible with ignite 
-* [#281](https://github.com/bnb-chain/greenfield/pull/281) feat: add versioned parameters to payment module 
 * [#286](https://github.com/bnb-chain/greenfield/pull/286) fix: update storage discontinue param's default value 
-* [#287](https://github.com/bnb-chain/greenfield/pull/287) feat: use median store price for secondary sp price 
 * [#295](https://github.com/bnb-chain/greenfield/pull/295) add missing field to event 
-* [#292](https://github.com/bnb-chain/greenfield/pull/292) feat: allows for setting a custom http client when NewGreenfieldClient 
 * [#285](https://github.com/bnb-chain/greenfield/pull/285) fix: ACTION_UPDATE_OBJECT_INFO not allowed to be used on object's bug 
-* [#288](https://github.com/bnb-chain/greenfield/pull/288) feat: limit the interval for updating quota 
 
 ## v0.2.2
 This release enables several features and some bugfix:

--- a/go.mod
+++ b/go.mod
@@ -181,6 +181,6 @@ replace (
 	github.com/btcsuite/btcd => github.com/btcsuite/btcd v0.23.0
 	github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v0.0.1
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v0.2.2-0.20230625115018-2d8301b63df1
+	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3-alpha.1
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 )

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,8 @@ github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edY
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
 github.com/bnb-chain/greenfield-cometbft v0.0.1 h1:pX8S9oZKjWJCrxH07l6rbU3zee9txZ11+UwO9stsNMQ=
 github.com/bnb-chain/greenfield-cometbft v0.0.1/go.mod h1:9q11eHNRY9FDwFH+4pompzPNGv//Z3VcfvkELaHJPMs=
-github.com/bnb-chain/greenfield-cosmos-sdk v0.2.2-0.20230625115018-2d8301b63df1 h1:9Ik/IUDCXmMH3UvEUfK7zVgWLsfZpEipRh5ex4Hl9qk=
-github.com/bnb-chain/greenfield-cosmos-sdk v0.2.2-0.20230625115018-2d8301b63df1/go.mod h1:ePxSdTXosDo5YE9TRxqzmXv8T0PH7AVqTfofRf81aRo=
+github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3-alpha.1 h1:woVNr3N+h/dY7sTZaKscTHARJv4RHLh0+qhniqkF734=
+github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3-alpha.1/go.mod h1:ePxSdTXosDo5YE9TRxqzmXv8T0PH7AVqTfofRf81aRo=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230425074444-eb5869b05fe9 h1:6fLpmmI0EZvDTfPvI0zy5dBaaTUboHnEkoC5/p/w8TQ=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230425074444-eb5869b05fe9/go.mod h1:rbc4o84RSEvhf09o2+4Qiazsv0snRJLiEZdk17HeIDw=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230425074444-eb5869b05fe9 h1:1ZdK+iR1Up02bOa2YTZCml7PBpP//kcdamOcK6aWO/s=


### PR DESCRIPTION
### Description

This release enables several features and bugfixes.  

### Rationale

* [#279](https://github.com/bnb-chain/greenfield/pull/279) fix: fix the security issues 
* [#280](https://github.com/bnb-chain/greenfield/pull/280) fix: update go.mod to be compatible with ignite 
* [#281](https://github.com/bnb-chain/greenfield/pull/281) feat: add versioned parameters to payment module 
* [#286](https://github.com/bnb-chain/greenfield/pull/286) fix: update storage discontinue param's default value 
* [#287](https://github.com/bnb-chain/greenfield/pull/287) feat: use median store price for secondary sp price 
* [#295](https://github.com/bnb-chain/greenfield/pull/295) add missing field to event 
* [#292](https://github.com/bnb-chain/greenfield/pull/292) feat: allows for setting a custom http client when NewGreenfieldClient 
* [#285](https://github.com/bnb-chain/greenfield/pull/285) fix: ACTION_UPDATE_OBJECT_INFO not allowed to be used on object's bug 
* [#288](https://github.com/bnb-chain/greenfield/pull/288) feat: limit the interval for updating quota 
* [#297](https://github.com/bnb-chain/greenfield/pull/297) feat: refine payment and update default parameter        

### Example

Please find detailed information in the PR

### Changes


Notable breaking changes:
none  

