### PR TITLE
feat: add support of group name in policy

### DIFF
--- a/e2e/tests/permission_test.go
+++ b/e2e/tests/permission_test.go
@@ -675,7 +675,7 @@ func (s *StorageTestSuite) TestGrantsPermissionToGroup() {
 		Actions: []types.ActionType{types.ACTION_UPDATE_BUCKET_INFO, types.ACTION_DELETE_BUCKET},
 		Effect:  types.EFFECT_ALLOW,
 	}
-	principal := types.NewPrincipalWithGroup(headGroupResponse.GroupInfo.Id)
+	principal := types.NewPrincipalWithGroupInfo(user[0].GetAddr(), headGroupResponse.GroupInfo.GroupName)
 	msgPutPolicy := storagetypes.NewMsgPutPolicy(user[0].GetAddr(), types2.NewBucketGRN(bucketName).String(),
 		principal, []*types.Statement{statement}, nil)
 	s.SendTxBlock(user[0], msgPutPolicy)
@@ -1103,7 +1103,7 @@ func (s *StorageTestSuite) TestStalePermissionForGroupGC() {
 	s.Require().True(owner.GetAddr().Equals(sdk.MustAccAddressFromHex(headGroupResponse.GroupInfo.Owner)))
 	s.T().Logf("GroupInfo: %s", headGroupResponse.GetGroupInfo().String())
 
-	principal := types.NewPrincipalWithGroup(headGroupResponse.GroupInfo.Id)
+	principal := types.NewPrincipalWithGroupId(headGroupResponse.GroupInfo.Id)
 	// Put bucket policy for group
 	bucketStatement := &types.Statement{
 		Actions: []types.ActionType{types.ACTION_DELETE_BUCKET},

--- a/x/permission/types/common.go
+++ b/x/permission/types/common.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"github.com/bnb-chain/greenfield/types"
+
 	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -12,10 +14,17 @@ func NewPrincipalWithAccount(addr sdk.AccAddress) *Principal {
 	}
 }
 
-func NewPrincipalWithGroup(groupID sdkmath.Uint) *Principal {
+func NewPrincipalWithGroupId(groupID sdkmath.Uint) *Principal {
 	return &Principal{
 		Type:  PRINCIPAL_TYPE_GNFD_GROUP,
 		Value: groupID.String(),
+	}
+}
+
+func NewPrincipalWithGroupInfo(groupOwner sdk.AccAddress, groupName string) *Principal {
+	return &Principal{
+		Type:  PRINCIPAL_TYPE_GNFD_GROUP,
+		Value: types.NewGroupGRN(groupOwner, groupName).String(),
 	}
 }
 
@@ -29,13 +38,7 @@ func (p *Principal) ValidateBasic() error {
 			return ErrInvalidPrincipal.Wrapf("Invalid account, principal: %s, err: %s", p.String(), err)
 		}
 	case PRINCIPAL_TYPE_GNFD_GROUP:
-		groupID, err := sdkmath.ParseUint(p.Value)
-		if err != nil {
-			return ErrInvalidPrincipal.Wrapf("Invalid groupID, principal: %s, err: %s", p.String(), err)
-		}
-		if groupID.Equal(sdkmath.ZeroUint()) {
-			return ErrInvalidPrincipal.Wrapf("Zero groupID, principal %s", p.String())
-		}
+		return nil
 	default:
 		return ErrInvalidPrincipal.Wrapf("Unknown principal type.")
 	}

--- a/x/storage/keeper/query.go
+++ b/x/storage/keeper/query.go
@@ -285,7 +285,7 @@ func (k Keeper) QueryPolicyForGroup(goCtx context.Context, req *types.QueryPolic
 	}
 
 	policy, err := k.GetPolicy(
-		ctx, &grn, permtypes.NewPrincipalWithGroup(id),
+		ctx, &grn, permtypes.NewPrincipalWithGroupId(id),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Description
This PR is to enable the following feature: user can bind a group by name to a resource.

### Rationale

In some scenario we dont know exact the group id of a group, for example the create group message and bind policy policy are in a same tx, but we know the name, so it is much easier to use name instead of ID.

### Example

Just make the vaule as:  `grn:g:0xB74AF3aea8F22AbE0683F6D49c9f03c4F8dF449b:xxgroupname`

### Changes

None
