### PR TITLE
release: prepare release for v0.2.3-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
 ## v0.2.3-alpha.2
-This release enables support for group name in policy
+This release enables 2 new features:  
 
-* [#301](https://github.com/bnb-chain/greenfield/pull/301) feat: add support of group name in policy  
+Features  
+* [#301](https://github.com/bnb-chain/greenfield/pull/301) feat: add support of group name in policy
+* [#304](https://github.com/bnb-chain/greenfield/pull/304) feat: allow simulate create bucket without approval
 
 ## v0.2.3-alpha.1
 This release enables several features and bugfixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.3-alpha.2
+This release enables support for group name in policy
+
+* [#301](https://github.com/bnb-chain/greenfield/pull/301) feat: add support of group name in policy  
+
 ## v0.2.3-alpha.1
 This release enables several features and bugfixes:
 

--- a/e2e/tests/permission_test.go
+++ b/e2e/tests/permission_test.go
@@ -675,7 +675,7 @@ func (s *StorageTestSuite) TestGrantsPermissionToGroup() {
 		Actions: []types.ActionType{types.ACTION_UPDATE_BUCKET_INFO, types.ACTION_DELETE_BUCKET},
 		Effect:  types.EFFECT_ALLOW,
 	}
-	principal := types.NewPrincipalWithGroup(headGroupResponse.GroupInfo.Id)
+	principal := types.NewPrincipalWithGroupInfo(user[0].GetAddr(), headGroupResponse.GroupInfo.GroupName)
 	msgPutPolicy := storagetypes.NewMsgPutPolicy(user[0].GetAddr(), types2.NewBucketGRN(bucketName).String(),
 		principal, []*types.Statement{statement}, nil)
 	s.SendTxBlock(user[0], msgPutPolicy)
@@ -1103,7 +1103,7 @@ func (s *StorageTestSuite) TestStalePermissionForGroupGC() {
 	s.Require().True(owner.GetAddr().Equals(sdk.MustAccAddressFromHex(headGroupResponse.GroupInfo.Owner)))
 	s.T().Logf("GroupInfo: %s", headGroupResponse.GetGroupInfo().String())
 
-	principal := types.NewPrincipalWithGroup(headGroupResponse.GroupInfo.Id)
+	principal := types.NewPrincipalWithGroupId(headGroupResponse.GroupInfo.Id)
 	// Put bucket policy for group
 	bucketStatement := &types.Statement{
 		Actions: []types.ActionType{types.ACTION_DELETE_BUCKET},

--- a/x/permission/types/common.go
+++ b/x/permission/types/common.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"github.com/bnb-chain/greenfield/types"
+
 	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -12,10 +14,17 @@ func NewPrincipalWithAccount(addr sdk.AccAddress) *Principal {
 	}
 }
 
-func NewPrincipalWithGroup(groupID sdkmath.Uint) *Principal {
+func NewPrincipalWithGroupId(groupID sdkmath.Uint) *Principal {
 	return &Principal{
 		Type:  PRINCIPAL_TYPE_GNFD_GROUP,
 		Value: groupID.String(),
+	}
+}
+
+func NewPrincipalWithGroupInfo(groupOwner sdk.AccAddress, groupName string) *Principal {
+	return &Principal{
+		Type:  PRINCIPAL_TYPE_GNFD_GROUP,
+		Value: types.NewGroupGRN(groupOwner, groupName).String(),
 	}
 }
 
@@ -29,13 +38,7 @@ func (p *Principal) ValidateBasic() error {
 			return ErrInvalidPrincipal.Wrapf("Invalid account, principal: %s, err: %s", p.String(), err)
 		}
 	case PRINCIPAL_TYPE_GNFD_GROUP:
-		groupID, err := sdkmath.ParseUint(p.Value)
-		if err != nil {
-			return ErrInvalidPrincipal.Wrapf("Invalid groupID, principal: %s, err: %s", p.String(), err)
-		}
-		if groupID.Equal(sdkmath.ZeroUint()) {
-			return ErrInvalidPrincipal.Wrapf("Zero groupID, principal %s", p.String())
-		}
+		return nil
 	default:
 		return ErrInvalidPrincipal.Wrapf("Unknown principal type.")
 	}

--- a/x/storage/keeper/keeper.go
+++ b/x/storage/keeper/keeper.go
@@ -99,9 +99,12 @@ func (k Keeper) CreateBucket(
 	if opts.PrimarySpApproval.ExpiredHeight < uint64(ctx.BlockHeight()) {
 		return sdkmath.ZeroUint(), errors.Wrapf(types.ErrInvalidApproval, "The approval of sp is expired.")
 	}
-	err = k.VerifySPAndSignature(ctx, primarySpAcc, opts.ApprovalMsgBytes, opts.PrimarySpApproval.Sig)
-	if err != nil {
-		return sdkmath.ZeroUint(), err
+
+	if !ctx.IsCheckTx() {
+		err = k.VerifySPAndSignature(ctx, primarySpAcc, opts.ApprovalMsgBytes, opts.PrimarySpApproval.Sig)
+		if err != nil {
+			return sdkmath.ZeroUint(), err
+		}
 	}
 
 	bucketInfo := types.BucketInfo{

--- a/x/storage/keeper/query.go
+++ b/x/storage/keeper/query.go
@@ -285,7 +285,7 @@ func (k Keeper) QueryPolicyForGroup(goCtx context.Context, req *types.QueryPolic
 	}
 
 	policy, err := k.GetPolicy(
-		ctx, &grn, permtypes.NewPrincipalWithGroup(id),
+		ctx, &grn, permtypes.NewPrincipalWithGroupId(id),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Description
This release enables 2 new features.  
  
### Rationale
* [#301](https://github.com/bnb-chain/greenfield/pull/301) feat: add support of group name in policy  
* [#304](https://github.com/bnb-chain/greenfield/pull/304) feat: allow simulate create bucket without approval  

### Example

Please refer to the PRs for detailed information.  

### Changes

Notable changes: 
none  
  