### PR TITLE
feat: allow simulate create bucket without approval

### DIFF
--- a/x/storage/keeper/keeper.go
+++ b/x/storage/keeper/keeper.go
@@ -99,9 +99,12 @@ func (k Keeper) CreateBucket(
 	if opts.PrimarySpApproval.ExpiredHeight < uint64(ctx.BlockHeight()) {
 		return sdkmath.ZeroUint(), errors.Wrapf(types.ErrInvalidApproval, "The approval of sp is expired.")
 	}
-	err = k.VerifySPAndSignature(ctx, primarySpAcc, opts.ApprovalMsgBytes, opts.PrimarySpApproval.Sig)
-	if err != nil {
-		return sdkmath.ZeroUint(), err
+
+	if !ctx.IsCheckTx() {
+		err = k.VerifySPAndSignature(ctx, primarySpAcc, opts.ApprovalMsgBytes, opts.PrimarySpApproval.Sig)
+		if err != nil {
+			return sdkmath.ZeroUint(), err
+		}
 	}
 
 	bucketInfo := types.BucketInfo{


### PR DESCRIPTION
### Description

This pr will allow simulating bucket creation without approval from storage provider.

### Rationale

For frontend's need, e.g., estimate gas, check whether bucket name exists.

### Example

NA

### Changes

Notable changes: 
* all simulate without approval
