### PR TITLE
feat: fix DefaultMaxPayloadSize from 2GB to 64GB

### DIFF
--- a/x/storage/types/params.go
+++ b/x/storage/types/params.go
@@ -14,7 +14,7 @@ const (
 	DefaultMaxSegmentSize            uint64 = 16 * 1024 * 1024 // 16M
 	DefaultRedundantDataChunkNum     uint32 = 4
 	DefaultRedundantParityChunkNum   uint32 = 2
-	DefaultMaxPayloadSize            uint64 = 2 * 1024 * 1024 * 1024
+	DefaultMaxPayloadSize            uint64 = 64 * 1024 * 1024 * 1024
 	DefaultMaxBucketsPerAccount      uint32 = 100
 	DefaultMinChargeSize             uint64 = 1 * 1024 * 1024 // 1M
 	DefaultDiscontinueCountingWindow uint64 = 10000


### PR DESCRIPTION
### Description

Due to the addition of resumable upload and resumable download functionalities(https://github.com/bnb-chain/greenfield-storage-provider/pull/480 & https://github.com/bnb-chain/greenfield-go-sdk/pull/91 ), we now allow uploading larger files to Greenfield. Therefore, we have increased the value of DefaultMaxPayloadSize from 2GB to 64 GB.


### Rationale

This configuration change allows users to upload files with a maximum size of 64GB to Greenfield. The DefaultMaxPayloadSize parameter defines the maximum payload size that can be handled by the system during file uploads.

### Example

NA

### Changes

NA
