### PR TITLE
fix: add chainid to sign bytes to prevent replay attack

### DIFF
--- a/e2e/tests/challenge_test.go
+++ b/e2e/tests/challenge_test.go
@@ -180,7 +180,7 @@ func (s *ChallengeTestSuite) TestNormalAttest() {
 
 	msgAttest := challengetypes.NewMsgAttest(s.Challenger.GetAddr(), event.ChallengeId, event.ObjectId, primarySp.String(),
 		challengetypes.CHALLENGE_SUCCEED, user.GetAddr().String(), valBitset.Bytes(), nil)
-	toSign := msgAttest.GetBlsSignBytes()
+	toSign := msgAttest.GetBlsSignBytes(s.Config.ChainId)
 
 	voteAggSignature, err := s.ValidatorBLS.Sign(toSign[:])
 	if err != nil {
@@ -261,7 +261,7 @@ func (s *ChallengeTestSuite) TestHeartbeatAttest() {
 
 	msgAttest := challengetypes.NewMsgAttest(s.Challenger.GetAddr(), event.ChallengeId, event.ObjectId,
 		event.SpOperatorAddress, challengetypes.CHALLENGE_FAILED, "", valBitset.Bytes(), nil)
-	toSign := msgAttest.GetBlsSignBytes()
+	toSign := msgAttest.GetBlsSignBytes(s.Config.ChainId)
 
 	voteAggSignature, err := s.ValidatorBLS.Sign(toSign[:])
 	if err != nil {
@@ -331,7 +331,7 @@ func (s *ChallengeTestSuite) TestFailedAttest_ChallengeExpired() {
 
 	msgAttest := challengetypes.NewMsgAttest(user.GetAddr(), event.ChallengeId, event.ObjectId, primarySp.String(),
 		challengetypes.CHALLENGE_SUCCEED, user.GetAddr().String(), valBitset.Bytes(), nil)
-	toSign := msgAttest.GetBlsSignBytes()
+	toSign := msgAttest.GetBlsSignBytes(s.Config.ChainId)
 
 	voteAggSignature, err := s.ValidatorBLS.Sign(toSign[:])
 	if err != nil {

--- a/x/challenge/keeper/bls_signed_msg.go
+++ b/x/challenge/keeper/bls_signed_msg.go
@@ -3,6 +3,8 @@ package keeper
 import (
 	"fmt"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"cosmossdk.io/errors"
 	"github.com/bits-and-blooms/bitset"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
@@ -14,7 +16,7 @@ import (
 // BlsSignedMsg defined the interface of a bls signed message.
 type BlsSignedMsg interface {
 	// GetBlsSignBytes returns the bls signed message in bytes.
-	GetBlsSignBytes() [32]byte
+	GetBlsSignBytes(chainId string) [32]byte
 
 	// GetVoteValidatorSet returns the validators who signed the message.
 	GetVoteValidatorSet() []uint64
@@ -24,7 +26,7 @@ type BlsSignedMsg interface {
 }
 
 // verifySignature verifies whether the signature is valid or not.
-func (k Keeper) verifySignature(signedMsg BlsSignedMsg, validators []stakingtypes.Validator) ([]string, error) {
+func (k Keeper) verifySignature(ctx sdk.Context, signedMsg BlsSignedMsg, validators []stakingtypes.Validator) ([]string, error) {
 	validatorsBitSet := bitset.From(signedMsg.GetVoteValidatorSet())
 	if validatorsBitSet.Count() > uint(len(validators)) {
 		return nil, errors.Wrap(types.ErrInvalidVoteValidatorSet, "number of validator set is larger than validators")
@@ -54,7 +56,7 @@ func (k Keeper) verifySignature(signedMsg BlsSignedMsg, validators []stakingtype
 		return nil, errors.Wrapf(types.ErrInvalidVoteAggSignature, fmt.Sprintf("BLS signature converts failed: %v", err))
 	}
 
-	if !aggSig.FastAggregateVerify(votedPubKeys, signedMsg.GetBlsSignBytes()) {
+	if !aggSig.FastAggregateVerify(votedPubKeys, signedMsg.GetBlsSignBytes(ctx.ChainID())) {
 		return nil, errors.Wrap(types.ErrInvalidVoteAggSignature, "Signature verify failed")
 	}
 

--- a/x/challenge/keeper/msg_server_attest.go
+++ b/x/challenge/keeper/msg_server_attest.go
@@ -54,7 +54,7 @@ func (k msgServer) Attest(goCtx context.Context, msg *types.MsgAttest) (*types.M
 	}
 
 	// check attest validators and signatures
-	validators, err := k.verifySignature(msg, allValidators)
+	validators, err := k.verifySignature(ctx, msg, allValidators)
 	if err != nil {
 		return nil, err
 	}

--- a/x/challenge/keeper/msg_server_attest_test.go
+++ b/x/challenge/keeper/msg_server_attest_test.go
@@ -147,7 +147,7 @@ func (s *TestSuite) TestAttest_Heartbeat() {
 		ChallengerAddress: "",
 		VoteValidatorSet:  []uint64{1},
 	}
-	toSign := attestMsg.GetBlsSignBytes()
+	toSign := attestMsg.GetBlsSignBytes(s.ctx.ChainID())
 
 	voteAggSignature := blsKey.Sign(toSign[:])
 	attestMsg.VoteAggSignature = voteAggSignature.Marshal()
@@ -209,7 +209,7 @@ func (s *TestSuite) TestAttest_Normal() {
 		ChallengerAddress: "",
 		VoteValidatorSet:  []uint64{1},
 	}
-	toSign := attestMsg.GetBlsSignBytes()
+	toSign := attestMsg.GetBlsSignBytes(s.ctx.ChainID())
 
 	voteAggSignature := blsKey.Sign(toSign[:])
 	attestMsg.VoteAggSignature = voteAggSignature.Marshal()

--- a/x/challenge/types/message_attest.go
+++ b/x/challenge/types/message_attest.go
@@ -80,7 +80,7 @@ func (msg *MsgAttest) ValidateBasic() error {
 	return nil
 }
 
-func (msg *MsgAttest) GetBlsSignBytes() [32]byte {
+func (msg *MsgAttest) GetBlsSignBytes(chainId string) [32]byte {
 	challengeIdBz := make([]byte, 8)
 	binary.BigEndian.PutUint64(challengeIdBz, msg.ChallengeId)
 	objectIdBz := msg.ObjectId.Bytes()
@@ -94,6 +94,7 @@ func (msg *MsgAttest) GetBlsSignBytes() [32]byte {
 	}
 
 	bs := make([]byte, 0)
+	bs = append(bs, []byte(chainId)...)
 	bs = append(bs, challengeIdBz...)
 	bs = append(bs, objectIdBz...)
 	bs = append(bs, resultBz...)


### PR DESCRIPTION
### Description

This pr will add `chain id` to challenge attestation sign bytes, for preventing replay attacks.

### Rationale

Security fix

### Example

NA

### Changes

Notable changes: 
* the message to sign is changed
