### PR TITLE
feat: update challenge and stop serving for sp exit

### DIFF
--- a/x/challenge/keeper/msg_server_attest_test.go
+++ b/x/challenge/keeper/msg_server_attest_test.go
@@ -3,6 +3,8 @@ package keeper_test
 import (
 	"testing"
 
+	virtualgroupmoduletypes "github.com/bnb-chain/greenfield/x/virtualgroup/types"
+
 	sptypes "github.com/bnb-chain/greenfield/x/sp/types"
 
 	"cosmossdk.io/math"
@@ -130,10 +132,18 @@ func (s *TestSuite) TestAttest_Heartbeat() {
 	s.stakingKeeper.EXPECT().GetHistoricalInfo(gomock.Any(), gomock.Any()).
 		Return(historicalInfo, true).AnyTimes()
 
-	existObjectName := "existobject"
+	existBucket := &storagetypes.BucketInfo{
+		Id:          math.NewUint(10),
+		BucketName:  "existbucket",
+		PrimarySpId: 1,
+	}
+	s.storageKeeper.EXPECT().GetBucketInfo(gomock.Any(), gomock.Eq(existBucket.BucketName)).
+		Return(existBucket, true).AnyTimes()
+
 	existObject := &storagetypes.ObjectInfo{
 		Id:           math.NewUint(10),
-		ObjectName:   existObjectName,
+		ObjectName:   "existobject",
+		BucketName:   existBucket.BucketName,
 		ObjectStatus: storagetypes.OBJECT_STATUS_SEALED,
 		PayloadSize:  500}
 	s.storageKeeper.EXPECT().GetObjectInfoById(gomock.Any(), gomock.Eq(math.NewUint(10))).
@@ -148,6 +158,12 @@ func (s *TestSuite) TestAttest_Heartbeat() {
 	sp := &sptypes.StorageProvider{Id: 10, OperatorAddress: spOperatorAcc.String()}
 	s.spKeeper.EXPECT().GetStorageProviderByOperatorAddr(gomock.Any(), gomock.Any()).
 		Return(sp, true).AnyTimes()
+
+	gvg := &virtualgroupmoduletypes.GlobalVirtualGroup{
+		SecondarySpIds: []uint32{10},
+	}
+	s.storageKeeper.EXPECT().GetObjectGVG(gomock.Any(), gomock.Eq(existBucket.Id), gomock.Any()).
+		Return(gvg, true).AnyTimes()
 
 	attestMsg := &types.MsgAttest{
 		Submitter:         validSubmitter.String(),
@@ -196,10 +212,18 @@ func (s *TestSuite) TestAttest_Normal() {
 	s.stakingKeeper.EXPECT().GetHistoricalInfo(gomock.Any(), gomock.Any()).
 		Return(historicalInfo, true).AnyTimes()
 
-	existObjectName := "existobject"
+	existBucket := &storagetypes.BucketInfo{
+		Id:          math.NewUint(10),
+		BucketName:  "existbucket",
+		PrimarySpId: 1,
+	}
+	s.storageKeeper.EXPECT().GetBucketInfo(gomock.Any(), gomock.Eq(existBucket.BucketName)).
+		Return(existBucket, true).AnyTimes()
+
 	existObject := &storagetypes.ObjectInfo{
 		Id:           math.NewUint(10),
-		ObjectName:   existObjectName,
+		ObjectName:   "existobject",
+		BucketName:   existBucket.BucketName,
 		ObjectStatus: storagetypes.OBJECT_STATUS_SEALED,
 		PayloadSize:  500}
 	s.storageKeeper.EXPECT().GetObjectInfoById(gomock.Any(), gomock.Eq(math.NewUint(10))).

--- a/x/challenge/keeper/msg_server_attest_test.go
+++ b/x/challenge/keeper/msg_server_attest_test.go
@@ -3,8 +3,6 @@ package keeper_test
 import (
 	"testing"
 
-	virtualgroupmoduletypes "github.com/bnb-chain/greenfield/x/virtualgroup/types"
-
 	sptypes "github.com/bnb-chain/greenfield/x/sp/types"
 
 	"cosmossdk.io/math"
@@ -17,6 +15,7 @@ import (
 	"github.com/bnb-chain/greenfield/testutil/sample"
 	"github.com/bnb-chain/greenfield/x/challenge/types"
 	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
+	virtualgrouptypes "github.com/bnb-chain/greenfield/x/virtualgroup/types"
 )
 
 func (s *TestSuite) TestAttest_Invalid() {
@@ -159,7 +158,7 @@ func (s *TestSuite) TestAttest_Heartbeat() {
 	s.spKeeper.EXPECT().GetStorageProviderByOperatorAddr(gomock.Any(), gomock.Any()).
 		Return(sp, true).AnyTimes()
 
-	gvg := &virtualgroupmoduletypes.GlobalVirtualGroup{
+	gvg := &virtualgrouptypes.GlobalVirtualGroup{
 		SecondarySpIds: []uint32{10},
 	}
 	s.storageKeeper.EXPECT().GetObjectGVG(gomock.Any(), gomock.Eq(existBucket.Id), gomock.Any()).

--- a/x/storage/keeper/keeper.go
+++ b/x/storage/keeper/keeper.go
@@ -216,6 +216,7 @@ func (k Keeper) doDeleteBucket(ctx sdk.Context, operator sdk.AccAddress, bucketI
 	store.Delete(types.GetBucketByIDKey(bucketInfo.Id))
 	store.Delete(types.GetQuotaKey(bucketInfo.Id))
 	store.Delete(types.GetInternalBucketInfoKey(bucketInfo.Id))
+	store.Delete(types.GetMigrationBucketKey(bucketInfo.Id))
 
 	err := k.appendResourceIdForGarbageCollection(ctx, resource.RESOURCE_TYPE_BUCKET, bucketInfo.Id)
 	if err != nil {


### PR DESCRIPTION
### Description

This pr refines challenge module and stop serving for sp exit.

### Rationale

* When force delete bucket, the bucket could be in migration status.
* When attestation submitted, should not slash the sp it it already exit/swapout/...

### Example

NA

### Changes

Notable changes: 
* challenge attestation
* force delete
