### PR TITLE
chore: refine migrate bucket and sp exit

### DIFF
--- a/internal/sequence/sequence.go
+++ b/internal/sequence/sequence.go
@@ -41,19 +41,12 @@ func (s Sequence[T]) CurVal(store storetypes.KVStore) T {
 	return any(ret).(T)
 }
 
-// PeekNextVal returns the CurVal + increment step. Not persistent.
-func (s Sequence[T]) PeekNextVal(store storetypes.KVStore) T {
-	v := store.Get(s.storeKey)
-	seq := s.DecodeSequence(v)
-	seq = s.IncreaseSequence(seq)
-	return any(seq).(T)
-}
-
 // InitVal this function sets the starting value for a sequence and can only be called once
 // on an empty database. If the key already exists, an error will be returned. The provided
 // start value will be stored as the current value. It is advised to use this function only
 // when the sequence start value is not '1', as calling it unnecessarily will consume
 // unnecessary gas. An example scenario would be importing from genesis.
+// WARNING: only for test now
 func (s Sequence[T]) InitVal(store storetypes.KVStore, seq T) error {
 	if store.Has(s.storeKey) {
 		return ErrSequenceUniqueConstraint

--- a/x/sp/keeper/sp.go
+++ b/x/sp/keeper/sp.go
@@ -134,14 +134,6 @@ func (k Keeper) GetAllStorageProviders(ctx sdk.Context) (sps []types.StorageProv
 
 func (k Keeper) Exit(ctx sdk.Context, sp *types.StorageProvider) error {
 	store := ctx.KVStore(k.storeKey)
-
-	// send back the total deposit
-	coins := sdk.NewCoins(sdk.NewCoin(k.DepositDenomForSP(ctx), sp.TotalDeposit))
-	err := k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, sdk.MustAccAddressFromHex(sp.FundingAddress), coins)
-	if err != nil {
-		return err
-	}
-
 	store.Delete(types.GetStorageProviderByOperatorAddrKey(sdk.MustAccAddressFromHex(sp.OperatorAddress)))
 	store.Delete(types.GetStorageProviderByFundingAddrKey(sdk.MustAccAddressFromHex(sp.FundingAddress)))
 	store.Delete(types.GetStorageProviderBySealAddrKey(sdk.MustAccAddressFromHex(sp.SealAddress)))

--- a/x/virtualgroup/keeper/keeper.go
+++ b/x/virtualgroup/keeper/keeper.go
@@ -133,11 +133,7 @@ func (k Keeper) DeleteGVG(ctx sdk.Context, primarySp *sptypes.StorageProvider, g
 
 	store.Delete(types.GetGVGKey(gvg.Id))
 
-	if len(gvgFamily.GlobalVirtualGroupIds) == 0 {
-		store.Delete(types.GetGVGFamilyKey(gvg.PrimarySpId, gvgFamily.Id))
-	} else {
-		k.SetGVGFamily(ctx, gvg.PrimarySpId, gvgFamily)
-	}
+	k.SetGVGFamily(ctx, gvg.PrimarySpId, gvgFamily)
 	return nil
 }
 
@@ -506,6 +502,10 @@ func (k Keeper) CompleteSwapOut(ctx sdk.Context, gvgFamilyID uint32, gvgIDs []ui
 		bz := store.Get(key)
 		k.cdc.MustUnmarshal(bz, &swapOutInfo)
 
+		if swapOutInfo.SuccessorSpId != successorSP.Id {
+			return types.ErrSwapOutFailed.Wrapf("The successor sp(ID: %d) is mismatch with the specify successor sp (ID: %d)", successorSP.Id, swapOutInfo.SuccessorSpId)
+		}
+
 		sp, found := k.spKeeper.GetStorageProvider(ctx, swapOutInfo.SpId)
 		if !found {
 			return sptypes.ErrStorageProviderNotFound.Wrapf("The storage provider(ID: %d) not found when complete swap out.", swapOutInfo.SpId)
@@ -521,6 +521,10 @@ func (k Keeper) CompleteSwapOut(ctx sdk.Context, gvgFamilyID uint32, gvgIDs []ui
 			key := types.GetSwapOutGVGKey(gvgID)
 			bz := store.Get(key)
 			k.cdc.MustUnmarshal(bz, &swapOutInfo)
+
+			if swapOutInfo.SuccessorSpId != successorSP.Id {
+				return types.ErrSwapOutFailed.Wrapf("The successor sp(ID: %d) is mismatch with the specify successor sp (ID: %d)", successorSP.Id, swapOutInfo.SuccessorSpId)
+			}
 
 			sp, found := k.spKeeper.GetStorageProvider(ctx, swapOutInfo.SpId)
 			if !found {

--- a/x/virtualgroup/keeper/msg_server.go
+++ b/x/virtualgroup/keeper/msg_server.go
@@ -436,6 +436,13 @@ func (k msgServer) CompleteStorageProviderExit(goCtx context.Context, msg *types
 		return nil, err
 	}
 
+	// send back the total deposit
+	coins := sdk.NewCoins(sdk.NewCoin(k.spKeeper.DepositDenomForSP(ctx), sp.TotalDeposit))
+	err = k.bankKeeper.SendCoinsFromModuleToAccount(ctx, sptypes.ModuleName, sdk.MustAccAddressFromHex(sp.FundingAddress), coins)
+	if err != nil {
+		return nil, err
+	}
+
 	err = k.spKeeper.Exit(ctx, sp)
 	if err != nil {
 		return nil, err

--- a/x/virtualgroup/types/expected_keepers.go
+++ b/x/virtualgroup/types/expected_keepers.go
@@ -14,6 +14,7 @@ type SpKeeper interface {
 	GetStorageProviderByFundingAddr(ctx sdk.Context, sealAddr sdk.AccAddress) (sp *sptypes.StorageProvider, found bool)
 	SetStorageProvider(ctx sdk.Context, sp *sptypes.StorageProvider)
 	Exit(ctx sdk.Context, sp *sptypes.StorageProvider) error
+	DepositDenomForSP(ctx sdk.Context) (res string)
 }
 
 // AccountKeeper defines the expected account keeper used for simulations (noalias)


### PR DESCRIPTION
### Description

refine the code of migrate bucket and sp exit process

### Rationale

1. add successor sp check
2. Adjust the order of some processes.

### Example

NA

### Changes

Notable changes: 
* NA
