### PR TITLE
feat: add tendermint to sdk

### DIFF
--- a/sdk/client/gnfd_client.go
+++ b/sdk/client/gnfd_client.go
@@ -34,6 +34,7 @@ import (
 	paymenttypes "github.com/bnb-chain/greenfield/x/payment/types"
 	sptypes "github.com/bnb-chain/greenfield/x/sp/types"
 	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
+	bfthttp "github.com/cometbft/cometbft/rpc/client/http"
 )
 
 // AuthQueryClient is a type to define the auth types Query Client
@@ -133,7 +134,8 @@ type GreenfieldClient struct {
 	TxClient
 	// TmService holds the tendermint service client
 	TmClient
-
+	// tendermintClient directly interact with tendermint Node
+	tendermintClient *bfthttp.HTTP
 	// keyManager is the manager used for generating and managing keys.
 	keyManager keys.KeyManager
 	// chainId is the id of the chain.
@@ -170,6 +172,7 @@ func newGreenfieldClient(rpcAddr, chainId string, rpcClient *rpchttp.HTTP, opts 
 		chainId: chainId,
 		codec:   cdc,
 	}
+	client.tendermintClient = rpcClient
 	for _, opt := range opts {
 		opt.Apply(client)
 	}

--- a/sdk/client/gnfd_tm.go
+++ b/sdk/client/gnfd_tm.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"encoding/hex"
+
 	ctypes "github.com/cometbft/cometbft/rpc/core/types"
 )
 

--- a/sdk/client/gnfd_tm.go
+++ b/sdk/client/gnfd_tm.go
@@ -11,8 +11,8 @@ func (c *GreenfieldClient) GetBlock(ctx context.Context, height *int64) (*ctypes
 	return c.tendermintClient.Block(ctx, height)
 }
 
-// GetTx gets a tx by detail by the tx hash
-func (c *GreenfieldClient) GetTx(ctx context.Context, txHash string) (*ctypes.ResultTx, error) {
+// Tx gets a tx by detail by the tx hash
+func (c *GreenfieldClient) Tx(ctx context.Context, txHash string) (*ctypes.ResultTx, error) {
 	hash, err := hex.DecodeString(txHash)
 	if err != nil {
 		return nil, err

--- a/sdk/client/gnfd_tm.go
+++ b/sdk/client/gnfd_tm.go
@@ -1,0 +1,41 @@
+package client
+
+import (
+	"context"
+	"encoding/hex"
+	ctypes "github.com/cometbft/cometbft/rpc/core/types"
+)
+
+// GetBlock by height, gets the latest block if height is nil
+func (c *GreenfieldClient) GetBlock(ctx context.Context, height *int64) (*ctypes.ResultBlock, error) {
+	return c.tendermintClient.Block(ctx, height)
+}
+
+// GetTx gets a tx by detail by the tx hash
+func (c *GreenfieldClient) GetTx(ctx context.Context, txHash string) (*ctypes.ResultTx, error) {
+	hash, err := hex.DecodeString(txHash)
+	if err != nil {
+		return nil, err
+	}
+	return c.tendermintClient.Tx(ctx, hash, true)
+}
+
+// GetBlockResults by height, gets the latest block result if height is nil
+func (c *GreenfieldClient) GetBlockResults(ctx context.Context, height *int64) (*ctypes.ResultBlockResults, error) {
+	return c.tendermintClient.BlockResults(ctx, height)
+}
+
+// GetValidators by height, gets the latest validators if height is nil
+func (c *GreenfieldClient) GetValidators(ctx context.Context, height *int64) (*ctypes.ResultValidators, error) {
+	return c.tendermintClient.Validators(ctx, height, nil, nil)
+}
+
+// GetHeader by height, gets the latest block header if height is nil
+func (c *GreenfieldClient) GetHeader(ctx context.Context, height *int64) (*ctypes.ResultHeader, error) {
+	return c.tendermintClient.Header(ctx, height)
+}
+
+// GetUnconfirmedTxs by height, gets the latest block header if height is nil
+func (c *GreenfieldClient) GetUnconfirmedTxs(ctx context.Context, limit *int) (*ctypes.ResultUnconfirmedTxs, error) {
+	return c.tendermintClient.UnconfirmedTxs(ctx, limit)
+}

--- a/sdk/client/gnfd_tm_test.go
+++ b/sdk/client/gnfd_tm_test.go
@@ -2,13 +2,14 @@ package client
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	"github.com/bnb-chain/greenfield/sdk/client/test"
 	"github.com/bnb-chain/greenfield/sdk/keys"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/stretchr/testify/assert"
-	"testing"
-	"time"
 )
 
 func TestTmClient(t *testing.T) {

--- a/sdk/client/gnfd_tm_test.go
+++ b/sdk/client/gnfd_tm_test.go
@@ -1,0 +1,52 @@
+package client
+
+import (
+	"context"
+	"github.com/bnb-chain/greenfield/sdk/client/test"
+	"github.com/bnb-chain/greenfield/sdk/keys"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestTmClient(t *testing.T) {
+	km, err := keys.NewPrivateKeyManager(test.TEST_PRIVATE_KEY)
+	assert.NoError(t, err)
+	gnfdCli, err := NewGreenfieldClient(test.TEST_RPC_ADDR, test.TEST_CHAIN_ID, WithKeyManager(km))
+	assert.NoError(t, err)
+	to, err := sdk.AccAddressFromHexUnsafe(test.TEST_ADDR)
+	assert.NoError(t, err)
+	transfer := banktypes.NewMsgSend(km.GetAddr(), to, sdk.NewCoins(sdk.NewInt64Coin(test.TEST_TOKEN_NAME, 12)))
+	response, err := gnfdCli.BroadcastTx(context.Background(), []sdk.Msg{transfer}, nil)
+	assert.NoError(t, err)
+	time.Sleep(2 * time.Second)
+	// get tx
+	res, err := gnfdCli.GetTx(context.Background(), response.TxResponse.TxHash)
+	assert.NoError(t, err)
+	t.Log(res.Hash)
+	t.Log(res.TxResult.String())
+
+	// get the latest block
+	block, err := gnfdCli.GetBlock(context.Background(), nil)
+	assert.NoError(t, err)
+	t.Log(block)
+
+	h := block.Block.Height
+
+	block, err = gnfdCli.GetBlock(context.Background(), &h)
+	assert.NoError(t, err)
+	t.Log(block)
+
+	// get block result
+	blockResult, err := gnfdCli.GetBlockResults(context.Background(), &h)
+	assert.NoError(t, err)
+	t.Log(blockResult)
+
+	// get validator
+	validators, err := gnfdCli.GetValidators(context.Background(), &h)
+	assert.NoError(t, err)
+	t.Log(validators.Validators)
+
+}

--- a/sdk/client/gnfd_tm_test.go
+++ b/sdk/client/gnfd_tm_test.go
@@ -23,7 +23,7 @@ func TestTmClient(t *testing.T) {
 	assert.NoError(t, err)
 	time.Sleep(2 * time.Second)
 	// get tx
-	res, err := gnfdCli.GetTx(context.Background(), response.TxResponse.TxHash)
+	res, err := gnfdCli.Tx(context.Background(), response.TxResponse.TxHash)
 	assert.NoError(t, err)
 	t.Log(res.Hash)
 	t.Log(res.TxResult.String())


### PR DESCRIPTION
### Description

add tendermint client to sdk and support basic functionality 

### Rationale

direct access to node instead of using abci query back to cosmos sdk

### Example

NA

### Changes

Notable changes: 
* NA