### PR TITLE
fix: add missing mempool and iavl flag for init app

### DIFF
--- a/cmd/gnfd/cmd/root.go
+++ b/cmd/gnfd/cmd/root.go
@@ -25,6 +25,7 @@ import (
 	snapshottypes "github.com/cosmos/cosmos-sdk/snapshots/types"
 	"github.com/cosmos/cosmos-sdk/store"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	"github.com/cosmos/cosmos-sdk/types/mempool"
 	authcmd "github.com/cosmos/cosmos-sdk/x/auth/client/cli"
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
@@ -367,6 +368,12 @@ func (a appCreator) newApp(
 		baseapp.SetSnapshot(snapshotStore, snapshotOptions),
 		baseapp.SetIAVLCacheSize(cast.ToInt(appOpts.Get(server.FlagIAVLCacheSize))),
 		baseapp.SetIAVLDisableFastNode(cast.ToBool(appOpts.Get(server.FlagDisableIAVLFastNode))),
+		baseapp.SetMempool(
+			mempool.NewSenderNonceMempool(
+				mempool.SenderNonceMaxTxOpt(cast.ToInt(appOpts.Get(server.FlagMempoolMaxTxs))),
+			),
+		),
+		baseapp.SetIAVLLazyLoading(cast.ToBool(appOpts.Get(server.FlagIAVLLazyLoading))),
 		baseapp.SetChainID(chainID),
 	)
 }


### PR DESCRIPTION
### Description

fix: add missing mempool and iavl flag for init app

### Rationale

the `mempool` and `IAVLLazyLoading` is missing to set.

cosmos-sdk->https://github.com/bnb-chain/greenfield-cosmos-sdk/blob/d906f0ee2d278d45658822c624837e9359d876bd/server/util.go#L493

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* root cmd
