### PR TITLE
feat: add create storage provider command

### DIFF
--- a/x/sp/client/cli/tx.go
+++ b/x/sp/client/cli/tx.go
@@ -87,7 +87,7 @@ Where create_storagep_provider.json contains:
   "metadata": "4pIMOgIGx1vZGU=",
   "deposit": "1000000000000000000BNB"
 }
-modify the related configrations as you need, where you can get the pubkey using "%s tendermint show-validator"
+modify the related configrations as you need.
 `, version.AppName, version.AppName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientTxContext(cmd)

--- a/x/sp/client/cli/tx.go
+++ b/x/sp/client/cli/tx.go
@@ -54,32 +54,32 @@ func CmdCreateStorageProvider() *cobra.Command {
 $ %s tx sp create-storage-provider path/to/create_validator_proposal.json --from keyname
 Where create_storagep_provider.json contains:
 {
-  "messages":[
+  "messages": [
     {
-      "@type":"/greenfield.sp.MsgCreateStorageProvider",
-      "description":{
+      "@type": "/greenfield.sp.MsgCreateStorageProvider",
+      "description": {
         "moniker": "sp0",
-        "identity":"",
-        "website":"",
-        "security_contact":"",
-        "details":""
+        "identity": "",
+        "website": "",
+        "security_contact": "",
+        "details": ""
       },
-      "sp_address":"0x012Eadb23D670db68Ba8e67e6F34DE6ACE55b547",
-      "funding_address":"0x84b3307313e253eF5787b55616BB1F6F7139C2c0",
-      "seal_address":"0xbBD6cD73Cd376c3Dda20de0c4CBD8Fb1Bca2410D",
-      "approval_address":"0xdCE01bfaBc7c9c0865bCCeF872493B4BE3b343E8",
+      "sp_address": "0x012Eadb23D670db68Ba8e67e6F34DE6ACE55b547",
+      "funding_address": "0x84b3307313e253eF5787b55616BB1F6F7139C2c0",
+      "seal_address": "0xbBD6cD73Cd376c3Dda20de0c4CBD8Fb1Bca2410D",
+      "approval_address": "0xdCE01bfaBc7c9c0865bCCeF872493B4BE3b343E8",
       "gc_address": "0x0a1C8982C619B93bA7100411Fc58382306ab431b",
       "endpoint": "https://www.greenfield.io",
-      "deposit":{
-        "denom":"BNB",
-        "amount":"10000000000000000000000"
+      "deposit": {
+        "denom": "BNB",
+        "amount": "10000000000000000000000"
       },
       "read_price": "0.087",
       "store_price": "0.0048",
       "free_read_quota": 10000000000,
-      "creator":"0x7b5Fe22B5446f7C62Ea27B8BD71CeF94e03f3dF2",
-      "bls_key": "89f5e82d1bbb7c751b063d6d69d30c5812a088cabb9ed015b1741939a45a896d83b5435d63257b954450c26d857de4e1",
-      "bls_proof": "987406f0dd2e5f5f3e9e3e447f832dbf73809479ea552fe9b23e06e65651c01a5893e92a797d12078ef9b0c9eb72b8d90faaee65f738e222793d94b80a58cd0f329375ee04e8460f12f4772cf42859d30dd6444ed3350c3335aedf1dbde3bb68"
+      "creator": "0x7b5Fe22B5446f7C62Ea27B8BD71CeF94e03f3dF2",
+      "bls_key": "af8c586885a490a1775bcbef95e6162de1904777f3fb91e3bfd0ffd690fe0d477d0984f11852c64dc77d4583c99f34cb",
+      "bls_proof": "8bbce5330c5a46416ec41bfb93d938e8fb2e01d0a4035bd7b87efb98762e5e71faf00427d991003680325b7f97b362640f8e58e69bf774cd59e2267bdfe5a2e6578194b6834531893a39253c718edae2511977991895cdc8dd9e1136e43d721c"
     }
   ],
   "title": "create sp for test",

--- a/x/sp/client/cli/tx.go
+++ b/x/sp/client/cli/tx.go
@@ -69,14 +69,14 @@ Where create_storagep_provider.json contains:
       "seal_address": "0xbBD6cD73Cd376c3Dda20de0c4CBD8Fb1Bca2410D",
       "approval_address": "0xdCE01bfaBc7c9c0865bCCeF872493B4BE3b343E8",
       "gc_address": "0x0a1C8982C619B93bA7100411Fc58382306ab431b",
-      "endpoint": "https://www.greenfield.io",
+      "endpoint": "https://sp0.greenfield.io",
       "deposit": {
         "denom": "BNB",
-        "amount": "10000000000000000000000"
+        "amount": "1000000000000000000000"
       },
-      "read_price": "0.087",
-      "store_price": "0.0048",
-      "free_read_quota": 10000000000,
+      "read_price": "0.108", 
+      "store_price": "0.016",
+      "free_read_quota": 1073741824,
       "creator": "0x7b5Fe22B5446f7C62Ea27B8BD71CeF94e03f3dF2",
       "bls_key": "af8c586885a490a1775bcbef95e6162de1904777f3fb91e3bfd0ffd690fe0d477d0984f11852c64dc77d4583c99f34cb",
       "bls_proof": "8bbce5330c5a46416ec41bfb93d938e8fb2e01d0a4035bd7b87efb98762e5e71faf00427d991003680325b7f97b362640f8e58e69bf774cd59e2267bdfe5a2e6578194b6834531893a39253c718edae2511977991895cdc8dd9e1136e43d721c"
@@ -87,8 +87,11 @@ Where create_storagep_provider.json contains:
   "metadata": "4pIMOgIGx1vZGU=",
   "deposit": "1000000000000000000BNB"
 }
-modify the related configrations as you need.
-`, version.AppName, version.AppName)),
+modify the related configrations as you need. Example:
+1) read_price = $0.09/1024/1024/1024/300(bnb price)*10^18/30/24/60/60 = 0.108 wei/bytes/s
+2) store_price = $0.023*(1-6*0.07)/1024/1024/1024/300(bnb price)*10^18/30/24/60/60 = 0.016 wei/bytes/s. (0.07 division for each secondary SP)
+3) free_read_quota defines free read quota for each bucket, uint bytes.
+`, version.AppName)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {

--- a/x/sp/keeper/msg_server.go
+++ b/x/sp/keeper/msg_server.go
@@ -354,7 +354,7 @@ func (k msgServer) checkBlsProof(blsPk []byte, sig string) error {
 		return types.ErrStorageProviderInvalidBlsKey
 	}
 	if !signature.Verify(blsPubKey, tmhash.Sum(blsPk)) {
-		return sdkerrors.ErrorInvalidSigner
+		return sdkerrors.ErrorInvalidSigner.Wrapf("check bls proof failed.")
 	}
 	return nil
 }


### PR DESCRIPTION
### Description

Add a command for creating storage provider in one transaction, this transaction includes authz the gov module to execute the create  storage provider  message and submit a create  storage provider  proposal.

### Rationale

Merge two messages into one transaction, create new storage provider would be much easier.

### Example

```
./build/bin/gnfd tx sp create-storage-provider ../create_storage_provider.json --from funding  --node http://localhost:26750
``` 

### Changes

Notable changes: 
* add create storage provider command
