### PR TITLE
release: draft release for v0.2.3-alpha.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.2.3-alpha.6
+This release includes 6 features and 5 bugfixes.
+
+Features:
+* [#346](https://github.com/bnb-chain/greenfield/pull/346) feat: Enable websocket client as a option in Greenfield sdk
+* [#349](https://github.com/bnb-chain/greenfield/pull/349) feat: add UpdateChannelPermissions tx for crosschain module
+* [#350](https://github.com/bnb-chain/greenfield/pull/350) feat: add create storage provider command
+* [#357](https://github.com/bnb-chain/greenfield/pull/357) feat: add api to filter virtual group families qualification
+* [#352](https://github.com/bnb-chain/greenfield/pull/352) feat: add query params for virtual group
+* [#348](https://github.com/bnb-chain/greenfield/pull/348) feat: fix issues and add test cases for payment
+
+Bugfixes:
+* [#351](https://github.com/bnb-chain/greenfield/pull/351) fix: update local virtual group event
+* [#353](https://github.com/bnb-chain/greenfield/pull/353) fix: panic when delete unsealed object from lvg
+* [#354](https://github.com/bnb-chain/greenfield/pull/354) fix: incorrect authority for keepers
+* [#342](https://github.com/bnb-chain/greenfield/pull/342) fix: remove primary sp id from bucket info
+* [#356](https://github.com/bnb-chain/greenfield/pull/356) fix: add validation of extra field when creating group
+
+Chores:
+* [#359](https://github.com/bnb-chain/greenfield/pull/359) chore: add swagger check
+* [#358](https://github.com/bnb-chain/greenfield/pull/358) chore: Refine event for sp exit and bucket migration
+
 ## v0.2.3-alpha.5
 This release adds 6 new features and 2 bugfixes.
 

--- a/go.mod
+++ b/go.mod
@@ -173,10 +173,10 @@ replace (
 	cosmossdk.io/api => github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230425074444-eb5869b05fe9
 	cosmossdk.io/math => github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230425074444-eb5869b05fe9
 	github.com/btcsuite/btcd => github.com/btcsuite/btcd v0.23.0
-	github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v0.0.0-20230718031614-f9c9a7e315e3
+	github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v0.0.2-alpha.2
 	github.com/cometbft/cometbft-db => github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3-alpha.3.0.20230718031859-8c90df2f80e3
+	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3-alpha.4
 	github.com/cosmos/iavl => github.com/bnb-chain/greenfield-iavl v0.20.1-alpha.1
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 )

--- a/go.sum
+++ b/go.sum
@@ -161,10 +161,12 @@ github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edY
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
 github.com/bnb-chain/greenfield-cometbft v0.0.0-20230718031614-f9c9a7e315e3 h1:vdTwluvqIlDwPg+u9O9z8NlP5V8Akcirotde5o/A3Z8=
 github.com/bnb-chain/greenfield-cometbft v0.0.0-20230718031614-f9c9a7e315e3/go.mod h1:EBmwmUdaNbGPyGjf1cMuoN3pAeM2tQu7Lfg95813EAw=
+github.com/bnb-chain/greenfield-cometbft v0.0.2-alpha.2/go.mod h1:EBmwmUdaNbGPyGjf1cMuoN3pAeM2tQu7Lfg95813EAw=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1 h1:XcWulGacHVRiSCx90Q8Y//ajOrLNBQWR/KDB89dy3cU=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1/go.mod h1:ey1CiK4bYo1RBNJLRiVbYr5CMdSxci9S/AZRINLtppI=
 github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3-alpha.3.0.20230718031859-8c90df2f80e3 h1:cCaVgSC8eYN0+/4BHn0JhCSpkB46aW0Rok9K++uoF2Y=
 github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3-alpha.3.0.20230718031859-8c90df2f80e3/go.mod h1:5rEryDIeWh4xgXLg3sc3xyV7vkEhtPTKfEInphNmhsY=
+github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3-alpha.4/go.mod h1:EghjYxFg4NRNMfTJ6g9rVhjImhXQm+tuboknHqeGmJA=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230425074444-eb5869b05fe9 h1:6fLpmmI0EZvDTfPvI0zy5dBaaTUboHnEkoC5/p/w8TQ=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230425074444-eb5869b05fe9/go.mod h1:rbc4o84RSEvhf09o2+4Qiazsv0snRJLiEZdk17HeIDw=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230425074444-eb5869b05fe9 h1:1ZdK+iR1Up02bOa2YTZCml7PBpP//kcdamOcK6aWO/s=


### PR DESCRIPTION
### Description

This release includes 6 features and 5 bugfixes.

### Rationale

Features:
* [#346](https://github.com/bnb-chain/greenfield/pull/346) feat: Enable websocket client as a option in Greenfield sdk
* [#349](https://github.com/bnb-chain/greenfield/pull/349) feat: add UpdateChannelPermissions tx for crosschain module
* [#350](https://github.com/bnb-chain/greenfield/pull/350) feat: add create storage provider command
* [#357](https://github.com/bnb-chain/greenfield/pull/357) feat: add api to filter virtual group families qualification
* [#352](https://github.com/bnb-chain/greenfield/pull/352) feat: add query params for virtual group
* [#348](https://github.com/bnb-chain/greenfield/pull/348) feat: fix issues and add test cases for payment  

Bugfixes:
* [#351](https://github.com/bnb-chain/greenfield/pull/351) fix: update local virtual group event
* [#353](https://github.com/bnb-chain/greenfield/pull/353) fix: panic when delete unsealed object from lvg
* [#354](https://github.com/bnb-chain/greenfield/pull/354) fix: incorrect authority for keepers
* [#342](https://github.com/bnb-chain/greenfield/pull/342) fix: remove primary sp id from bucket info
* [#356](https://github.com/bnb-chain/greenfield/pull/356) fix: add validation of extra field when creating group

Chores:
* [#359](https://github.com/bnb-chain/greenfield/pull/359) chore: add swagger check
* [#358](https://github.com/bnb-chain/greenfield/pull/358) chore: Refine event for sp exit and bucket migration
