### PR TITLE
add docs for gnfd-challenger and relayer

### DIFF
--- a/deployment/helm/challenger-readme.md
+++ b/deployment/helm/challenger-readme.md
@@ -8,6 +8,9 @@ Helm Chart Deployment for Greenfield Challenger
 2. `helm repo update`
 3. `helm install greenfield-challenger bnb-chain/gnfd-challenger`
 
+## Setting up configuration files
+You will have to set up the configuration files with reference to [this repo](https://github.com/bnb-chain/bsc-relayer-chllenger).
+
 ## Common Operations
 
 ### Check Pod Status

--- a/deployment/helm/challenger-readme.md
+++ b/deployment/helm/challenger-readme.md
@@ -44,9 +44,7 @@ The following tables lists the configurable parameters of the chart and their de
 
 You **must** change the values according to the your aws environment parametes in ``greenfield-challenger/testnet-values.yaml`` file.
 
-1. In `greenfield-config`, change: `aws_region`, `aws_secret_name`, `aws_bls_secret_name`, `private_key` and `bls_private_key`.
+1. In `greenfield-config`, change: `private_key` and `bls_private_key`.
 
-2. In `db_config`, change: `aws_region`, `aws_secret_name`, `password`, `username`, `url`.
-
-3. In `containers`, change values of `AWS_REGION` and `AWS_SECRET_KEY`
+2. In `db_config`, change: `password`, `username`, `url`.
 

--- a/deployment/helm/challenger-readme.md
+++ b/deployment/helm/challenger-readme.md
@@ -1,33 +1,52 @@
 Helm Chart Deployment for Greenfield Challenger
 
-## Dependence
-1. VMServiceScrape
-
 ## Deployment
-1. `helm repo add bnb-chain https://chart.bnbchain.world/`
-2. `helm repo update`
-3. `helm install greenfield-challenger bnb-chain/gnfd-challenger`
 
-## Setting up configuration files
-You will have to set up the configuration files with reference to [this repo](https://github.com/bnb-chain/bsc-relayer-chllenger).
+These are the steps to deploy the greenfield challenger application using Helm Chart V3.
+
+We run these commands first to get the chart and test the installation.
+
+```console
+helm repo add bnb-chain https://chart.bnbchain.world/
+helm repo update
+helm show values bnb-chain/gnfd-challenger-testnet-values > testnet-challenger-values.yaml
+helm install greenfield-challenger bnb-chain/gnfd-challenger -f testnet-challenger-values.yaml -n NAMESPACE --debug --dry-run
+```
+
+If dry-run runs successfully, we install the chart:
+
+`helm install greenfield-challenger bnb-chain/gnfd-challenger -f testnet-challenger-values.yaml -n NAMESPACE`
 
 ## Common Operations
 
-### Check Pod Status
+Get the pods lists by running this commands:
 
+```console
+kubectl get pods -n NAMESPACE
 ```
-$ kubectl get pod
-```
+See the history of versions of ``greenfield-challenger`` application with command.
 
-You should see a `1/1` pod running for the challenger. This means there is 1 container running for the challenger.
-
-To see more details about a pod, you can describe it:
-
-```
-$ kubectl describe pod <POD_NAME> 
+```console
+helm history greenfield-challenger -n NAMESPACE
 ```
 
-### Check the Pod Logs 
+## How to uninstall
 
+Remove application with command.
+
+```console
+helm uninstall greenfield-challenger -n NAMESPACE
 ```
-$ kubectl logs <POD_NAME>
+
+## Parameters
+
+The following tables lists the configurable parameters of the chart and their default values.
+
+You **must** change the values according to the your aws environment parametes in ``greenfield-challenger/testnet-values.yaml`` file.
+
+1. In `greenfield-config`, change: `aws_region`, `aws_secret_name`, `aws_bls_secret_name`, `private_key` and `bls_private_key`.
+
+2. In `db_config`, change: `aws_region`, `aws_secret_name`, `password`, `username`, `url`.
+
+3. In `containers`, change values of `AWS_REGION` and `AWS_SECRET_KEY`
+

--- a/deployment/helm/challenger-readme.md
+++ b/deployment/helm/challenger-readme.md
@@ -1,0 +1,30 @@
+Helm Chart Deployment for Greenfield Challenger
+
+## Dependence
+1. VMServiceScrape
+
+## Deployment
+1. `helm repo add bnb-chain https://chart.bnbchain.world/`
+2. `helm repo update`
+3. `helm install greenfield-challenger bnb-chain/gnfd-challenger`
+
+## Common Operations
+
+### Check Pod Status
+
+```
+$ kubectl get pod
+```
+
+You should see a `1/1` pod running for the challenger. This means there is 1 container running for the challenger.
+
+To see more details about a pod, you can describe it:
+
+```
+$ kubectl describe pod <POD_NAME> 
+```
+
+### Check the Pod Logs 
+
+```
+$ kubectl logs <POD_NAME>

--- a/deployment/helm/relayer-readme.md
+++ b/deployment/helm/relayer-readme.md
@@ -7,8 +7,8 @@ These are the steps to deploy the greenfield relayer application using Helm Char
 ```console
 helm repo add bnb-chain https://chart.bnbchain.world/
 helm repo update
-helm show values bnb-chain/gnfd-relayer-testnet-values > testnet-values.yaml
-helm install greenfield-relayer bnb-chain/gnfd-relayer -f testnet.values.yaml -n NAMESPACE --dry-run
+helm show values bnb-chain/gnfd-relayer-testnet-values > testnet-relayer-values.yaml
+helm install greenfield-relayer bnb-chain/gnfd-relayer -f testnet-relayer-values.yaml -n NAMESPACE --dry-run
 ```
 
 ## Common Operations

--- a/deployment/helm/relayer-readme.md
+++ b/deployment/helm/relayer-readme.md
@@ -8,6 +8,9 @@ Helm Chart Deployment for Greenfield Relayer
 2. `helm repo update`
 3. `helm install greenfield-relayer bnb-chain/gnfd-relayer`
 
+## Setting up configuration files
+You will have to set up the configuration files with reference to [this repo](https://github.com/bnb-chain/greenfield-relayer#deployment).
+
 ## Common Operations
 
 ### Check Pod Status

--- a/deployment/helm/relayer-readme.md
+++ b/deployment/helm/relayer-readme.md
@@ -44,10 +44,8 @@ The following tables lists the configurable parameters of the chart and their de
 
 You **must** change the values according to the your aws environment parametes in ``greenfield-relayer/testnet-values.yaml`` file.
 
-1. In `greenfield-config`, change: `aws_region`, `aws_secret_name`, `aws_bls_secret_name`, `private_key` and `bls_private_key`.
+1. In `greenfield-config`, change: `private_key` and `bls_private_key`.
 
-2. In `bsc-config`, change: `aws_region`, `aws_secret_name` and `private_key`
+2. In `bsc-config`, change: `private_key`
 
-3. In `db_config`, change: `aws_region`, `aws_secret_name`, `password`, `username`, `url`.
-
-4. In `containers`, change values of `AWS_REGION` and `AWS_SECRET_KEY`
+3. In `db_config`, change: `password`, `username`, `url`.

--- a/deployment/helm/relayer-readme.md
+++ b/deployment/helm/relayer-readme.md
@@ -4,12 +4,18 @@ Helm Chart Deployment for Greenfield Relayer
 
 These are the steps to deploy the greenfield relayer application using Helm Chart V3.
 
+We run these commands first to get the chart and test the installation.
+
 ```console
 helm repo add bnb-chain https://chart.bnbchain.world/
 helm repo update
 helm show values bnb-chain/gnfd-relayer-testnet-values > testnet-relayer-values.yaml
-helm install greenfield-relayer bnb-chain/gnfd-relayer -f testnet-relayer-values.yaml -n NAMESPACE --dry-run
+helm install greenfield-relayer bnb-chain/gnfd-relayer -f testnet-relayer-values.yaml -n NAMESPACE --debug --dry-run
 ```
+
+If dry-run runs successfully, we install the chart:
+
+`helm install greenfield-relayer bnb-chain/gnfd-relayer -f testnet-relayer-values.yaml -n NAMESPACE`
 
 ## Common Operations
 

--- a/deployment/helm/relayer-readme.md
+++ b/deployment/helm/relayer-readme.md
@@ -1,33 +1,47 @@
 Helm Chart Deployment for Greenfield Relayer
 
-## Dependence
-1. VMServiceScrape
-
 ## Deployment
-1. `helm repo add bnb-chain https://chart.bnbchain.world/`
-2. `helm repo update`
-3. `helm install greenfield-relayer bnb-chain/gnfd-relayer`
 
-## Setting up configuration files
-You will have to set up the configuration files with reference to [this repo](https://github.com/bnb-chain/greenfield-relayer#deployment).
+These are the steps to deploy the greenfield relayer application using Helm Chart V3.
+
+```console
+helm repo add bnb-chain https://chart.bnbchain.world/
+helm repo update
+helm show values bnb-chain/gnfd-relayer-testnet-values > testnet-values.yaml
+helm install greenfield-relayer bnb-chain/gnfd-relayer -f testnet.values.yaml -n NAMESPACE --dry-run
+```
 
 ## Common Operations
 
-### Check Pod Status
+Get the pods lists by running this commands:
 
+```console
+kubectl get pods -n NAMESPACE
 ```
-$ kubectl get pod
-```
+See the history of versions of ``greenfield-relayer`` application with command.
 
-You should see a `1/1` pod running for the relayer. This means there is 1 container running for the relayer.
-
-To see more details about a pod, you can describe it:
-
-```
-$ kubectl describe pod <POD_NAME> 
+```console
+helm history greenfield-relayer -n NAMESPACE
 ```
 
-### Check the Pod Logs 
+## How to uninstall
 
+Remove application with command.
+
+```console
+helm uninstall greenfield-relayer -n NAMESPACE
 ```
-$ kubectl logs <POD_NAME>
+
+## Parameters
+
+The following tables lists the configurable parameters of the chart and their default values.
+
+You **must** change the values according to the your aws environment parametes in ``greenfield-relayer/testnet-values.yaml`` file.
+
+1. In `greenfield-config`, change: `aws_region`, `aws_secret_name`, `aws_bls_secret_name`, `private_key` and `bls_private_key`.
+
+2. In `bsc-config`, change: `aws_region`, `aws_secret_name` and `private_key`
+
+3. In `db_config`, change: `aws_region`, `aws_secret_name`, `password`, `username`, `url`.
+
+4. In `containers`, change values of `AWS_REGION` and `AWS_SECRET_KEY`

--- a/deployment/helm/relayer-readme.md
+++ b/deployment/helm/relayer-readme.md
@@ -1,0 +1,30 @@
+Helm Chart Deployment for Greenfield Relayer
+
+## Dependence
+1. VMServiceScrape
+
+## Deployment
+1. `helm repo add bnb-chain https://chart.bnbchain.world/`
+2. `helm repo update`
+3. `helm install greenfield-relayer bnb-chain/gnfd-relayer`
+
+## Common Operations
+
+### Check Pod Status
+
+```
+$ kubectl get pod
+```
+
+You should see a `1/1` pod running for the relayer. This means there is 1 container running for the relayer.
+
+To see more details about a pod, you can describe it:
+
+```
+$ kubectl describe pod <POD_NAME> 
+```
+
+### Check the Pod Logs 
+
+```
+$ kubectl logs <POD_NAME>


### PR DESCRIPTION
### Description

Add readme for gnfd-relayer and gnfd-challenger helm deployment.

### Rationale

Automate the deployment process and make it customisable for users.

### Example

1. `helm repo add bnb-chain https://chart.bnbchain.world/`
2. `helm repo update`
3. `helm install greenfield-validator bnb-chain/gnfd-challenger`

### Changes

Notable changes: 
* Update readme
