### PR TITLE
fix: parse failed when object name contains /

### DIFF
--- a/types/grn.go
+++ b/types/grn.go
@@ -192,16 +192,21 @@ func (r *GRN) ParseFromString(res string, wildcards bool) error {
 
 func (r *GRN) parseBucketAndObjectName(name string) (string, string, error) {
 	nameArr := strings.Split(name, "/")
-	if len(nameArr) != 2 {
+	if len(nameArr) < 2 {
 		return "", "", gnfderrors.ErrInvalidGRN.Wrapf("expect bucketName/object, actual %s", r.name)
 	}
-	err := s3util.CheckValidBucketName(nameArr[0])
+	bucketName := nameArr[0]
+	objectName, found := strings.CutPrefix(name, bucketName+"/")
+	if !found {
+		return "", "", gnfderrors.ErrInvalidGRN.Wrapf("object name not found, grn: %s", name)
+	}
+	err := s3util.CheckValidBucketName(bucketName)
 	if err != nil {
 		return "", "", gnfderrors.ErrInvalidGRN.Wrapf("invalid bucketName, err: %s", err)
 	}
-	err = s3util.CheckValidObjectName(nameArr[1])
+	err = s3util.CheckValidObjectName(objectName)
 	if err != nil {
 		return "", "", gnfderrors.ErrInvalidGRN.Wrapf("invalid objectName, err: %s", err)
 	}
-	return nameArr[0], nameArr[1], nil
+	return bucketName, objectName, nil
 }

--- a/types/grn_test.go
+++ b/types/grn_test.go
@@ -91,3 +91,14 @@ func TestGRNBasicNew(t *testing.T) {
 	groupGRNString := "grn:g:" + ownerAcc.String() + ":testgroup"
 	require.Equal(t, groupGRNString, types3.NewGroupGRN(ownerAcc, "testgroup").String())
 }
+
+func TestGRNWithSlash(t *testing.T) {
+	var grn types3.GRN
+
+	err := grn.ParseFromString("grn:o::"+"testbucket"+"/"+"test/object", false)
+	require.NoError(t, err)
+	require.Equal(t, grn.ResourceType(), resource.RESOURCE_TYPE_OBJECT)
+	bucketName, objectName := grn.MustGetBucketAndObjectName()
+	require.Equal(t, bucketName, "testbucket")
+	require.Equal(t, objectName, "test/object")
+}


### PR DESCRIPTION
### Description

fix parse bucket and object name failed  when object name contains "/"

### Rationale

bufix

### Example
```
grn:o::testbucket/test/test2/object
```
### Changes

Notable changes: 
* grn ParseBucketAndObjectName
* grn test