### PR TITLE
release: draft release for v0.2.3-alpha.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.2.3-alpha.7
+This release includes 2 features and 3 bugfixes.
+
+Features:
+* [#366](https://github.com/bnb-chain/greenfield/pull/366) feat: add strategy for event emit
+* [#368](https://github.com/bnb-chain/greenfield/pull/368) feat: limit sp slash amount and add query api
+
+Bugfixes:
+* [#369](https://github.com/bnb-chain/greenfield/pull/369) fix: parse failed when object name contains /
+* [#370](https://github.com/bnb-chain/greenfield/pull/370) fix: fix the precision issue of storage bill
+* [#371](https://github.com/bnb-chain/greenfield/pull/371) fix: add src dst sp check when migrate bucket
+
+Chores:
+* [#365](https://github.com/bnb-chain/greenfield/pull/365) ci: add e2e test coverage report
+
 ## 0.2.3-alpha.6
 This release includes 6 features and 5 bugfixes.
 

--- a/go.mod
+++ b/go.mod
@@ -176,7 +176,7 @@ replace (
 	github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v0.0.2-alpha.2
 	github.com/cometbft/cometbft-db => github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3-alpha.3.0.20230725020809-dbb91ace4379
+	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3-alpha.5
 	github.com/cosmos/iavl => github.com/bnb-chain/greenfield-iavl v0.20.1-alpha.1
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 )

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,8 @@ github.com/bnb-chain/greenfield-cometbft v0.0.2-alpha.2 h1:ys9kmgtRx04wcCextE6Cr
 github.com/bnb-chain/greenfield-cometbft v0.0.2-alpha.2/go.mod h1:EBmwmUdaNbGPyGjf1cMuoN3pAeM2tQu7Lfg95813EAw=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1 h1:XcWulGacHVRiSCx90Q8Y//ajOrLNBQWR/KDB89dy3cU=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1/go.mod h1:ey1CiK4bYo1RBNJLRiVbYr5CMdSxci9S/AZRINLtppI=
-github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3-alpha.3.0.20230725020809-dbb91ace4379 h1:f8FL22UuG01EfnCx+8NTyR3aFfuZ6IMwJo7XmNg+pAE=
-github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3-alpha.3.0.20230725020809-dbb91ace4379/go.mod h1:EghjYxFg4NRNMfTJ6g9rVhjImhXQm+tuboknHqeGmJA=
+github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3-alpha.5 h1:VZKjhnM/GvdG6iTXj63SrBgDQLtXG4piDDG2fTMTiV4=
+github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3-alpha.5/go.mod h1:EghjYxFg4NRNMfTJ6g9rVhjImhXQm+tuboknHqeGmJA=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230425074444-eb5869b05fe9 h1:6fLpmmI0EZvDTfPvI0zy5dBaaTUboHnEkoC5/p/w8TQ=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230425074444-eb5869b05fe9/go.mod h1:rbc4o84RSEvhf09o2+4Qiazsv0snRJLiEZdk17HeIDw=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230425074444-eb5869b05fe9 h1:1ZdK+iR1Up02bOa2YTZCml7PBpP//kcdamOcK6aWO/s=


### PR DESCRIPTION
### Description

This pr drafts the release v0.2.3-alpha.7, which includes 2 features and 3 bugfixes.

Features:
* [#366](https://github.com/bnb-chain/greenfield/pull/366) feat: add strategy for event emit
* [#368](https://github.com/bnb-chain/greenfield/pull/368) feat: limit sp slash amount and add query api

Bugfixes:
* [#369](https://github.com/bnb-chain/greenfield/pull/369) fix: parse failed when object name contains /
* [#370](https://github.com/bnb-chain/greenfield/pull/370) fix: fix the precision issue of storage bill
* [#371](https://github.com/bnb-chain/greenfield/pull/371) fix: add src dst sp check when migrate bucket

Chores:
* [#365](https://github.com/bnb-chain/greenfield/pull/365) ci: add e2e test coverage report


### Rationale

Draft release

### Example

NA

### Changes

Notable changes: 
* new features 
