### PR TITLE
fix: improve e2e tests to  include more coverage from server side

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -44,19 +44,9 @@ jobs:
           ${{ runner.os }}-go-
     - name: Setup GitHub Token
       run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
-    - name: Build
-      run: |
-        make build
-    - name: start e2e local chain
-      run: |
-        make e2e_start_localchain
-        sleep 5
     - name: run e2e test
       run: |
         make e2e_test
-    - name: stop e2e local chain
-      run: |
-        make e2e_stop_localchain
     - name: make coverage report
       id: coverage-report
       if: github.event_name == 'pull_request'

--- a/e2e/core/basesuite.go
+++ b/e2e/core/basesuite.go
@@ -9,10 +9,14 @@ import (
 	"math"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	sdkmath "cosmossdk.io/math"
 	"github.com/cometbft/cometbft/crypto/tmhash"
+	tmlog "github.com/cometbft/cometbft/libs/log"
+	sdkClient "github.com/cosmos/cosmos-sdk/client"
+	sdkServer "github.com/cosmos/cosmos-sdk/server"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/cosmos/cosmos-sdk/types/tx"
@@ -22,8 +26,10 @@ import (
 	gov "github.com/cosmos/cosmos-sdk/x/gov/types"
 	govtypesv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	"github.com/prysmaticlabs/prysm/crypto/bls"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/bnb-chain/greenfield/cmd/gnfd/cmd"
 	"github.com/bnb-chain/greenfield/sdk/client"
 	"github.com/bnb-chain/greenfield/sdk/keys"
 	"github.com/bnb-chain/greenfield/sdk/types"
@@ -43,6 +49,8 @@ type StorageProvider struct {
 	GlobalVirtualGroupFamilies map[uint32][]*virtualgroupmoduletypes.GlobalVirtualGroup
 }
 
+var initValidatorOnce sync.Once
+
 type BaseSuite struct {
 	suite.Suite
 	Config           *Config
@@ -55,8 +63,72 @@ type BaseSuite struct {
 	StorageProviders map[uint32]*StorageProvider
 }
 
+func findCommand(cmd *cobra.Command, name string) *cobra.Command {
+	if len(cmd.Commands()) == 0 {
+		return nil
+	}
+	for _, subCmd := range cmd.Commands() {
+		if subCmd.Name() == name {
+			return subCmd
+		}
+		if found := findCommand(subCmd, name); found != nil {
+			return found
+		}
+	}
+
+	return nil
+}
+
+func (s *BaseSuite) InitChain() {
+	s.T().Log("Initializing chain")
+	rootCmd, _ := cmd.NewRootCmd()
+	// Initialize and start chain
+	ctx := context.Background()
+	srvCtx := sdkServer.NewDefaultContext()
+	ctx = context.WithValue(ctx, sdkClient.ClientContextKey, &sdkClient.Context{})
+	ctx = context.WithValue(ctx, sdkServer.ServerContextKey, srvCtx)
+
+	// if you want to debug with chain logs, please discard this
+	startCmd := findCommand(rootCmd, "start")
+	startCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		err := rootCmd.PersistentPreRunE(cmd, args)
+		if err != nil {
+			return err
+		}
+		ctx := cmd.Context()
+		serverCtx := sdkServer.GetServerContextFromCmd(cmd)
+		serverCtx.Logger = tmlog.NewNopLogger()
+		ctx = context.WithValue(ctx, sdkServer.ServerContextKey, serverCtx)
+		cmd.SetContext(ctx)
+		return nil
+	}
+	rootCmd.SetArgs([]string{
+		"start",
+		"--home", s.Config.ValidatorHomeDir,
+		"--rpc.laddr", s.Config.ValidatorTmRPCAddr,
+	})
+
+	errChan := make(chan error)
+	go func() {
+		errChan <- rootCmd.ExecuteContext(ctx)
+	}()
+
+	select {
+	case err := <-errChan:
+		s.Require().NoError(err)
+	case <-time.After(15 * time.Second):
+		// wait 15 seconds for the server to start if no errors
+	}
+
+	s.T().Log("Chain started")
+}
+
 func (s *BaseSuite) SetupSuite() {
 	s.Config = InitConfig()
+	initValidatorOnce.Do(func() {
+		s.InitChain()
+	})
+
 	s.Client, _ = client.NewGreenfieldClient(s.Config.TendermintAddr, s.Config.ChainId)
 	tmClient := client.NewTendermintClient(s.Config.TendermintAddr)
 	s.TmClient = &tmClient

--- a/e2e/core/config.go
+++ b/e2e/core/config.go
@@ -26,6 +26,8 @@ type Config struct {
 	SPMnemonics          []SPMnemonics `yaml:"SPMnemonics"`
 	SPBLSMnemonic        []string      `yaml:"SPBLSMnemonic"`
 	Denom                string        `yaml:"Denom"`
+	ValidatorHomeDir     string        `yaml:"ValidatorHomeDir"`
+	ValidatorTmRPCAddr   string        `yaml:"ValidatorTmRPCAddr"`
 }
 
 func InitConfig() *Config {
@@ -43,6 +45,8 @@ func InitE2eConfig() *Config {
 		ValidatorBlsMnemonic: ParseValidatorBlsMnemonic(0),
 		RelayerMnemonic:      ParseRelayerMnemonic(0),
 		ChallengerMnemonic:   ParseChallengerMnemonic(0),
+		ValidatorHomeDir:     ParseValidatorHomeDir(0),
+		ValidatorTmRPCAddr:   ParseValidatorTmRPCAddrDir(0),
 	}
 	for i := 0; i < 7; i++ {
 		config.SPMnemonics = append(config.SPMnemonics, ParseSPMnemonics(i))
@@ -104,4 +108,14 @@ func ParseMnemonicFromFile(fileName string) string {
 		}
 	}
 	return line
+}
+
+// ParseValidatorHomeDir returns the home dir of the validator
+func ParseValidatorHomeDir(i int) string {
+	return fmt.Sprintf("../../deployment/localup/.local/validator%d", i)
+}
+
+// ParseValidatorTmRPCAddrDir returns the home dir of the validator
+func ParseValidatorTmRPCAddrDir(i int) string {
+	return fmt.Sprintf("tcp://0.0.0.0:%d", 26750+i)
 }


### PR DESCRIPTION
### Description

 improve e2e tests to  include more coverage from the server side

### Rationale

run the server side(chain) and test case in one process to calculate both coverage

### Example
https://github.com/bnb-chain/greenfield/actions/runs/5666030339/attempts/1#summary-15351941848

```
File coverage threshold (80%) satisfied:				FAIL
  below threshold:							coverage:	threshold:
  app/ante/ante.go							64%		80%
  app/export.go								0%		80%
  app/genesis.go							0%		80%
  app/upgrade.go							75%		80%
  cmd/gnfd/cmd/genaccounts.go						8%		80%
  cmd/gnfd/cmd/root.go							78%		80%
  sdk/client/gnfd_client.go						63%		80%
  sdk/client/gnfd_client_option.go					0%		80%
  sdk/client/gnfd_tm.go							0%		80%
  sdk/client/tendermint_client.go					75%		80%
  sdk/client/tx.go							65%		80%
  sdk/keys/key_manager.go						79%		80%
  types/grn.go								63%		80%
  types/openapiutil/apiconsole.go					66%		80%
  types/s3util/s3util.go						59%		80%
  types/verifier.go							64%		80%
  version/version.go							0%		80%
  x/bridge/client/cli/query_params.go					33%		80%
  x/bridge/client/cli/tx_transfer_out.go				18%		80%
  x/bridge/genesis.go							33%		80%
  x/bridge/keeper/cross_app.go						9%		80%
  x/bridge/keeper/grpc_query_params.go					75%		80%
  x/bridge/keeper/keeper.go						25%		80%
  x/bridge/keeper/msg_server_update_params.go				66%		80%
  x/bridge/module.go							68%		80%
  x/bridge/module_simulation.go						0%		80%
  x/bridge/simulation/helpers.go					0%		80%
  x/bridge/simulation/transfer_out.go					0%		80%
  x/bridge/types/genesis.go						0%		80%
  x/bridge/types/keys.go						0%		80%
  x/bridge/types/message_transfer_out.go				50%		80%
  x/bridge/types/message_update_params.go				62%		80%
  x/bridge/types/params.go						62%		80%
  x/bridge/types/types.go						8%		80%
  x/challenge/client/cli/query.go					37%		80%
  x/challenge/client/cli/tx_attest.go					7%		80%
  x/challenge/client/cli/tx_submit.go					11%		80%
  x/challenge/genesis.go						33%		80%
  x/challenge/keeper/bls_signed_msg.go					71%		80%
  x/challenge/keeper/grpc_query.go					78%		80%
  x/challenge/keeper/msg_server_submit.go				59%		80%
  x/challenge/keeper/msg_server_update_params.go			66%		80%
  x/challenge/module.go							72%		80%
  x/challenge/module_simulation.go					0%		80%
  x/challenge/simulation/attest.go					0%		80%
  x/challenge/simulation/helpers.go					0%		80%
  x/challenge/simulation/submit.go					0%		80%
  x/challenge/types/genesis.go						0%		80%
  x/challenge/types/keys.go						0%		80%
  x/challenge/types/message_attest.go					75%		80%
  x/challenge/types/message_submit.go					55%		80%
  x/challenge/types/message_update_params.go				62%		80%
  x/challenge/types/params.go						59%		80%
  x/gensp/client/cli/collect.go						12%		80%
  x/gensp/client/cli/gentx.go						8%		80%
  x/gensp/collect.go							0%		80%
  x/gensp/gentx.go							20%		80%
  x/gensp/module.go							52%		80%
  x/gensp/types/genesis_state.go					0%		80%
  x/gensp/types/keys.go							0%		80%
  x/gensp/types/params.go						0%		80%
  x/payment/client/cli/query_auto_settle_record.go			28%		80%
  x/payment/client/cli/query_dynamic_balance.go				23%		80%
  x/payment/client/cli/query_get_payment_accounts_by_owner.go		23%		80%
  x/payment/client/cli/query_params.go					33%		80%
  x/payment/client/cli/query_payment_account.go				28%		80%
  x/payment/client/cli/query_payment_account_count.go			28%		80%
  x/payment/client/cli/query_stream_record.go				28%		80%
  x/payment/client/cli/tx_create_payment_account.go			30%		80%
  x/payment/client/cli/tx_deposit.go					21%		80%
  x/payment/client/cli/tx_disable_refund.go				27%		80%
  x/payment/client/cli/tx_withdraw.go					21%		80%
  x/payment/genesis.go							33%		80%
  x/payment/keeper/auto_resume_record.go				72%		80%
  x/payment/keeper/auto_settle_record.go				47%		80%
  x/payment/keeper/grpc_query_out_flow.go				71%		80%
  x/payment/keeper/grpc_query_params.go					75%		80%
  x/payment/keeper/grpc_query_params_by_timestamp.go			75%		80%
  x/payment/keeper/grpc_query_payment_account.go			26%		80%
  x/payment/keeper/grpc_query_payment_account_count.go			0%		80%
  x/payment/keeper/grpc_query_stream_record.go				30%		80%
  x/payment/keeper/keeper.go						78%		80%
  x/payment/keeper/msg_server.go					71%		80%
  x/payment/keeper/msg_server_disable_refund.go				75%		80%
  x/payment/keeper/msg_server_withdraw.go				74%		80%
  x/payment/keeper/payment_account.go					67%		80%
  x/payment/keeper/payment_account_count.go				54%		80%
  x/payment/keeper/price.go						75%		80%
  x/payment/module.go							71%		80%
  x/payment/module_simulation.go					0%		80%
  x/payment/simulation/helpers.go					0%		80%
  x/payment/types/genesis.go						0%		80%
  x/payment/types/message_create_payment_account.go			46%		80%
  x/payment/types/message_deposit.go					50%		80%
  x/payment/types/message_disable_refund.go				50%		80%
  x/payment/types/message_update_params.go				62%		80%
  x/payment/types/message_withdraw.go					55%		80%
  x/payment/types/params.go						59%		80%
  x/permission/client/cli/query_params.go				33%		80%
  x/permission/genesis.go						33%		80%
  x/permission/keeper/keeper.go						75%		80%
  x/permission/keeper/msg_server.go					14%		80%
  x/permission/keeper/params.go						31%		80%
  x/permission/keeper/query.go						0%		80%
  x/permission/module.go						68%		80%
  x/permission/module_simulation.go					0%		80%
  x/permission/simulation/helpers.go					0%		80%
  x/permission/types/common.go						70%		80%
  x/permission/types/genesis.go						0%		80%
  x/permission/types/message.go						0%		80%
  x/permission/types/params.go						33%		80%
  x/permission/types/types.go						62%		80%
  x/sp/client/cli/query.go						25%		80%
  x/sp/client/cli/query_params.go					33%		80%
  x/sp/client/cli/tx.go							17%		80%
  x/sp/genesis.go							33%		80%
  x/sp/keeper/authz.go							60%		80%
  x/sp/keeper/genesis.go						60%		80%
  x/sp/keeper/grpc_query.go						78%		80%
  x/sp/keeper/msg_server.go						75%		80%
  x/sp/keeper/slash.go							75%		80%
  x/sp/keeper/sp_storage_price.go					71%		80%
  x/sp/module.go							69%		80%
  x/sp/module_simulation.go						0%		80%
  x/sp/simulation/helpers.go						0%		80%
  x/sp/types/authz.go							72%		80%
  x/sp/types/genesis.go							0%		80%
  x/sp/types/message.go							56%		80%
  x/sp/types/params.go							51%		80%
  x/sp/types/types.go							64%		80%
  x/sp/types/util.go							62%		80%
  x/storage/abci.go							63%		80%
  x/storage/client/cli/flags.go						12%		80%
  x/storage/client/cli/query.go						23%		80%
  x/storage/client/cli/query_params.go					33%		80%
  x/storage/client/cli/tx.go						20%		80%
  x/storage/client/cli/tx_cancel_migrate_bucket.go			30%		80%
  x/storage/genesis.go							33%		80%
  x/storage/keeper/cross_app.go						75%		80%
  x/storage/keeper/cross_app_bucket.go					0%		80%
  x/storage/keeper/cross_app_group.go					0%		80%
  x/storage/keeper/cross_app_object.go					1%		80%
  x/storage/keeper/grpc_query.go					34%		80%
  x/storage/keeper/keeper.go						74%		80%
  x/storage/keeper/params.go						77%		80%
  x/storage/keeper/permission.go					70%		80%
  x/storage/keeper/query.go						50%		80%
  x/storage/keeper/verify.go						75%		80%
  x/storage/keeper/virtualgroup.go					75%		80%
  x/storage/module.go							72%		80%
  x/storage/module_simulation.go					0%		80%
  x/storage/simulation/cancel_migrate_bucket.go				0%		80%
  x/storage/simulation/complete_migrate_bucket.go			0%		80%
  x/storage/simulation/helpers.go					0%		80%
  x/storage/simulation/migrate_bucket.go				0%		80%
  x/storage/types/crosschain.go						2%		80%
  x/storage/types/genesis.go						0%		80%
  x/storage/types/message.go						59%		80%
  x/storage/types/message_cancel_migrate_bucket.go			56%		80%
  x/storage/types/message_complete_migrate_bucket.go			60%		80%
  x/storage/types/message_migrate_bucket.go				69%		80%
  x/storage/types/params.go						43%		80%
  x/storage/types/types.go						60%		80%
  x/virtualgroup/client/cli/query.go					62%		80%
  x/virtualgroup/client/cli/query_global_virtual_group.go		20%		80%
  x/virtualgroup/client/cli/query_global_virtual_group_by_family_id.go	20%		80%
  x/virtualgroup/client/cli/query_global_virtual_group_families.go	20%		80%
  x/virtualgroup/client/cli/query_global_virtual_group_family.go	20%		80%
  x/virtualgroup/client/cli/tx.go					26%		80%
  x/virtualgroup/genesis.go						42%		80%
  x/virtualgroup/keeper/grpc_query.go					60%		80%
  x/virtualgroup/keeper/msg_server.go					77%		80%
  x/virtualgroup/keeper/payment.go					76%		80%
  x/virtualgroup/module.go						68%		80%
  x/virtualgroup/module_simulation.go					0%		80%
  x/virtualgroup/simulation/cancel_swap_out.go				0%		80%
  x/virtualgroup/simulation/complete_storage_provider_exit.go		0%		80%
  x/virtualgroup/simulation/complete_swap_out.go			0%		80%
  x/virtualgroup/simulation/helpers.go					0%		80%
  x/virtualgroup/simulation/storage_provider_exit.go			0%		80%
  x/virtualgroup/types/genesis.go					0%		80%
  x/virtualgroup/types/message.go					56%		80%
  x/virtualgroup/types/message_cancel_swap_out.go			55%		80%
  x/virtualgroup/types/message_complete_storage_provider_exit.go	46%		80%
  x/virtualgroup/types/message_complete_swap_out.go			55%		80%
  x/virtualgroup/types/message_storage_provider_exit.go			46%		80%
  x/virtualgroup/types/params.go					3%		80%
  x/virtualgroup/types/types.go						30%		80%

Package coverage threshold (80%) satisfied:	FAIL
  below threshold:				coverage:	threshold:
  types						64%		80%
  types/s3util					59%		80%
  x/challenge					68%		80%
  x/challenge/simulation			0%		80%
  x/payment/types				61%		80%
  x/permission/client/cli			57%		80%
  app						66%		80%
  sdk/keys					79%		80%
  x/storage/types				48%		80%
  x/virtualgroup				30%		80%
  x/permission					48%		80%
  x/sp/client/cli				19%		80%
  x/permission/types				61%		80%
  x/sp/types					64%		80%
  x/bridge					44%		80%
  x/gensp					16%		80%
  x/payment/client/cli				33%		80%
  x/sp/keeper					78%		80%
  x/virtualgroup/keeper				77%		80%
  app/ante					64%		80%
  version					0%		80%
  x/bridge/simulation				0%		80%
  x/bridge/types				37%		80%
  x/payment/keeper				76%		80%
  cmd/gnfd/cmd					47%		80%
  x/gensp/client/cli				9%		80%
  x/permission/keeper				69%		80%
  x/sp/simulation				0%		80%
  x/storage					55%		80%
  x/storage/client/cli				20%		80%
  x/storage/simulation				0%		80%
  sdk/client					58%		80%
  x/challenge/types				63%		80%
  x/virtualgroup/simulation			0%		80%
  x/payment					48%		80%
  x/payment/simulation				0%		80%
  x/storage/keeper				63%		80%
  x/virtualgroup/client/cli			28%		80%
  types/openapiutil				66%		80%
  x/bridge/client/cli				38%		80%
  x/sp						47%		80%
  x/bridge/keeper				35%		80%
  x/permission/simulation			0%		80%
  x/gensp/types					1%		80%
  x/virtualgroup/types				49%		80%
  x/challenge/client/cli			22%		80%

Total coverage threshold (80%) satisfied:	FAIL
Total test coverage: 56%
```

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
