### PR TITLE
fix: error member name in transferInRefundPackageType

### DIFF
--- a/x/bridge/types/types.go
+++ b/x/bridge/types/types.go
@@ -197,7 +197,7 @@ type TransferInRefundPackageStruct struct {
 var (
 	transferInRefundPackageType, _ = abi.NewType("tuple", "", []abi.ArgumentMarshaling{
 		{Name: "RefundAmount", Type: "uint256"},
-		{Name: "RefundAddr", Type: "address"},
+		{Name: "RefundAddress", Type: "address"},
 		{Name: "RefundReason", Type: "uint32"},
 	})
 

--- a/x/challenge/abci_test.go
+++ b/x/challenge/abci_test.go
@@ -3,12 +3,7 @@ package challenge_test
 import (
 	"testing"
 
-	sptypes "github.com/bnb-chain/greenfield/x/sp/types"
-	virtualgrouptypes "github.com/bnb-chain/greenfield/x/virtualgroup/types"
-
 	"cosmossdk.io/math"
-	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
-
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
@@ -23,6 +18,9 @@ import (
 	"github.com/bnb-chain/greenfield/x/challenge"
 	"github.com/bnb-chain/greenfield/x/challenge/keeper"
 	"github.com/bnb-chain/greenfield/x/challenge/types"
+	sptypes "github.com/bnb-chain/greenfield/x/sp/types"
+	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
+	virtualgrouptypes "github.com/bnb-chain/greenfield/x/virtualgroup/types"
 )
 
 type TestSuite struct {

--- a/x/virtualgroup/keeper/grpc_query.go
+++ b/x/virtualgroup/keeper/grpc_query.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"math"
 
-	"github.com/bnb-chain/greenfield/x/virtualgroup/types"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/bnb-chain/greenfield/x/virtualgroup/types"
 )
 
 func (k Keeper) Params(c context.Context, req *types.QueryParamsRequest) (*types.QueryParamsResponse, error) {


### PR DESCRIPTION
### Description
fix error member name in transferInRefundPackageType

### Rationale

error name that caused pkg encode error


### Changes

Notable changes: 
* modify `RefundAddr` to `RefundAddress` from transferInRefundPackageType
* ...
