### PR TITLE
release: prepare v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Bugfixes:
 * [#379](https://github.com/bnb-chain/greenfield/pull/379) fix: error member name in transferInRefundPackageType
 * [#383](https://github.com/bnb-chain/greenfield/pull/383) fix: lock balance not updated for frozen payment account
 * [#385](https://github.com/bnb-chain/greenfield/pull/385) fix: returned operation type in group cross chain app 
+* [#395](https://github.com/bnb-chain/greenfield/pull/395) fix: register gov cross-chain app
 
 Chores:
 * [#376](https://github.com/bnb-chain/greenfield/pull/376) chore: add unit tests for the storage module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.2.3
+This is a official release for v0.2.3, includes all the changes since v0.2.2.
+
+Bugfixes:
+* [#375](https://github.com/bnb-chain/greenfield/pull/375) fix: defining err
+* [#379](https://github.com/bnb-chain/greenfield/pull/379) fix: error member name in transferInRefundPackageType
+* [#383](https://github.com/bnb-chain/greenfield/pull/383) fix: lock balance not updated for frozen payment account
+* [#385](https://github.com/bnb-chain/greenfield/pull/385) fix: returned operation type in group cross chain app 
+
+Chores:
+* [#376](https://github.com/bnb-chain/greenfield/pull/376) chore: add unit tests for the storage module
+* [#377](https://github.com/bnb-chain/greenfield/pull/377) chore: improve e2e tests to include more coverage from server side
+* [#380](https://github.com/bnb-chain/greenfield/pull/380) chore: add unit test cases for payment module
+* [#381](https://github.com/bnb-chain/greenfield/pull/381) chore: add tests for bridge module
+* [#383](https://github.com/bnb-chain/greenfield/pull/383) chore: add unit test cases for challenge module
+
 ## 0.2.3-alpha.7
 This release includes 2 features and 3 bugfixes.
 

--- a/go.mod
+++ b/go.mod
@@ -173,10 +173,10 @@ replace (
 	cosmossdk.io/api => github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230425074444-eb5869b05fe9
 	cosmossdk.io/math => github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230425074444-eb5869b05fe9
 	github.com/btcsuite/btcd => github.com/btcsuite/btcd v0.23.0
-	github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v0.0.2-alpha.2
+	github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v0.0.2
 	github.com/cometbft/cometbft-db => github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3-alpha.5
+	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3
 	github.com/cosmos/iavl => github.com/bnb-chain/greenfield-iavl v0.20.1-alpha.1
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 )

--- a/go.sum
+++ b/go.sum
@@ -159,12 +159,12 @@ github.com/bgentry/speakeasy v0.1.1-0.20220910012023-760eaf8b6816/go.mod h1:+zsy
 github.com/bits-and-blooms/bitset v1.2.0 h1:Kn4yilvwNtMACtf1eYDlG8H77R07mZSPbMjLyS07ChA=
 github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
-github.com/bnb-chain/greenfield-cometbft v0.0.2-alpha.2 h1:ys9kmgtRx04wcCextE6CrVmbL1bJDklWr+hWgm1y2k4=
-github.com/bnb-chain/greenfield-cometbft v0.0.2-alpha.2/go.mod h1:EBmwmUdaNbGPyGjf1cMuoN3pAeM2tQu7Lfg95813EAw=
+github.com/bnb-chain/greenfield-cometbft v0.0.2 h1:bRamS8Lq1lA3ttRLZBha22uiNG5tqN+diD3hapdUCYI=
+github.com/bnb-chain/greenfield-cometbft v0.0.2/go.mod h1:EBmwmUdaNbGPyGjf1cMuoN3pAeM2tQu7Lfg95813EAw=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1 h1:XcWulGacHVRiSCx90Q8Y//ajOrLNBQWR/KDB89dy3cU=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1/go.mod h1:ey1CiK4bYo1RBNJLRiVbYr5CMdSxci9S/AZRINLtppI=
-github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3-alpha.5 h1:VZKjhnM/GvdG6iTXj63SrBgDQLtXG4piDDG2fTMTiV4=
-github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3-alpha.5/go.mod h1:EghjYxFg4NRNMfTJ6g9rVhjImhXQm+tuboknHqeGmJA=
+github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3 h1:bpro+qS2jjSi7vQN781gtxebuYNDrLewAye+iGB299c=
+github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3/go.mod h1:hpvg93+VGXHAcv/pVVdp24Ik/9miw4uRh8+tD0DDYas=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230425074444-eb5869b05fe9 h1:6fLpmmI0EZvDTfPvI0zy5dBaaTUboHnEkoC5/p/w8TQ=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230425074444-eb5869b05fe9/go.mod h1:rbc4o84RSEvhf09o2+4Qiazsv0snRJLiEZdk17HeIDw=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230425074444-eb5869b05fe9 h1:1ZdK+iR1Up02bOa2YTZCml7PBpP//kcdamOcK6aWO/s=


### PR DESCRIPTION
### Description
This is a official release for v0.2.3, includes all the changes since v0.2.2.

Bugfixes:
* [#375](https://github.com/bnb-chain/greenfield/pull/375) fix: defining err
* [#379](https://github.com/bnb-chain/greenfield/pull/379) fix: error member name in transferInRefundPackageType
* [#383](https://github.com/bnb-chain/greenfield/pull/383) fix: lock balance not updated for frozen payment account
* [#385](https://github.com/bnb-chain/greenfield/pull/385) fix: returned operation type in group cross chain app 
* [#395](https://github.com/bnb-chain/greenfield/pull/395) fix: register gov cross-chain app

Chores:
* [#376](https://github.com/bnb-chain/greenfield/pull/376) chore: add unit tests for the storage module
* [#377](https://github.com/bnb-chain/greenfield/pull/377) chore: improve e2e tests to include more coverage from server side
* [#380](https://github.com/bnb-chain/greenfield/pull/380) chore: add unit test cases for payment module
* [#381](https://github.com/bnb-chain/greenfield/pull/381) chore: add tests for bridge module
* [#383](https://github.com/bnb-chain/greenfield/pull/383) chore: add unit test cases for challenge module

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
