### PR TITLE
fix: add group existence check when verify permission

### DIFF
--- a/e2e/tests/permission_test.go
+++ b/e2e/tests/permission_test.go
@@ -9,6 +9,11 @@ import (
 	"time"
 
 	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	govtypesv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+
 	sdktype "github.com/bnb-chain/greenfield/sdk/types"
 	storageutil "github.com/bnb-chain/greenfield/testutil/storage"
 	types2 "github.com/bnb-chain/greenfield/types"
@@ -16,10 +21,6 @@ import (
 	"github.com/bnb-chain/greenfield/types/resource"
 	"github.com/bnb-chain/greenfield/x/permission/types"
 	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
-	govtypesv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 )
 
 func (s *StorageTestSuite) TestDeleteBucketPermission() {

--- a/e2e/tests/permission_test.go
+++ b/e2e/tests/permission_test.go
@@ -1656,8 +1656,21 @@ func (s *StorageTestSuite) TestVerifyStaleGroupPermission() {
 
 	// Create Group with 3 group member
 	testGroupName := "testGroup"
-	msgCreateGroup := storagetypes.NewMsgCreateGroup(owner.GetAddr(), testGroupName, []sdk.AccAddress{user[0].GetAddr(), user[1].GetAddr(), user[2].GetAddr()}, "")
-	s.SendTxBlock(owner, msgCreateGroup)
+	msgCreateGroup := storagetypes.NewMsgCreateGroup(owner.GetAddr(), testGroupName, "")
+	msgUpdateGroupMember := storagetypes.NewMsgUpdateGroupMember(owner.GetAddr(), owner.GetAddr(), testGroupName,
+		[]*storagetypes.MsgGroupMember{
+			{
+				Member:         user[0].GetAddr().String(),
+				ExpirationTime: storagetypes.MaxTimeStamp,
+			}, {
+				Member:         user[1].GetAddr().String(),
+				ExpirationTime: storagetypes.MaxTimeStamp,
+			}, {
+				Member:         user[2].GetAddr().String(),
+				ExpirationTime: storagetypes.MaxTimeStamp,
+			}},
+		[]sdk.AccAddress{})
+	s.SendTxBlock(owner, msgCreateGroup, msgUpdateGroupMember)
 
 	// Head Group
 	headGroupRequest := storagetypes.QueryHeadGroupRequest{GroupOwner: owner.GetAddr().String(), GroupName: testGroupName}

--- a/e2e/tests/permission_test.go
+++ b/e2e/tests/permission_test.go
@@ -5,11 +5,10 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"strconv"
 	"time"
 
 	sdkmath "cosmossdk.io/math"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	sdktype "github.com/bnb-chain/greenfield/sdk/types"
 	storageutil "github.com/bnb-chain/greenfield/testutil/storage"
 	types2 "github.com/bnb-chain/greenfield/types"
@@ -17,6 +16,10 @@ import (
 	"github.com/bnb-chain/greenfield/types/resource"
 	"github.com/bnb-chain/greenfield/x/permission/types"
 	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	govtypesv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 )
 
 func (s *StorageTestSuite) TestDeleteBucketPermission() {
@@ -1560,6 +1563,7 @@ func (s *StorageTestSuite) TestPutPolicy_ObjectWithSlash() {
 	var err error
 	user := s.GenAndChargeAccounts(2, 1000000)
 
+	ctx := context.Background()
 	sp := s.BaseSuite.PickStorageProvider()
 	gvg, found := sp.GetFirstGlobalVirtualGroup()
 	s.Require().True(found)
@@ -1574,7 +1578,6 @@ func (s *StorageTestSuite) TestPutPolicy_ObjectWithSlash() {
 	s.SendTxBlock(user[0], msgCreateBucket)
 
 	// HeadBucket
-	ctx := context.Background()
 	queryHeadBucketRequest := storagetypes.QueryHeadBucketRequest{
 		BucketName: bucketName,
 	}
@@ -1628,4 +1631,205 @@ func (s *StorageTestSuite) TestPutPolicy_ObjectWithSlash() {
 		principal, []*types.Statement{statement}, nil)
 	s.SendTxBlock(user[0], msgPutPolicy)
 
+}
+
+func (s *StorageTestSuite) TestVerifyStaleGroupPermission() {
+	ctx := context.Background()
+
+	// set the params, not to delete stale policy
+	queryParamsRequest := storagetypes.QueryParamsRequest{}
+	queryParamsResponse, err := s.Client.StorageQueryClient.Params(ctx, &queryParamsRequest)
+	s.Require().NoError(err)
+
+	newParams := queryParamsResponse.GetParams()
+	newParams.StalePolicyCleanupMax = 0
+	s.UpdateParams(&newParams)
+
+	defer func() {
+		newParams.StalePolicyCleanupMax = 100
+		s.UpdateParams(&newParams)
+	}()
+
+	user := s.GenAndChargeAccounts(3, 10000)
+	_, owner, bucketName, bucketId, objectName, objectId := s.createObjectWithVisibility(storagetypes.VISIBILITY_TYPE_PUBLIC_READ)
+
+	// Create Group with 3 group member
+	testGroupName := "testGroup"
+	msgCreateGroup := storagetypes.NewMsgCreateGroup(owner.GetAddr(), testGroupName, []sdk.AccAddress{user[0].GetAddr(), user[1].GetAddr(), user[2].GetAddr()}, "")
+	s.SendTxBlock(owner, msgCreateGroup)
+
+	// Head Group
+	headGroupRequest := storagetypes.QueryHeadGroupRequest{GroupOwner: owner.GetAddr().String(), GroupName: testGroupName}
+	headGroupResponse, err := s.Client.HeadGroup(ctx, &headGroupRequest)
+	s.Require().NoError(err)
+	s.Require().Equal(headGroupResponse.GroupInfo.GroupName, testGroupName)
+	s.Require().True(owner.GetAddr().Equals(sdk.MustAccAddressFromHex(headGroupResponse.GroupInfo.Owner)))
+	s.T().Logf("GroupInfo: %s", headGroupResponse.GetGroupInfo().String())
+
+	principal := types.NewPrincipalWithGroupId(headGroupResponse.GroupInfo.Id)
+	// Put bucket policy for group
+	bucketStatement := &types.Statement{
+		Actions: []types.ActionType{types.ACTION_DELETE_BUCKET},
+		Effect:  types.EFFECT_ALLOW,
+	}
+	msgPutBucketPolicy := storagetypes.NewMsgPutPolicy(owner.GetAddr(), types2.NewBucketGRN(bucketName).String(),
+		principal, []*types.Statement{bucketStatement}, nil)
+	s.SendTxBlock(owner, msgPutBucketPolicy)
+
+	// Put Object policy for group
+	objectStatement := &types.Statement{
+		Actions: []types.ActionType{types.ACTION_DELETE_OBJECT},
+		Effect:  types.EFFECT_ALLOW,
+	}
+	msgPutObjectPolicy := storagetypes.NewMsgPutPolicy(owner.GetAddr(), types2.NewObjectGRN(bucketName, objectName).String(),
+		principal, []*types.Statement{objectStatement}, nil)
+	s.SendTxBlock(owner, msgPutObjectPolicy)
+
+	// Query bucket policy for group
+	grn := types2.NewBucketGRN(bucketName)
+	queryPolicyForGroupReq := storagetypes.QueryPolicyForGroupRequest{Resource: grn.String(),
+		PrincipalGroupId: headGroupResponse.GroupInfo.Id.String()}
+
+	queryPolicyForGroupResp, err := s.Client.QueryPolicyForGroup(ctx, &queryPolicyForGroupReq)
+	s.Require().NoError(err)
+	s.Require().Equal(bucketId, queryPolicyForGroupResp.Policy.ResourceId)
+	s.Require().Equal(queryPolicyForGroupResp.Policy.ResourceType, resource.RESOURCE_TYPE_BUCKET)
+	s.Require().Equal(types.EFFECT_ALLOW, queryPolicyForGroupResp.Policy.Statements[0].Effect)
+	bucketPolicyID := queryPolicyForGroupResp.Policy.Id
+
+	// Query object policy for group
+	grn2 := types2.NewObjectGRN(bucketName, objectName)
+	queryPolicyForGroupResp, err = s.Client.QueryPolicyForGroup(ctx, &storagetypes.QueryPolicyForGroupRequest{Resource: grn2.String(),
+		PrincipalGroupId: headGroupResponse.GroupInfo.Id.String()})
+	s.Require().NoError(err)
+	s.Require().Equal(objectId, queryPolicyForGroupResp.Policy.ResourceId)
+	s.Require().Equal(queryPolicyForGroupResp.Policy.ResourceType, resource.RESOURCE_TYPE_OBJECT)
+	s.Require().Equal(types.EFFECT_ALLOW, queryPolicyForGroupResp.Policy.Statements[0].Effect)
+	objectPolicyID := queryPolicyForGroupResp.Policy.Id
+
+	// verify group policy
+	verifyPermResp, err := s.Client.VerifyPermission(ctx, &storagetypes.QueryVerifyPermissionRequest{
+		Operator:   user[2].GetAddr().String(),
+		BucketName: bucketName,
+		ActionType: types.ACTION_DELETE_BUCKET,
+	})
+	s.T().Logf("Verify Bucket Permission, %s", verifyPermResp.String())
+	s.Require().NoError(err)
+	s.Require().Equal(types.EFFECT_ALLOW, verifyPermResp.Effect)
+	// verify group policy
+	verifyPermResp, err = s.Client.VerifyPermission(ctx, &storagetypes.QueryVerifyPermissionRequest{
+		Operator:   user[2].GetAddr().String(),
+		BucketName: bucketName,
+		ObjectName: objectName,
+		ActionType: types.ACTION_DELETE_OBJECT,
+	})
+	s.T().Logf("Verify Object Permission, %s", verifyPermResp.String())
+	s.Require().NoError(err)
+	s.Require().Equal(types.EFFECT_ALLOW, verifyPermResp.Effect)
+
+	// user1 deletes the group
+	msgDeleteGroup := storagetypes.NewMsgDeleteGroup(owner.GetAddr(), testGroupName)
+	s.SendTxBlock(owner, msgDeleteGroup)
+
+	// group don't exist after deletion
+	_, err = s.Client.HeadGroup(ctx, &storagetypes.QueryHeadGroupRequest{
+		GroupOwner: owner.GetAddr().String(),
+		GroupName:  testGroupName,
+	})
+	s.Require().Error(err)
+	s.Require().ErrorContains(err, "No such group")
+
+	// stale permission is still exist
+	queryPolicyByIDResp, err := s.Client.QueryPolicyById(ctx, &storagetypes.QueryPolicyByIdRequest{PolicyId: bucketPolicyID.String()})
+	s.T().Logf("Qyery policy by id resp: %s", queryPolicyByIDResp)
+	s.Require().NoError(err)
+
+	queryPolicyByIDResp, err = s.Client.QueryPolicyById(ctx, &storagetypes.QueryPolicyByIdRequest{PolicyId: objectPolicyID.String()})
+	s.T().Logf("Qyery policy by id resp: %s", queryPolicyByIDResp)
+	s.Require().NoError(err)
+
+	// verify group policy
+	verifyPermResp, err = s.Client.VerifyPermission(ctx, &storagetypes.QueryVerifyPermissionRequest{
+		Operator:   user[2].GetAddr().String(),
+		BucketName: bucketName,
+		ActionType: types.ACTION_DELETE_BUCKET,
+	})
+	s.T().Logf("Verify Bucket Permission, %s", verifyPermResp.String())
+	s.Require().NoError(err)
+	s.Require().Equal(types.EFFECT_DENY, verifyPermResp.Effect)
+	// verify group policy
+	verifyPermResp, err = s.Client.VerifyPermission(ctx, &storagetypes.QueryVerifyPermissionRequest{
+		Operator:   user[2].GetAddr().String(),
+		BucketName: bucketName,
+		ObjectName: objectName,
+		ActionType: types.ACTION_DELETE_OBJECT,
+	})
+	s.T().Logf("Verify Object Permission, %s", verifyPermResp.String())
+	s.Require().NoError(err)
+	s.Require().Equal(types.EFFECT_DENY, verifyPermResp.Effect)
+}
+
+func (s *StorageTestSuite) UpdateParams(newParams *storagetypes.Params) {
+	var err error
+	validator := s.Validator.GetAddr()
+
+	ctx := context.Background()
+
+	msgUpdateParams := &storagetypes.MsgUpdateParams{
+		Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		Params:    *newParams,
+	}
+
+	msgProposal, err := govtypesv1.NewMsgSubmitProposal(
+		[]sdk.Msg{msgUpdateParams},
+		sdk.Coins{sdk.NewCoin(s.BaseSuite.Config.Denom, sdktype.NewIntFromInt64WithDecimal(100, sdktype.DecimalBNB))},
+		validator.String(),
+		"test", "test", "test",
+	)
+	s.Require().NoError(err)
+
+	txRes := s.SendTxBlock(s.Validator, msgProposal)
+	s.Require().Equal(txRes.Code, uint32(0))
+
+	// 3. query proposal and get proposal ID
+	var proposalId uint64
+	for _, event := range txRes.Logs[0].Events {
+		if event.Type == "submit_proposal" {
+			for _, attr := range event.Attributes {
+				if attr.Key == "proposal_id" {
+					proposalId, err = strconv.ParseUint(attr.Value, 10, 0)
+					s.Require().NoError(err)
+					break
+				}
+			}
+			break
+		}
+	}
+	s.Require().True(proposalId != 0)
+
+	queryProposal := &govtypesv1.QueryProposalRequest{ProposalId: proposalId}
+	_, err = s.Client.GovQueryClientV1.Proposal(ctx, queryProposal)
+	s.Require().NoError(err)
+
+	// 4. submit MsgVote and wait the proposal exec
+	msgVote := govtypesv1.NewMsgVote(validator, proposalId, govtypesv1.OptionYes, "test")
+	txRes = s.SendTxBlock(s.Validator, msgVote)
+	s.Require().Equal(txRes.Code, uint32(0))
+
+	queryVoteParamsReq := govtypesv1.QueryParamsRequest{ParamsType: "voting"}
+	queryVoteParamsResp, err := s.Client.GovQueryClientV1.Params(ctx, &queryVoteParamsReq)
+	s.Require().NoError(err)
+
+	// 5. wait a voting period and confirm that the proposal success.
+	s.T().Logf("voting period %s", *queryVoteParamsResp.Params.VotingPeriod)
+	time.Sleep(*queryVoteParamsResp.Params.VotingPeriod)
+	time.Sleep(1 * time.Second)
+	proposalRes, err := s.Client.GovQueryClientV1.Proposal(ctx, queryProposal)
+	s.Require().NoError(err)
+	s.Require().Equal(proposalRes.Proposal.Status, govtypesv1.ProposalStatus_PROPOSAL_STATUS_PASSED)
+
+	queryParamsResponse, err := s.Client.StorageQueryClient.Params(ctx, &storagetypes.QueryParamsRequest{})
+	s.Require().NoError(err)
+	s.T().Logf("QueryParmas: %s", queryParamsResponse.Params.String())
+	s.Require().Equal(queryParamsResponse.Params, *newParams)
 }

--- a/x/payment/keeper/msg_server_test.go
+++ b/x/payment/keeper/msg_server_test.go
@@ -3,7 +3,6 @@ package keeper_test
 import (
 	"testing"
 
-	"github.com/bnb-chain/greenfield/testutil/sample"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"

--- a/x/payment/keeper/msg_server_test.go
+++ b/x/payment/keeper/msg_server_test.go
@@ -3,6 +3,7 @@ package keeper_test
 import (
 	"testing"
 
+	"github.com/bnb-chain/greenfield/testutil/sample"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"

--- a/x/permission/keeper/keeper.go
+++ b/x/permission/keeper/keeper.go
@@ -247,7 +247,7 @@ func (k Keeper) GetPolicyGroupForResource(ctx sdk.Context, resourceID math.Uint,
 
 	var policyGroup types.PolicyGroup
 	k.cdc.MustUnmarshal(bz, &policyGroup)
-	return &policyGroup, false
+	return &policyGroup, true
 }
 
 func (k Keeper) GetPolicyForGroup(ctx sdk.Context, resourceID math.Uint,

--- a/x/permission/keeper/keeper.go
+++ b/x/permission/keeper/keeper.go
@@ -5,15 +5,16 @@ import (
 	"time"
 
 	"cosmossdk.io/math"
-	"github.com/bnb-chain/greenfield/internal/sequence"
-	"github.com/bnb-chain/greenfield/types/resource"
-	"github.com/bnb-chain/greenfield/x/permission/types"
-	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/bnb-chain/greenfield/internal/sequence"
+	"github.com/bnb-chain/greenfield/types/resource"
+	"github.com/bnb-chain/greenfield/x/permission/types"
+	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
 )
 
 type (

--- a/x/permission/keeper/keeper.go
+++ b/x/permission/keeper/keeper.go
@@ -5,16 +5,15 @@ import (
 	"time"
 
 	"cosmossdk.io/math"
+	"github.com/bnb-chain/greenfield/internal/sequence"
+	"github.com/bnb-chain/greenfield/types/resource"
+	"github.com/bnb-chain/greenfield/x/permission/types"
+	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
-	"github.com/bnb-chain/greenfield/internal/sequence"
-	"github.com/bnb-chain/greenfield/types/resource"
-	"github.com/bnb-chain/greenfield/x/permission/types"
-	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
 )
 
 type (
@@ -258,69 +257,6 @@ func (k Keeper) GetPolicyForGroup(ctx sdk.Context, resourceID math.Uint,
 		}
 	}
 	return nil, false
-}
-
-func (k Keeper) VerifyPolicy(ctx sdk.Context, resourceID math.Uint, resourceType resource.ResourceType,
-	operator sdk.AccAddress, action types.ActionType, opts *types.VerifyOptions) types.Effect {
-	// verify policy which grant permission to account
-	policy, found := k.GetPolicyForAccount(ctx, resourceID, resourceType, operator)
-	if found {
-		effect, newPolicy := policy.Eval(action, ctx.BlockTime(), opts)
-		k.Logger(ctx).Info(fmt.Sprintf("CreateObject LimitSize update: %s, effect: %s, ctx.TxBytes : %d",
-			newPolicy.String(), effect, ctx.TxSize()))
-		if effect != types.EFFECT_UNSPECIFIED {
-			if effect == types.EFFECT_ALLOW && action == types.ACTION_CREATE_OBJECT && newPolicy != nil && ctx.TxBytes() != nil {
-				_, err := k.PutPolicy(ctx, newPolicy)
-				if err != nil {
-					panic(fmt.Sprintf("Update policy error, %s", err))
-				}
-			}
-			return effect
-		}
-	}
-
-	// verify policy which grant permission to group
-	store := ctx.KVStore(k.storeKey)
-	bz := store.Get(types.GetPolicyForGroupKey(resourceID, resourceType))
-	if bz != nil {
-		policyGroup := types.PolicyGroup{}
-		k.cdc.MustUnmarshal(bz, &policyGroup)
-		allowed := false
-		var (
-			newPolicy *types.Policy
-			effect    types.Effect
-		)
-		for _, item := range policyGroup.Items {
-			// check the group has the right permission of this resource
-			p := k.MustGetPolicyByID(ctx, item.PolicyId)
-			effect, newPolicy = p.Eval(action, ctx.BlockTime(), opts)
-			if effect != types.EFFECT_UNSPECIFIED {
-				// check the operator is the member of this group
-				groupMember, memberFound := k.GetGroupMember(ctx, item.GroupId, operator)
-				if memberFound && groupMember.ExpirationTime.After(ctx.BlockTime().UTC()) {
-					// check if the operator has been revoked
-					if effect == types.EFFECT_ALLOW {
-						allowed = true
-					} else if effect == types.EFFECT_DENY {
-						return types.EFFECT_DENY
-					}
-				}
-			}
-		}
-		if allowed {
-			if action == types.ACTION_CREATE_OBJECT && newPolicy != nil && ctx.TxBytes() != nil {
-				if effect == types.EFFECT_ALLOW && action == types.ACTION_CREATE_OBJECT && newPolicy != nil && ctx.TxBytes() != nil {
-					_, err := k.PutPolicy(ctx, newPolicy)
-					if err != nil {
-						panic(fmt.Sprintf("Update policy error, %s", err))
-					}
-				}
-			}
-			return types.EFFECT_ALLOW
-		}
-	}
-
-	return types.EFFECT_UNSPECIFIED
 }
 
 func (k Keeper) DeletePolicy(ctx sdk.Context, principal *types.Principal, resourceType resource.ResourceType,

--- a/x/permission/keeper/keeper.go
+++ b/x/permission/keeper/keeper.go
@@ -236,6 +236,20 @@ func (k Keeper) GetPolicyForAccount(ctx sdk.Context, resourceID math.Uint,
 	return k.GetPolicyByID(ctx, k.policySeq.DecodeSequence(bz))
 }
 
+func (k Keeper) GetPolicyGroupForResource(ctx sdk.Context, resourceID math.Uint, resourceType resource.ResourceType) (*types.PolicyGroup, bool) {
+	store := ctx.KVStore(k.storeKey)
+	policyGroupKey := types.GetPolicyForGroupKey(resourceID, resourceType)
+
+	bz := store.Get(policyGroupKey)
+	if bz == nil {
+		return nil, false
+	}
+
+	var policyGroup types.PolicyGroup
+	k.cdc.MustUnmarshal(bz, &policyGroup)
+	return &policyGroup, false
+}
+
 func (k Keeper) GetPolicyForGroup(ctx sdk.Context, resourceID math.Uint,
 	resourceType resource.ResourceType, groupID math.Uint) (policy *types.Policy,
 	isFound bool) {

--- a/x/storage/keeper/keeper.go
+++ b/x/storage/keeper/keeper.go
@@ -2131,3 +2131,9 @@ func (k Keeper) SetInternalBucketInfo(ctx sdk.Context, bucketID sdkmath.Uint, in
 func (k Keeper) fromSpMaintenanceAcct(sp *sptypes.StorageProvider, operatorAddr sdk.AccAddress) bool {
 	return sp.Status == sptypes.STATUS_IN_MAINTENANCE && operatorAddr.Equals(sdk.MustAccAddressFromHex(sp.MaintenanceAddress))
 }
+
+func (k Keeper) hasGroup(ctx sdk.Context, groupID sdkmath.Uint) bool {
+	store := ctx.KVStore(k.storeKey)
+
+	return store.Has(types.GetGroupByIDKey(groupID))
+}

--- a/x/storage/keeper/permission.go
+++ b/x/storage/keeper/permission.go
@@ -148,15 +148,10 @@ func (k Keeper) VerifyPolicy(ctx sdk.Context, resourceID math.Uint, resourceType
 	}
 
 	// verify policy which grant permission to group
-	store := ctx.KVStore(k.storeKey)
-	bz := store.Get(permtypes.GetPolicyForGroupKey(resourceID, resourceType))
-	if bz != nil {
-		policyGroup := permtypes.PolicyGroup{}
-		k.cdc.MustUnmarshal(bz, &policyGroup)
+	policyGroup, found := k.permKeeper.GetPolicyGroupForResource(ctx, resourceID, resourceType)
+	if found {
 		allowed := false
-		var (
-			allowedPolicy *permtypes.Policy
-		)
+		var allowedPolicy *permtypes.Policy
 		for _, item := range policyGroup.Items {
 			if !k.hasGroup(ctx, item.GroupId) {
 				continue

--- a/x/storage/types/expected_keepers.go
+++ b/x/storage/types/expected_keepers.go
@@ -59,6 +59,7 @@ type PermissionKeeper interface {
 	RemoveGroupMember(ctx sdk.Context, groupID math.Uint, member sdk.AccAddress) error
 	GetPolicyByID(ctx sdk.Context, policyID math.Uint) (*permtypes.Policy, bool)
 	GetPolicyForAccount(ctx sdk.Context, resourceID math.Uint, resourceType resource.ResourceType, addr sdk.AccAddress) (policy *permtypes.Policy, isFound bool)
+	GetPolicyGroupForResource(ctx sdk.Context, resourceID math.Uint, resourceType resource.ResourceType) (*permtypes.PolicyGroup, bool)
 	GetPolicyForGroup(ctx sdk.Context, resourceID math.Uint, resourceType resource.ResourceType,
 		groupID math.Uint) (policy *permtypes.Policy, isFound bool)
 	GetGroupMember(ctx sdk.Context, groupID math.Uint, member sdk.AccAddress) (*permtypes.GroupMember, bool)

--- a/x/storage/types/expected_keepers.go
+++ b/x/storage/types/expected_keepers.go
@@ -56,10 +56,10 @@ type PermissionKeeper interface {
 	AddGroupMember(ctx sdk.Context, groupID math.Uint, member sdk.AccAddress, expiration time.Time) error
 	UpdateGroupMember(ctx sdk.Context, groupID math.Uint, member sdk.AccAddress, memberID math.Uint, expiration time.Time)
 	MustGetPolicyByID(ctx sdk.Context, policyID math.Uint) *permtypes.Policy
+	GetPolicyGroupForResource(ctx sdk.Context, resourceID math.Uint, resourceType resource.ResourceType) (*permtypes.PolicyGroup, bool)
 	RemoveGroupMember(ctx sdk.Context, groupID math.Uint, member sdk.AccAddress) error
 	GetPolicyByID(ctx sdk.Context, policyID math.Uint) (*permtypes.Policy, bool)
 	GetPolicyForAccount(ctx sdk.Context, resourceID math.Uint, resourceType resource.ResourceType, addr sdk.AccAddress) (policy *permtypes.Policy, isFound bool)
-	GetPolicyGroupForResource(ctx sdk.Context, resourceID math.Uint, resourceType resource.ResourceType) (*permtypes.PolicyGroup, bool)
 	GetPolicyForGroup(ctx sdk.Context, resourceID math.Uint, resourceType resource.ResourceType,
 		groupID math.Uint) (policy *permtypes.Policy, isFound bool)
 	GetGroupMember(ctx sdk.Context, groupID math.Uint, member sdk.AccAddress) (*permtypes.GroupMember, bool)

--- a/x/storage/types/expected_keepers.go
+++ b/x/storage/types/expected_keepers.go
@@ -53,10 +53,9 @@ type PermissionKeeper interface {
 	PutPolicy(ctx sdk.Context, policy *permtypes.Policy) (math.Uint, error)
 	DeletePolicy(ctx sdk.Context, principal *permtypes.Principal, resourceType resource.ResourceType,
 		resourceID math.Uint) (math.Uint, error)
-	VerifyPolicy(ctx sdk.Context, resourceID math.Uint, resourceType resource.ResourceType, operator sdk.AccAddress,
-		action permtypes.ActionType, opts *permtypes.VerifyOptions) permtypes.Effect
 	AddGroupMember(ctx sdk.Context, groupID math.Uint, member sdk.AccAddress, expiration time.Time) error
 	UpdateGroupMember(ctx sdk.Context, groupID math.Uint, member sdk.AccAddress, memberID math.Uint, expiration time.Time)
+	MustGetPolicyByID(ctx sdk.Context, policyID math.Uint) *permtypes.Policy
 	RemoveGroupMember(ctx sdk.Context, groupID math.Uint, member sdk.AccAddress) error
 	GetPolicyByID(ctx sdk.Context, policyID math.Uint) (*permtypes.Policy, bool)
 	GetPolicyForAccount(ctx sdk.Context, resourceID math.Uint, resourceType resource.ResourceType, addr sdk.AccAddress) (policy *permtypes.Policy, isFound bool)

--- a/x/storage/types/expected_keepers_mocks.go
+++ b/x/storage/types/expected_keepers_mocks.go
@@ -558,6 +558,20 @@ func (mr *MockPermissionKeeperMockRecorder) GetPolicyForGroup(ctx, resourceID, r
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPolicyForGroup", reflect.TypeOf((*MockPermissionKeeper)(nil).GetPolicyForGroup), ctx, resourceID, resourceType, groupID)
 }
 
+// MustGetPolicyByID mocks base method.
+func (m *MockPermissionKeeper) MustGetPolicyByID(ctx types3.Context, policyID math.Uint) *types0.Policy {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MustGetPolicyByID", ctx, policyID)
+	ret0, _ := ret[0].(*types0.Policy)
+	return ret0
+}
+
+// MustGetPolicyByID indicates an expected call of MustGetPolicyByID.
+func (mr *MockPermissionKeeperMockRecorder) MustGetPolicyByID(ctx, policyID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MustGetPolicyByID", reflect.TypeOf((*MockPermissionKeeper)(nil).MustGetPolicyByID), ctx, policyID)
+}
+
 // PutPolicy mocks base method.
 func (m *MockPermissionKeeper) PutPolicy(ctx types3.Context, policy *types0.Policy) (math.Uint, error) {
 	m.ctrl.T.Helper()
@@ -597,20 +611,6 @@ func (m *MockPermissionKeeper) UpdateGroupMember(ctx types3.Context, groupID mat
 func (mr *MockPermissionKeeperMockRecorder) UpdateGroupMember(ctx, groupID, member, memberID, expiration interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateGroupMember", reflect.TypeOf((*MockPermissionKeeper)(nil).UpdateGroupMember), ctx, groupID, member, memberID, expiration)
-}
-
-// VerifyPolicy mocks base method.
-func (m *MockPermissionKeeper) VerifyPolicy(ctx types3.Context, resourceID math.Uint, resourceType resource.ResourceType, operator types3.AccAddress, action types0.ActionType, opts *types0.VerifyOptions) types0.Effect {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "VerifyPolicy", ctx, resourceID, resourceType, operator, action, opts)
-	ret0, _ := ret[0].(types0.Effect)
-	return ret0
-}
-
-// VerifyPolicy indicates an expected call of VerifyPolicy.
-func (mr *MockPermissionKeeperMockRecorder) VerifyPolicy(ctx, resourceID, resourceType, operator, action, opts interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyPolicy", reflect.TypeOf((*MockPermissionKeeper)(nil).VerifyPolicy), ctx, resourceID, resourceType, operator, action, opts)
 }
 
 // MockCrossChainKeeper is a mock of CrossChainKeeper interface.

--- a/x/storage/types/expected_keepers_mocks.go
+++ b/x/storage/types/expected_keepers_mocks.go
@@ -558,6 +558,21 @@ func (mr *MockPermissionKeeperMockRecorder) GetPolicyForGroup(ctx, resourceID, r
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPolicyForGroup", reflect.TypeOf((*MockPermissionKeeper)(nil).GetPolicyForGroup), ctx, resourceID, resourceType, groupID)
 }
 
+// GetPolicyGroupForResource mocks base method.
+func (m *MockPermissionKeeper) GetPolicyGroupForResource(ctx types3.Context, resourceID math.Uint, resourceType resource.ResourceType) (*types0.PolicyGroup, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPolicyGroupForResource", ctx, resourceID, resourceType)
+	ret0, _ := ret[0].(*types0.PolicyGroup)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// GetPolicyGroupForResource indicates an expected call of GetPolicyGroupForResource.
+func (mr *MockPermissionKeeperMockRecorder) GetPolicyGroupForResource(ctx, resourceID, resourceType interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPolicyGroupForResource", reflect.TypeOf((*MockPermissionKeeper)(nil).GetPolicyGroupForResource), ctx, resourceID, resourceType)
+}
+
 // MustGetPolicyByID mocks base method.
 func (m *MockPermissionKeeper) MustGetPolicyByID(ctx types3.Context, policyID math.Uint) *types0.Policy {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
### Description

add group existence check when verify permission

### Rationale

Because the expired permission information is not deleted in time, the verification will success, but is expected to failed.

for more information, see stale permission clean in EndBlock. https://github.com/bnb-chain/greenfield/blob/master/x/storage/keeper/keeper.go#L1693-L1728

### Example

NA

### Changes

Notable changes: 
* add group existence check
* return group id when verify permission in permission module
