### PR TITLE
chore: Update go version to 1.20 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bnb-chain/greenfield
 
-go 1.19
+go 1.20
 
 require (
 	cosmossdk.io/api v0.4.0


### PR DESCRIPTION
### Description

update go version in go mod to 1.20

### Rationale

- Some functions like `strings.CutPrefix` only supported in go 1.20
- It already update to go 1.20 in github ci workflows.

### Example

NA

### Changes

Notable changes: 
* NA