### PR TITLE
fix: fix the SettleTimestamp calculation

### DIFF
--- a/e2e/tests/payment_test.go
+++ b/e2e/tests/payment_test.go
@@ -126,7 +126,7 @@ func (s *PaymentTestSuite) TestVersionedParams_SealObjectAfterReserveTimeChange(
 	s.Require().True(found)
 
 	// create bucket, create object
-	user, bucketName, objectName, objectId, checksums := s.createBucketAndObject(sp)
+	user, bucketName, objectName, objectId, checksums := s.createBucketAndObject(sp, gvg)
 
 	// update params
 	params := s.queryParams()
@@ -180,7 +180,7 @@ func (s *PaymentTestSuite) TestVersionedParams_DeleteBucketAfterValidatorTaxRate
 	s.T().Logf("netflow, validatorTaxPoolRate: %s", validatorTaxPoolRate)
 
 	// create bucket, create object
-	user, bucketName, objectName, objectId, checksums := s.createBucketAndObject(sp)
+	user, bucketName, objectName, objectId, checksums := s.createBucketAndObject(sp, gvg)
 
 	// seal object
 	s.sealObject(sp, gvg, bucketName, objectName, objectId, checksums)
@@ -221,7 +221,7 @@ func (s *PaymentTestSuite) TestVersionedParams_DeleteObjectAfterReserveTimeChang
 	s.Require().True(found)
 
 	// create bucket, create object
-	user, bucketName, objectName, objectId, checksums := s.createBucketAndObject(sp)
+	user, bucketName, objectName, objectId, checksums := s.createBucketAndObject(sp, gvg)
 
 	// seal object
 	s.sealObject(sp, gvg, bucketName, objectName, objectId, checksums)
@@ -2279,11 +2279,8 @@ func (s *PaymentTestSuite) updateParams(params paymenttypes.Params) {
 	s.T().Log("params after", core.YamlString(queryParamsResponse.Params))
 }
 
-func (s *PaymentTestSuite) createBucketAndObject(sp *core.StorageProvider) (keys.KeyManager, string, string, storagetypes.Uint, [][]byte) {
+func (s *PaymentTestSuite) createBucketAndObject(sp *core.StorageProvider, gvg *virtualgrouptypes.GlobalVirtualGroup) (keys.KeyManager, string, string, storagetypes.Uint, [][]byte) {
 	var err error
-	gvg, found := sp.GetFirstGlobalVirtualGroup()
-	s.Require().True(found)
-
 	// CreateBucket
 	user := s.GenAndChargeAccounts(1, 1000000)[0]
 	bucketName := "ch" + storagetestutils.GenRandomBucketName()

--- a/x/payment/keeper/auto_settle_record.go
+++ b/x/payment/keeper/auto_settle_record.go
@@ -42,14 +42,10 @@ func (k Keeper) GetAllAutoSettleRecord(ctx sdk.Context) (list []types.AutoSettle
 		val := types.ParseAutoSettleRecordKey(iterator.Key())
 		list = append(list, val)
 	}
-
 	return
 }
 
 func (k Keeper) UpdateAutoSettleRecord(ctx sdk.Context, addr sdk.AccAddress, oldTime, newTime int64) {
-	if oldTime == newTime {
-		return
-	}
 	if oldTime != 0 {
 		k.RemoveAutoSettleRecord(ctx, oldTime, addr)
 	}

--- a/x/payment/keeper/stream_record.go
+++ b/x/payment/keeper/stream_record.go
@@ -373,6 +373,7 @@ func (k Keeper) TryResumeStreamRecord(ctx sdk.Context, streamRecord *types.Strea
 	}
 
 	now := ctx.BlockTime().Unix()
+	prevSettleTime := streamRecord.SettleTimestamp
 	streamRecord.SettleTimestamp = now + streamRecord.StaticBalance.Quo(totalRate.Abs()).Int64() - int64(forcedSettleTime)
 	streamRecord.BufferBalance = expectedBalanceToResume
 	streamRecord.StaticBalance = streamRecord.StaticBalance.Sub(expectedBalanceToResume)
@@ -416,7 +417,7 @@ func (k Keeper) TryResumeStreamRecord(ctx sdk.Context, streamRecord *types.Strea
 		}
 
 		k.SetStreamRecord(ctx, streamRecord)
-		k.UpdateAutoSettleRecord(ctx, sdk.MustAccAddressFromHex(streamRecord.Account), 0, streamRecord.SettleTimestamp)
+		k.UpdateAutoSettleRecord(ctx, sdk.MustAccAddressFromHex(streamRecord.Account), prevSettleTime, streamRecord.SettleTimestamp)
 		return nil
 	} else { //enqueue for resume in end block
 		k.SetStreamRecord(ctx, streamRecord)

--- a/x/payment/keeper/stream_record.go
+++ b/x/payment/keeper/stream_record.go
@@ -373,7 +373,7 @@ func (k Keeper) TryResumeStreamRecord(ctx sdk.Context, streamRecord *types.Strea
 	}
 
 	now := ctx.BlockTime().Unix()
-	streamRecord.SettleTimestamp = now + streamRecord.StaticBalance.Quo(totalRate).Int64() - int64(forcedSettleTime)
+	streamRecord.SettleTimestamp = now + streamRecord.StaticBalance.Quo(totalRate.Abs()).Int64() - int64(forcedSettleTime)
 	streamRecord.BufferBalance = expectedBalanceToResume
 	streamRecord.StaticBalance = streamRecord.StaticBalance.Sub(expectedBalanceToResume)
 	streamRecord.CrudTimestamp = now


### PR DESCRIPTION
### Description

The `StaticBalance` is positive and `totalRate` is negative. need to use `totalRate.abs()` to calculate the timestamp. 

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
