### PR TITLE
fix: fix early deletion fee calculation

### DIFF
--- a/x/sp/abci_test.go
+++ b/x/sp/abci_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bnb-chain/greenfield/testutil/sample"
-
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
@@ -18,6 +16,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/bnb-chain/greenfield/testutil/sample"
 	spmodule "github.com/bnb-chain/greenfield/x/sp"
 	"github.com/bnb-chain/greenfield/x/sp/keeper"
 	"github.com/bnb-chain/greenfield/x/sp/types"

--- a/x/sp/keeper/msg_server_test.go
+++ b/x/sp/keeper/msg_server_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bnb-chain/greenfield/x/sp/keeper"
-
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -16,6 +14,7 @@ import (
 
 	"github.com/bnb-chain/greenfield/sdk/types"
 	"github.com/bnb-chain/greenfield/testutil/sample"
+	"github.com/bnb-chain/greenfield/x/sp/keeper"
 	sptypes "github.com/bnb-chain/greenfield/x/sp/types"
 )
 

--- a/x/sp/types/message.go
+++ b/x/sp/types/message.go
@@ -3,9 +3,8 @@ package types
 import (
 	"encoding/hex"
 
-	"github.com/cometbft/cometbft/crypto/tmhash"
-
 	"cosmossdk.io/errors"
+	"github.com/cometbft/cometbft/crypto/tmhash"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/prysmaticlabs/prysm/crypto/bls"

--- a/x/storage/keeper/grpc_query.go
+++ b/x/storage/keeper/grpc_query.go
@@ -367,7 +367,7 @@ func (k Keeper) QueryIsPriceChanged(c context.Context, req *types.QueryIsPriceCh
 		Changed:                    changed,
 		CurrentReadPrice:           currentPrice.ReadPrice,
 		CurrentPrimaryStorePrice:   currentPrice.PrimaryStorePrice,
-		CurrentSecondaryStorePrice: currentPrice.ReadPrice,
+		CurrentSecondaryStorePrice: currentPrice.SecondaryStorePrice,
 		CurrentValidatorTaxRate:    currentTaxRate,
 		NewReadPrice:               newPrice.ReadPrice,
 		NewPrimaryStorePrice:       newPrice.PrimaryStorePrice,

--- a/x/storage/keeper/keeper.go
+++ b/x/storage/keeper/keeper.go
@@ -6,7 +6,6 @@ import (
 
 	"cosmossdk.io/errors"
 	sdkmath "cosmossdk.io/math"
-
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/store/prefix"

--- a/x/storage/keeper/payment.go
+++ b/x/storage/keeper/payment.go
@@ -250,7 +250,7 @@ func (k Keeper) UnChargeObjectStoreFee(ctx sdk.Context, primarySpId uint32, buck
 func (k Keeper) ChargeObjectStoreFeeForEarlyDeletion(ctx sdk.Context, userFlows []types.OutFlow, bucketInfo *storagetypes.BucketInfo, objectInfo *storagetypes.ObjectInfo, timeToPay int64) error {
 	totalStaticBalanceChange := sdkmath.NewInt(0)
 	for _, flow := range userFlows {
-		staticBalanceChange := flow.Rate.MulRaw(timeToPay)
+		staticBalanceChange := flow.Rate.Abs().MulRaw(timeToPay)
 		_, err := k.paymentKeeper.UpdateStreamRecordByAddr(ctx,
 			types.NewDefaultStreamRecordChangeWithAddr(sdk.MustAccAddressFromHex(flow.ToAddress)).WithStaticBalanceChange(staticBalanceChange))
 		if err != nil {

--- a/x/storage/types/expected_keepers.go
+++ b/x/storage/types/expected_keepers.go
@@ -48,6 +48,7 @@ type PaymentKeeper interface {
 	ApplyUserFlowsList(ctx sdk.Context, userFlows []paymenttypes.UserFlows) (err error)
 	UpdateStreamRecordByAddr(ctx sdk.Context, change *paymenttypes.StreamRecordChange) (ret *paymenttypes.StreamRecord, err error)
 	GetStreamRecord(ctx sdk.Context, account sdk.AccAddress) (ret *paymenttypes.StreamRecord, found bool)
+	MergeOutFlows(flows []paymenttypes.OutFlow) []paymenttypes.OutFlow
 }
 
 type PermissionKeeper interface {

--- a/x/storage/types/expected_keepers_mocks.go
+++ b/x/storage/types/expected_keepers_mocks.go
@@ -11,6 +11,7 @@ import (
 
 	math "cosmossdk.io/math"
 	resource "github.com/bnb-chain/greenfield/types/resource"
+	paymenttypes "github.com/bnb-chain/greenfield/x/payment/types"
 	types "github.com/bnb-chain/greenfield/x/payment/types"
 	types0 "github.com/bnb-chain/greenfield/x/permission/types"
 	types1 "github.com/bnb-chain/greenfield/x/sp/types"
@@ -357,6 +358,20 @@ func (m *MockPaymentKeeper) UpdateStreamRecordByAddr(ctx types3.Context, change 
 func (mr *MockPaymentKeeperMockRecorder) UpdateStreamRecordByAddr(ctx, change interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStreamRecordByAddr", reflect.TypeOf((*MockPaymentKeeper)(nil).UpdateStreamRecordByAddr), ctx, change)
+}
+
+// MergeOutFlows mocks base method.
+func (m *MockPaymentKeeper) MergeOutFlows(flows []paymenttypes.OutFlow) []paymenttypes.OutFlow {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MergeOutFlows", flows)
+	ret0, _ := ret[0].([]paymenttypes.OutFlow)
+	return ret0
+}
+
+// MergeOutFlows indicates an expected call of MergeOutFlows.
+func (mr *MockPaymentKeeperMockRecorder) MergeOutFlows(flows interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MergeOutFlows", reflect.TypeOf((*MockPaymentKeeper)(nil).MergeOutFlows), flows)
 }
 
 // MockPermissionKeeper is a mock of PermissionKeeper interface.


### PR DESCRIPTION
### Description

this pr fixes that when deleting a object within the reserved period should use ` rate * (LVG stored size diff)` to calculate the fee to avoid deviation. 

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
