### PR TITLE
feat: deposit the balance of  the bank account to the payment account

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -527,7 +527,7 @@ func New(
 			encodingConfig.TxConfig),
 		auth.NewAppModule(appCodec, app.AccountKeeper, nil, nil),
 		authzmodule.NewAppModule(appCodec, app.AuthzKeeper, app.AccountKeeper, app.BankKeeper, app.interfaceRegistry),
-		bank.NewAppModule(appCodec, app.BankKeeper, app.AccountKeeper, nil),
+		bank.NewAppModule(appCodec, app.BankKeeper, app.AccountKeeper, app.PaymentKeeper, nil),
 		feegrantmodule.NewAppModule(appCodec, app.AccountKeeper, app.BankKeeper, app.FeeGrantKeeper, app.interfaceRegistry),
 		gov.NewAppModule(appCodec, &app.GovKeeper, app.AccountKeeper, app.BankKeeper, nil),
 		slashing.NewAppModule(appCodec, app.SlashingKeeper, app.AccountKeeper, app.BankKeeper, app.StakingKeeper, nil),

--- a/app/upgrade.go
+++ b/app/upgrade.go
@@ -51,7 +51,7 @@ func (app *App) registerNagquUpgradeHandler() {
 	// Register the upgrade initializer
 	app.UpgradeKeeper.SetUpgradeInitializer(upgradetypes.Nagqu,
 		func() error {
-			app.Logger().Info("Init enable public delegation upgrade")
+			app.Logger().Info("Init Nagqu upgrade")
 			return nil
 		},
 	)

--- a/app/upgrade.go
+++ b/app/upgrade.go
@@ -2,6 +2,9 @@ package app
 
 import (
 	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 )
 
 func (app *App) RegisterUpgradeHandlers(chainID string, serverCfg *serverconfig.Config) error {
@@ -12,7 +15,7 @@ func (app *App) RegisterUpgradeHandlers(chainID string, serverCfg *serverconfig.
 	}
 
 	// Register the upgrade handlers here
-	// app.registerPublicDelegationUpgradeHandler()
+	app.registerNagquUpgradeHandler()
 	// app.register...()
 	// ...
 	return nil
@@ -36,3 +39,20 @@ func (app *App) RegisterUpgradeHandlers(chainID string, serverCfg *serverconfig.
 // 		},
 // 	)
 // }
+
+func (app *App) registerNagquUpgradeHandler() {
+	// Register the upgrade handler
+	app.UpgradeKeeper.SetUpgradeHandler(upgradetypes.Nagqu,
+		func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+			app.Logger().Info("upgrade to ", plan.Name)
+			return fromVM, nil
+		})
+
+	// Register the upgrade initializer
+	app.UpgradeKeeper.SetUpgradeInitializer(upgradetypes.Nagqu,
+		func() error {
+			app.Logger().Info("Init enable public delegation upgrade")
+			return nil
+		},
+	)
+}

--- a/deployment/localup/localup.sh
+++ b/deployment/localup/localup.sh
@@ -154,6 +154,7 @@ function generate_genesis() {
         sed -i -e "s/src-chain-id = 1/src-chain-id = ${SRC_CHAIN_ID}/g" ${workspace}/.local/validator${i}/config/app.toml
         sed -i -e "s/dest-bsc-chain-id = 2/dest-bsc-chain-id = ${DEST_CHAIN_ID}/g" ${workspace}/.local/validator${i}/config/app.toml
         sed -i -e "s/snapshot-keep-recent = 2/snapshot-keep-recent = ${SNAPSHOT_KEEP_RECENT}/g" ${workspace}/.local/validator${i}/config/app.toml
+        echo -e '[[upgrade]]\nname = "Nagqu"\nheight = 1\ninfo = ""' >> ${workspace}/.local/validator${i}/config/app.toml
         sed -i -e "s/\"reserve_time\": \"15552000\"/\"reserve_time\": \"60\"/g" ${workspace}/.local/validator${i}/config/genesis.json
         sed -i -e "s/\"forced_settle_time\": \"86400\"/\"forced_settle_time\": \"30\"/g" ${workspace}/.local/validator${i}/config/genesis.json
         sed -i -e "s/172800s/${DEPOSIT_VOTE_PERIOD}/g" ${workspace}/.local/validator${i}/config/genesis.json

--- a/e2e/tests/storage_bill_test.go
+++ b/e2e/tests/storage_bill_test.go
@@ -1712,7 +1712,6 @@ func (s *PaymentTestSuite) TestStorageBill_UpdatePaymentAddress() {
 	// assertions
 	streamAddresses[0] = paymentAccountAddr
 	streamRecordsAfter = s.getStreamRecords(streamAddresses)
-	s.Require().Equal(streamRecordsAfter.User.StaticBalance, sdkmath.ZeroInt())
 	s.Require().Equal(streamRecordsAfter.User.NetflowRate.Sub(streamRecordsBefore.User.NetflowRate), userTotalRate.Neg())
 	s.Require().Equal(streamRecordsAfter.GVGFamily.NetflowRate.Sub(streamRecordsBefore.GVGFamily.NetflowRate), readChargeRate)
 	s.Require().Equal(streamRecordsAfter.Tax.NetflowRate.Sub(streamRecordsBefore.Tax.NetflowRate), taxRate)
@@ -2235,8 +2234,12 @@ func (s *PaymentTestSuite) CreatePaymentAccount(user keys.KeyManager, amount, de
 	paymentAccountAddr := paymentAccounts.PaymentAccounts[len(paymentAccounts.PaymentAccounts)-1]
 	// charge payment account
 	paymentAcc := sdk.MustAccAddressFromHex(paymentAccountAddr)
-	msgSend := banktypes.NewMsgSend(user.GetAddr(), paymentAcc, []sdk.Coin{{Denom: "BNB", Amount: types.NewIntFromInt64WithDecimal(amount, decimal)}})
-	s.SendTxBlock(user, msgSend)
+	msgDeposit := &paymenttypes.MsgDeposit{
+		Creator: user.GetAddr().String(),
+		To:      paymentAcc.String(),
+		Amount:  types.NewIntFromInt64WithDecimal(amount, decimal), // deposit more than needed
+	}
+	s.SendTxBlock(user, msgDeposit)
 
 	return paymentAccountAddr
 }

--- a/go.mod
+++ b/go.mod
@@ -178,7 +178,7 @@ replace (
 	github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v0.0.3
 	github.com/cometbft/cometbft-db => github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v0.2.4
+	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3-alpha.3.0.20230830024916-258a09e84d27
 	github.com/cosmos/iavl => github.com/bnb-chain/greenfield-iavl v0.20.1
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 )

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,8 @@ github.com/bnb-chain/greenfield-cometbft v0.0.3 h1:tv8NMy3bzX/1urqXGQIIAZSLy83lo
 github.com/bnb-chain/greenfield-cometbft v0.0.3/go.mod h1:f35mk/r5ab6yvzlqEWZt68LfUje68sYgMpVlt2CUYMk=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1 h1:XcWulGacHVRiSCx90Q8Y//ajOrLNBQWR/KDB89dy3cU=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1/go.mod h1:ey1CiK4bYo1RBNJLRiVbYr5CMdSxci9S/AZRINLtppI=
-github.com/bnb-chain/greenfield-cosmos-sdk v0.2.4 h1:09ST+MTEAyjyBSc4ZjZzHxpNLMnIIkZ518jJVRtrKFc=
-github.com/bnb-chain/greenfield-cosmos-sdk v0.2.4/go.mod h1:y3hDhQhil5hMIhwBTpu07RZBF30ZITkoE+GHhVZChtY=
+github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3-alpha.3.0.20230830024916-258a09e84d27 h1:sqmAIC7IRqptGrwNPGQZuqDhcNQYpX1iUADGKMwa9RQ=
+github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3-alpha.3.0.20230830024916-258a09e84d27/go.mod h1:y3hDhQhil5hMIhwBTpu07RZBF30ZITkoE+GHhVZChtY=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230816082903-b48770f5e210 h1:GHPbV2bC+gmuO6/sG0Tm8oGal3KKSRlyE+zPscDjlA8=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230816082903-b48770f5e210/go.mod h1:vhsZxXE9tYJeYB5JR4hPhd6Pc/uPf7j1T8IJ7p9FdeM=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230816082903-b48770f5e210 h1:FLVOn4+OVbsKi2+YJX5kmD27/4dRu4FW7xCXFhzDO5s=

--- a/types/openapiutil/apiconsole.go
+++ b/types/openapiutil/apiconsole.go
@@ -11,15 +11,21 @@ var index embed.FS
 
 // Handler returns a http handler that servers OpenAPI console for an OpenAPI spec at specURL.
 func Handler(title, specURL string) http.HandlerFunc {
-	t, _ := template.ParseFS(index, "index.tpl")
+	t, err := template.ParseFS(index, "index.tpl")
+	if err != nil {
+		panic(err)
+	}
 
 	return func(w http.ResponseWriter, req *http.Request) {
-		_ = t.Execute(w, struct {
+		err := t.Execute(w, struct {
 			Title string
 			URL   string
 		}{
 			title,
 			specURL,
 		})
+		if err != nil {
+			panic(err)
+		}
 	}
 }

--- a/x/challenge/client/cli/tx_submit.go
+++ b/x/challenge/client/cli/tx_submit.go
@@ -45,7 +45,7 @@ func CmdSubmit() *cobra.Command {
 
 			argSegmentIndex := uint64(0)
 			if !argRandomIndex {
-				argSegmentIndex, err = strconv.ParseUint(args[4], 10, 64)
+				argSegmentIndex, err = strconv.ParseUint(args[4], 10, 32)
 				if err != nil {
 					return fmt.Errorf("segment-index %s not a valid uint, please input a valid segment-index", args[4])
 				}

--- a/x/payment/keeper/msg_server_deposit_test.go
+++ b/x/payment/keeper/msg_server_deposit_test.go
@@ -31,41 +31,6 @@ func (s *TestSuite) TestDeposit_ToBankAccount() {
 	s.Require().True(record.StaticBalance.Int64() == msg.Amount.Int64())
 }
 
-func (s *TestSuite) TestDeposit_ToPaymentAccountAccount() {
-	s.bankKeeper.EXPECT().SendCoinsFromAccountToModule(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(nil).AnyTimes()
-	s.accountKeeper.EXPECT().HasAccount(gomock.Any(), gomock.Any()).
-		Return(true).AnyTimes()
-
-	// deposit to self
-	owner := sample.RandAccAddress()
-	paymentAddress := s.paymentKeeper.DerivePaymentAccountAddress(owner, 0)
-	paymentAccount1 := &types.PaymentAccount{
-		Owner:      owner.String(),
-		Addr:       paymentAddress.String(),
-		Refundable: true,
-	}
-
-	s.ctx = s.ctx.WithBlockHeight(10)
-
-	// set
-	s.paymentKeeper.SetPaymentAccount(s.ctx, paymentAccount1)
-
-	msg := types.NewMsgDeposit(owner.String(), paymentAddress.String(), sdkmath.NewInt(1000))
-	_, err := s.msgServer.Deposit(s.ctx, msg)
-	s.Require().NoError(err)
-	record, _ := s.paymentKeeper.GetStreamRecord(s.ctx, owner)
-	s.Require().True(record.StaticBalance.Int64() == msg.Amount.Int64())
-
-	// deposit to other account
-	to := sample.RandAccAddress()
-	msg = types.NewMsgDeposit(owner.String(), to.String(), sdkmath.NewInt(1000))
-	_, err = s.msgServer.Deposit(s.ctx, msg)
-	s.Require().NoError(err)
-	record, _ = s.paymentKeeper.GetStreamRecord(s.ctx, to)
-	s.Require().True(record.StaticBalance.Int64() == msg.Amount.Int64())
-}
-
 func (s *TestSuite) TestDeposit_ToActiveStreamRecord() {
 	s.bankKeeper.EXPECT().SendCoinsFromAccountToModule(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil).AnyTimes()

--- a/x/payment/keeper/msg_server_deposit_test.go
+++ b/x/payment/keeper/msg_server_deposit_test.go
@@ -31,6 +31,41 @@ func (s *TestSuite) TestDeposit_ToBankAccount() {
 	s.Require().True(record.StaticBalance.Int64() == msg.Amount.Int64())
 }
 
+func (s *TestSuite) TestDeposit_ToPaymentAccountAccount() {
+	s.bankKeeper.EXPECT().SendCoinsFromAccountToModule(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil).AnyTimes()
+	s.accountKeeper.EXPECT().HasAccount(gomock.Any(), gomock.Any()).
+		Return(true).AnyTimes()
+
+	// deposit to self
+	owner := sample.RandAccAddress()
+	paymentAddress := s.paymentKeeper.DerivePaymentAccountAddress(owner, 0)
+	paymentAccount1 := &types.PaymentAccount{
+		Owner:      owner.String(),
+		Addr:       paymentAddress.String(),
+		Refundable: true,
+	}
+
+	s.ctx = s.ctx.WithBlockHeight(10)
+
+	// set
+	s.paymentKeeper.SetPaymentAccount(s.ctx, paymentAccount1)
+
+	msg := types.NewMsgDeposit(owner.String(), paymentAddress.String(), sdkmath.NewInt(1000))
+	_, err := s.msgServer.Deposit(s.ctx, msg)
+	s.Require().NoError(err)
+	record, _ := s.paymentKeeper.GetStreamRecord(s.ctx, owner)
+	s.Require().True(record.StaticBalance.Int64() == msg.Amount.Int64())
+
+	// deposit to other account
+	to := sample.RandAccAddress()
+	msg = types.NewMsgDeposit(owner.String(), to.String(), sdkmath.NewInt(1000))
+	_, err = s.msgServer.Deposit(s.ctx, msg)
+	s.Require().NoError(err)
+	record, _ = s.paymentKeeper.GetStreamRecord(s.ctx, to)
+	s.Require().True(record.StaticBalance.Int64() == msg.Amount.Int64())
+}
+
 func (s *TestSuite) TestDeposit_ToActiveStreamRecord() {
 	s.bankKeeper.EXPECT().SendCoinsFromAccountToModule(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil).AnyTimes()

--- a/x/payment/keeper/payment_account.go
+++ b/x/payment/keeper/payment_account.go
@@ -46,6 +46,18 @@ func (k Keeper) GetPaymentAccount(
 	return val, true
 }
 
+// IsPaymentAccount returns is the account address a payment account
+func (k Keeper) IsPaymentAccount(
+	ctx sdk.Context,
+	addr sdk.AccAddress,
+) bool {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.PaymentAccountKeyPrefix)
+	b := store.Get(types.PaymentAccountKey(
+		addr,
+	))
+	return b != nil
+}
+
 // GetAllPaymentAccount returns all paymentAccount
 func (k Keeper) GetAllPaymentAccount(ctx sdk.Context) (list []types.PaymentAccount) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.PaymentAccountKeyPrefix)

--- a/x/payment/keeper/payment_account.go
+++ b/x/payment/keeper/payment_account.go
@@ -52,10 +52,9 @@ func (k Keeper) IsPaymentAccount(
 	addr sdk.AccAddress,
 ) bool {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.PaymentAccountKeyPrefix)
-	b := store.Get(types.PaymentAccountKey(
+	return store.Has(types.PaymentAccountKey(
 		addr,
 	))
-	return b != nil
 }
 
 // GetAllPaymentAccount returns all paymentAccount

--- a/x/storage/client/cli/tx.go
+++ b/x/storage/client/cli/tx.go
@@ -899,7 +899,7 @@ func CmdMirrorBucket() *cobra.Command {
 			if argDestChainId == "" {
 				return fmt.Errorf("destination chain id should be provided")
 			}
-			destChainId, err := strconv.ParseUint(argDestChainId, 10, 64)
+			destChainId, err := strconv.ParseUint(argDestChainId, 10, 16)
 			if err != nil {
 				return err
 			}
@@ -992,7 +992,7 @@ func CmdMirrorObject() *cobra.Command {
 			if argDestChainId == "" {
 				return fmt.Errorf("destination chain id should be provided")
 			}
-			destChainId, err := strconv.ParseUint(argDestChainId, 10, 64)
+			destChainId, err := strconv.ParseUint(argDestChainId, 10, 16)
 			if err != nil {
 				return err
 			}
@@ -1053,7 +1053,7 @@ func CmdMirrorGroup() *cobra.Command {
 			if argDestChainId == "" {
 				return fmt.Errorf("destination chain id should be provided")
 			}
-			destChainId, err := strconv.ParseUint(argDestChainId, 10, 64)
+			destChainId, err := strconv.ParseUint(argDestChainId, 10, 16)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
### Description

This pr will update the logic of `Deposit` method in the payment module.

Since the payment account is a derived address from the owner address with an index, if users wrongly transfer tokens to the payment address, they cannot get the tokens back for missing the private key. 

This pr will add an additional check for the balance of the payment address for the `Deposit` method, if the balance of the payment account is not zero, the balance of the payment address will be automatically deposited to the payment account.

### Rationale

Deposit the balance of the bank account to the payment account.

### Example

n/a

### Changes

Notable changes: 
* deposit the balance of the bank account to the payment account
