### PR TITLE
fix: fix the last block time is empty issue

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -763,9 +763,6 @@ func (app *App) BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock) abci.R
 
 // EndBlocker application updates every end block
 func (app *App) EndBlocker(ctx sdk.Context, req abci.RequestEndBlock) abci.ResponseEndBlock {
-	lastBlockTime := app.GetCheckState().Context().BlockHeader().Time.Unix()
-	ctx = ctx.WithValue(spmodule.LastBlockTimeKey, lastBlockTime)
-
 	resp := app.mm.EndBlock(ctx, req)
 	if app.IsIavlStore() {
 		bankIavl, _ := app.CommitMultiStore().GetCommitStore(sdk.NewKVStoreKey(banktypes.StoreKey)).(*iavl.Store)

--- a/x/sp/abci.go
+++ b/x/sp/abci.go
@@ -9,9 +9,6 @@ import (
 	"github.com/bnb-chain/greenfield/x/sp/types"
 )
 
-// LastBlockTimeKey is the key to record last block's time, which will be set by app
-const LastBlockTimeKey = "last_block_time"
-
 func EndBlocker(ctx sdk.Context, k keeper.Keeper) {
 	if ctx.BlockHeight()%types.MaintenanceRecordsGCFrequencyInBlocks == 0 {
 		k.ForceUpdateMaintenanceRecords(ctx)
@@ -28,13 +25,10 @@ func EndBlocker(ctx sdk.Context, k keeper.Keeper) {
 				needUpdate = true
 			}
 		} else { // update every month
-			lastBlockTimeUnix := ctx.Value(LastBlockTimeKey).(int64)
-			if lastBlockTimeUnix != 0 {
-				lastBlockTime := time.Unix(lastBlockTimeUnix, 0).UTC()
-				currentBlockTime := ctx.BlockTime().UTC()
-				if lastBlockTime.Month() != currentBlockTime.Month() {
-					needUpdate = true
-				}
+			lastUpdateTime := time.Unix(price.UpdateTimeSec, 0).UTC()
+			currentBlockTime := ctx.BlockTime().UTC()
+			if lastUpdateTime.Month() != currentBlockTime.Month() {
+				needUpdate = true
 			}
 		}
 	}

--- a/x/sp/abci_test.go
+++ b/x/sp/abci_test.go
@@ -154,7 +154,7 @@ func (s *TestSuite) TestEndBlocker_WithUpdateInterval() {
 }
 
 func (s *TestSuite) TestEndBlocker_WithoutUpdateInterval() {
-	preTime := int64(1691648908)
+	preTime := int64(1691648908) //UTC Aug 10 2023
 	s.ctx = s.ctx.WithBlockTime(time.Unix(preTime, 0))
 	globalPrice := types.GlobalSpStorePrice{
 		UpdateTimeSec:       0,
@@ -186,7 +186,6 @@ func (s *TestSuite) TestEndBlocker_WithoutUpdateInterval() {
 	s.spKeeper.SetSpStoragePrice(s.ctx, spPrice)
 
 	// in the same month
-	s.ctx = s.ctx.WithValue(spmodule.LastBlockTimeKey, newTime+1)
 	s.ctx = s.ctx.WithBlockTime(time.Unix(newTime+2, 0))
 	spmodule.EndBlocker(s.ctx, *s.spKeeper)
 	// global price will not be updated
@@ -196,7 +195,6 @@ func (s *TestSuite) TestEndBlocker_WithoutUpdateInterval() {
 	s.Require().Equal(globalPrice.ReadPrice, globalPriceAfter.ReadPrice)
 
 	// a new month
-	s.ctx = s.ctx.WithValue(spmodule.LastBlockTimeKey, newTime+10)
 	t := time.Unix(newTime+10, 0).UTC()
 	year, month, _ := t.Date()
 	location := t.Location()


### PR DESCRIPTION
### Description

This pr will remove `last block time`. In previous version, the `last block time` is not set when restart, which will cause some issues.

### Rationale

Bug fix

### Example

NA

### Changes

Notable changes: 
* remove `last block time`
