### PR TITLE
chore: switch the order of create sp event and update price event

### DIFF
--- a/x/sp/keeper/msg_server.go
+++ b/x/sp/keeper/msg_server.go
@@ -144,16 +144,6 @@ func (k msgServer) CreateStorageProvider(goCtx context.Context, msg *types.MsgCr
 	k.SetStorageProviderByGcAddr(ctx, &sp)
 	k.SetStorageProviderByBlsKey(ctx, &sp)
 
-	// set initial sp storage price
-	spStoragePrice := types.SpStoragePrice{
-		SpId:          sp.Id,
-		UpdateTimeSec: ctx.BlockTime().Unix(),
-		ReadPrice:     msg.ReadPrice,
-		StorePrice:    msg.StorePrice,
-		FreeReadQuota: msg.FreeReadQuota,
-	}
-	k.SetSpStoragePrice(ctx, spStoragePrice)
-
 	if err = ctx.EventManager().EmitTypedEvents(&types.EventCreateStorageProvider{
 		SpId:               sp.Id,
 		SpAddress:          spAcc.String(),
@@ -170,6 +160,17 @@ func (k msgServer) CreateStorageProvider(goCtx context.Context, msg *types.MsgCr
 	}); err != nil {
 		return nil, err
 	}
+
+	// set initial sp storage price
+	spStoragePrice := types.SpStoragePrice{
+		SpId:          sp.Id,
+		UpdateTimeSec: ctx.BlockTime().Unix(),
+		ReadPrice:     msg.ReadPrice,
+		StorePrice:    msg.StorePrice,
+		FreeReadQuota: msg.FreeReadQuota,
+	}
+	k.SetSpStoragePrice(ctx, spStoragePrice)
+
 	return &types.MsgCreateStorageProviderResponse{}, nil
 }
 


### PR DESCRIPTION
### Description

This pr will switch the orders of create sp event and update price event.

### Rationale

If the update price event is emitted ahead of create sp event, it will bring some difficulties for downstream services and dApps.

### Example

NA

### Changes

Notable changes: 
*NA
