### PR TITLE
fix: remaining policies need re-persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.5-alpha.2
+This release contains 1 bugfix.
+* [#465](https://github.com/bnb-chain/greenfield/pull/465) fix: remaining policies need re-persistence
+
 ## v0.2.5-alpha.1
 This release contains 4 features and 4 bugfixes.
 

--- a/x/storage/keeper/grpc_query.go
+++ b/x/storage/keeper/grpc_query.go
@@ -315,12 +315,12 @@ func (k Keeper) QueryLockFee(c context.Context, req *types.QueryLockFeeRequest) 
 		return nil, status.Error(codes.InvalidArgument, "invalid primary storage provider address")
 	}
 
-	sp, found := k.spKeeper.GetStorageProviderByOperatorAddr(ctx, primaryAcc)
+	_, found := k.spKeeper.GetStorageProviderByOperatorAddr(ctx, primaryAcc)
 	if !found {
 		return nil, sptypes.ErrStorageProviderNotFound
 	}
 
-	amount, err := k.GetObjectLockFee(ctx, sp.GetId(), createAt, req.PayloadSize)
+	amount, err := k.GetObjectLockFee(ctx, createAt, req.PayloadSize)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/x/storage/keeper/keeper.go
+++ b/x/storage/keeper/keeper.go
@@ -326,7 +326,7 @@ func (k Keeper) ForceDeleteBucket(ctx sdk.Context, bucketId sdkmath.Uint, cap ui
 		}
 
 		if objectStatus == types.OBJECT_STATUS_CREATED {
-			if err = k.UnlockObjectStoreFee(ctx, sp.Id, bucketInfo, &objectInfo); err != nil {
+			if err = k.UnlockObjectStoreFee(ctx, bucketInfo, &objectInfo); err != nil {
 				ctx.Logger().Error("unlock store fee error", "err", err)
 				return false, deleted, err
 			}
@@ -623,7 +623,7 @@ func (k Keeper) CreateObject(
 		}
 	} else {
 		// Lock Fee
-		err = k.LockObjectStoreFee(ctx, sp.Id, bucketInfo, &objectInfo)
+		err = k.LockObjectStoreFee(ctx, bucketInfo, &objectInfo)
 		if err != nil {
 			return sdkmath.ZeroUint(), err
 		}
@@ -835,7 +835,7 @@ func (k Keeper) CancelCreateObject(
 		return errors.Wrapf(types.ErrAccessDenied, "Only allowed owner/creator to do cancel create object")
 	}
 
-	err := k.UnlockObjectStoreFee(ctx, spInState.Id, bucketInfo, objectInfo)
+	err := k.UnlockObjectStoreFee(ctx, bucketInfo, objectInfo)
 	if err != nil {
 		return err
 	}
@@ -955,7 +955,7 @@ func (k Keeper) ForceDeleteObject(ctx sdk.Context, objectId sdkmath.Uint) error 
 
 	spInState := k.MustGetPrimarySPForBucket(ctx, bucketInfo)
 	if objectStatus == types.OBJECT_STATUS_CREATED {
-		err := k.UnlockObjectStoreFee(ctx, spInState.Id, bucketInfo, objectInfo)
+		err := k.UnlockObjectStoreFee(ctx, bucketInfo, objectInfo)
 		if err != nil {
 			ctx.Logger().Error("unlock store fee error", "err", err)
 			return err
@@ -1057,7 +1057,7 @@ func (k Keeper) CopyObject(
 			return sdkmath.ZeroUint(), err
 		}
 	} else {
-		err = k.LockObjectStoreFee(ctx, dstPrimarySP.Id, dstBucketInfo, &objectInfo)
+		err = k.LockObjectStoreFee(ctx, dstBucketInfo, &objectInfo)
 		if err != nil {
 			return sdkmath.ZeroUint(), err
 		}
@@ -1111,7 +1111,7 @@ func (k Keeper) RejectSealObject(ctx sdk.Context, operator sdk.AccAddress, bucke
 		return errors.Wrapf(types.ErrAccessDenied, "Only allowed primary SP to do cancel create object")
 	}
 
-	err := k.UnlockObjectStoreFee(ctx, spInState.Id, bucketInfo, objectInfo)
+	err := k.UnlockObjectStoreFee(ctx, bucketInfo, objectInfo)
 	if err != nil {
 		return err
 	}
@@ -1843,7 +1843,6 @@ func (k Keeper) garbageCollectionForResource(ctx sdk.Context, deleteStalePolicie
 			deletedTotal, done = k.permKeeper.ForceDeleteAccountPolicyForResource(ctx, maxCleanup, deletedTotal, resourceType, id)
 			if !done {
 				resourceIds.Id = temp
-
 				deleteStalePoliciesPrefixStore.Set(iterator.Key(), k.cdc.MustMarshal(deleteInfo))
 				return deletedTotal, false
 			}

--- a/x/storage/keeper/payment.go
+++ b/x/storage/keeper/payment.go
@@ -107,9 +107,9 @@ func (k Keeper) UpdateBucketInfoAndCharge(ctx sdk.Context, bucketInfo *storagety
 	return err
 }
 
-func (k Keeper) LockObjectStoreFee(ctx sdk.Context, primarySpId uint32, bucketInfo *storagetypes.BucketInfo, objectInfo *storagetypes.ObjectInfo) error {
+func (k Keeper) LockObjectStoreFee(ctx sdk.Context, bucketInfo *storagetypes.BucketInfo, objectInfo *storagetypes.ObjectInfo) error {
 	paymentAddr := sdk.MustAccAddressFromHex(bucketInfo.PaymentAddress)
-	amount, err := k.GetObjectLockFee(ctx, primarySpId, objectInfo.CreateAt, objectInfo.PayloadSize)
+	amount, err := k.GetObjectLockFee(ctx, objectInfo.CreateAt, objectInfo.PayloadSize)
 	if err != nil {
 		return fmt.Errorf("get object store fee rate failed: %s %s %w", bucketInfo.BucketName, objectInfo.ObjectName, err)
 	}
@@ -133,9 +133,8 @@ func (k Keeper) LockObjectStoreFee(ctx sdk.Context, primarySpId uint32, bucketIn
 }
 
 // UnlockObjectStoreFee unlock store fee if the object is deleted in INIT state
-func (k Keeper) UnlockObjectStoreFee(ctx sdk.Context, primarySpId uint32, bucketInfo *storagetypes.BucketInfo, objectInfo *storagetypes.ObjectInfo) error {
-
-	lockedBalance, err := k.GetObjectLockFee(ctx, primarySpId, objectInfo.CreateAt, objectInfo.PayloadSize)
+func (k Keeper) UnlockObjectStoreFee(ctx sdk.Context, bucketInfo *storagetypes.BucketInfo, objectInfo *storagetypes.ObjectInfo) error {
+	lockedBalance, err := k.GetObjectLockFee(ctx, objectInfo.CreateAt, objectInfo.PayloadSize)
 	if err != nil {
 		return fmt.Errorf("get object store fee rate failed: %s %s %w", bucketInfo.BucketName, objectInfo.ObjectName, err)
 	}
@@ -151,7 +150,7 @@ func (k Keeper) UnlockObjectStoreFee(ctx sdk.Context, primarySpId uint32, bucket
 func (k Keeper) UnlockAndChargeObjectStoreFee(ctx sdk.Context, primarySpId uint32, bucketInfo *storagetypes.BucketInfo,
 	internalBucketInfo *storagetypes.InternalBucketInfo, objectInfo *storagetypes.ObjectInfo) error {
 	// unlock store fee
-	err := k.UnlockObjectStoreFee(ctx, primarySpId, bucketInfo, objectInfo)
+	err := k.UnlockObjectStoreFee(ctx, bucketInfo, objectInfo)
 	if err != nil {
 		return fmt.Errorf("unlock store fee failed: %s %s %w", bucketInfo.BucketName, objectInfo.ObjectName, err)
 	}
@@ -488,7 +487,7 @@ func getNegFlows(flows []types.OutFlow) (negFlows []types.OutFlow) {
 	return negFlows
 }
 
-func (k Keeper) GetObjectLockFee(ctx sdk.Context, primarySpId uint32, priceTime int64, payloadSize uint64) (amount sdkmath.Int, err error) {
+func (k Keeper) GetObjectLockFee(ctx sdk.Context, priceTime int64, payloadSize uint64) (amount sdkmath.Int, err error) {
 	price, err := k.spKeeper.GetGlobalSpStorePriceByTime(ctx, priceTime)
 	if err != nil {
 		return amount, fmt.Errorf("get store price failed: %d %w", priceTime, err)

--- a/x/storage/keeper/payment_test.go
+++ b/x/storage/keeper/payment_test.go
@@ -117,7 +117,7 @@ func (s *TestSuite) TestGetObjectLockFee() {
 
 	// verify lock fee calculation
 	payloadSize := int64(10 * 1024 * 1024)
-	amount, err := s.storageKeeper.GetObjectLockFee(s.ctx, 100, time.Now().Unix(), uint64(payloadSize))
+	amount, err := s.storageKeeper.GetObjectLockFee(s.ctx, time.Now().Unix(), uint64(payloadSize))
 	s.Require().NoError(err)
 	secondarySPNum := int64(s.storageKeeper.GetExpectSecondarySPNumForECObject(s.ctx, time.Now().Unix()))
 	spRate := price.PrimaryStorePrice.Add(price.SecondaryStorePrice.MulInt64(secondarySPNum)).MulInt64(payloadSize)


### PR DESCRIPTION
### Description

If policies within one policy group can not be GC within 1 block. We should get rid of policy item which are already handled, and re-persist the policy group.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
