### PR TITLE
fix: allow migrate empty bucket with zero read quote

### DIFF
--- a/x/storage/keeper/keeper.go
+++ b/x/storage/keeper/keeper.go
@@ -4,8 +4,6 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
-
 	"cosmossdk.io/errors"
 	sdkmath "cosmossdk.io/math"
 	"github.com/cometbft/cometbft/libs/log"
@@ -24,6 +22,7 @@ import (
 	sptypes "github.com/bnb-chain/greenfield/x/sp/types"
 	"github.com/bnb-chain/greenfield/x/storage/types"
 	virtualgroupmoduletypes "github.com/bnb-chain/greenfield/x/virtualgroup/types"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 )
 
 type (


### PR DESCRIPTION
### Description

Current if 
* a bucket is empty,
* and the read quote of it is zero,
* and the payment account's stream record is not created,

then the bucket is not allowed to migrate.

### Rationale

We can judge whether we need this fix or not.


### Example

NA

### Changes

Notable changes: 
* NA
