### PR TITLE
release: prepare for release v0.2.5  

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,6 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     env:
-      GOPRIVATE: github.com/bnb-chain
-      GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_SECRET }}
       CGO_CFLAGS: "-O -D__BLST_PORTABLE__"
       CGO_CFLAGS_ALLOW: "-O -D__BLST_PORTABLE__"
     steps:
@@ -44,9 +42,6 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-
-    - name: Setup GitHub Token
-      run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
 
     - name: Test Build
       run: |

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -7,8 +7,9 @@ on:
       - v*
 
 env:
-  IMAGE_NAME: ghcr.io/bnb-chain/greenfield
-  IMAGE_SOURCE: https://github.com/bnb-chain/greenfield
+  IMAGE_NAME: ghcr.io/${{ github.repository }}
+  IMAGE_SOURCE: https://github.com/${{ github.repository }}
+
 
 jobs:
   # Push image to GitHub Packages.
@@ -22,15 +23,18 @@ jobs:
       - name: Build image
         run: |
           docker build . \
-          --build-arg "GH_TOKEN=${{ secrets.GH_ACCESS_SECRET }}" \
           --label "org.opencontainers.image.source=${IMAGE_SOURCE}" \
           --label "org.opencontainers.image.revision=$(git rev-parse HEAD)" \
           --label "org.opencontainers.image.version=$(git describe --tags --abbrev=0)" \
           --label "org.opencontainers.image.licenses=LGPL-3.0,AGPL-3.0" \
           -f ./Dockerfile -t "${IMAGE_NAME}"
 
-      - name: Log into registry
-        run: echo "${{ secrets.GH_ACCESS_SECRET }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push image
         run: |

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -17,14 +17,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       GOPRIVATE: github.com/bnb-chain
-      GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_SECRET }}
     steps:
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
       - uses: actions/checkout@v3
-      - name: Setup GitHub Token
-        run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
       - uses: actions/cache@v3
         with:
           # In order:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,14 +19,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       GOPRIVATE: github.com/bnb-chain
-      GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_SECRET }}
     steps:
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
       - uses: actions/checkout@v3
-      - name: Setup GitHub Token
-        run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
       - uses: actions/cache@v3
         with:
           # In order:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,9 +39,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
-      - name: Setup GitHub Token
-        run: git config --global url.https://${{ secrets.GH_ACCESS_SECRET }}@github.com/.insteadOf https://github.com/
-
       # ==============================
       #       Linux/Macos Build
       # ==============================
@@ -117,7 +114,7 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_SECRET }} # This token is provided by Actions, you do not need to create your own token
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
           tag_name: ${{ env.RELEASE_VERSION}}
           release_name: ${{ env.RELEASE_VERSION}}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,8 +16,6 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     env:
-      GOPRIVATE: github.com/bnb-chain
-      GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_SECRET }}
       CGO_CFLAGS: "-O -D__BLST_PORTABLE__"
       CGO_CFLAGS_ALLOW: "-O -D__BLST_PORTABLE__"
     steps:
@@ -42,8 +40,6 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-    - name: Setup GitHub Token
-      run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
     - name: run tests
       run: |
         make test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## v0.2.5
+This release contains all the changes for the v0.2.5 alpha versions.    
+
+Features:
+* [#435](https://github.com/bnb-chain/greenfield/pull/435) feat: deposit the balance of the bank account to the payment account
+* [#448](https://github.com/bnb-chain/greenfield/pull/448) feat: timelock for large amount withdraw from payment
+* [#449](https://github.com/bnb-chain/greenfield/pull/449) feat: complete cdc register
+* [#457](https://github.com/bnb-chain/greenfield/pull/457) feat: add api for querying last quota update time
+
+Bugfixes:
+* [#471](https://github.com/bnb-chain/greenfield/pull/471) fix: some issues in challenge module
+* [#470](https://github.com/bnb-chain/greenfield/pull/470) fix: testnet block sync issue
+* [#451](https://github.com/bnb-chain/greenfield/pull/451) fix: audit issues by verichain
+* [#456](https://github.com/bnb-chain/greenfield/pull/456) fix: fix parameter init issue
+* [#458](https://github.com/bnb-chain/greenfield/pull/458) fix: correct emit event filed
+* [#462](https://github.com/bnb-chain/greenfield/pull/462) fix: fix app hash mismatch for genesis block
+
+Chore: 
+* [#474](https://github.com/bnb-chain/greenfield/pull/474) chore: cleaning up ci jobs
+
 ## v0.2.5-alpha.3
 This release is a bugfix release.
 

--- a/go.mod
+++ b/go.mod
@@ -178,7 +178,7 @@ replace (
 	github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v0.0.3
 	github.com/cometbft/cometbft-db => github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v0.2.5-alpha.1
+	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v0.2.5
 	github.com/cosmos/iavl => github.com/bnb-chain/greenfield-iavl v0.20.1
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 )

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,8 @@ github.com/bnb-chain/greenfield-cometbft v0.0.3 h1:tv8NMy3bzX/1urqXGQIIAZSLy83lo
 github.com/bnb-chain/greenfield-cometbft v0.0.3/go.mod h1:f35mk/r5ab6yvzlqEWZt68LfUje68sYgMpVlt2CUYMk=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1 h1:XcWulGacHVRiSCx90Q8Y//ajOrLNBQWR/KDB89dy3cU=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1/go.mod h1:ey1CiK4bYo1RBNJLRiVbYr5CMdSxci9S/AZRINLtppI=
-github.com/bnb-chain/greenfield-cosmos-sdk v0.2.5-alpha.1 h1:E6AOXDWIcFC6e4KAqI7XzMWn8nZQcGjl1ESBRwrhVh8=
-github.com/bnb-chain/greenfield-cosmos-sdk v0.2.5-alpha.1/go.mod h1:y3hDhQhil5hMIhwBTpu07RZBF30ZITkoE+GHhVZChtY=
+github.com/bnb-chain/greenfield-cosmos-sdk v0.2.5 h1:8zIn/ExfMHZVBbVwhILG9KYO1m3pZO8I8stpqbFgzkk=
+github.com/bnb-chain/greenfield-cosmos-sdk v0.2.5/go.mod h1:y3hDhQhil5hMIhwBTpu07RZBF30ZITkoE+GHhVZChtY=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230816082903-b48770f5e210 h1:GHPbV2bC+gmuO6/sG0Tm8oGal3KKSRlyE+zPscDjlA8=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230816082903-b48770f5e210/go.mod h1:vhsZxXE9tYJeYB5JR4hPhd6Pc/uPf7j1T8IJ7p9FdeM=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230816082903-b48770f5e210 h1:FLVOn4+OVbsKi2+YJX5kmD27/4dRu4FW7xCXFhzDO5s=


### PR DESCRIPTION

### Description

This release includes all the changes in the v0.2.5 alpha versions.  

### Rationale

Features:
* [#435](https://github.com/bnb-chain/greenfield/pull/435) feat: deposit the balance of the bank account to the payment account
* [#448](https://github.com/bnb-chain/greenfield/pull/448) feat: timelock for large amount withdraw from payment
* [#449](https://github.com/bnb-chain/greenfield/pull/449) feat: complete cdc register
* [#457](https://github.com/bnb-chain/greenfield/pull/457) feat: add api for querying last quota update time

Bugfixes:
* [#471](https://github.com/bnb-chain/greenfield/pull/471) fix: some issues in challenge module
* [#470](https://github.com/bnb-chain/greenfield/pull/470) fix: testnet block sync issue
* [#451](https://github.com/bnb-chain/greenfield/pull/451) fix: audit issues by verichain
* [#456](https://github.com/bnb-chain/greenfield/pull/456) fix: fix parameter init issue
* [#458](https://github.com/bnb-chain/greenfield/pull/458) fix: correct emit event filed
* [#462](https://github.com/bnb-chain/greenfield/pull/462) fix: fix app hash mismatch for genesis block

Chore: 
* [#474](https://github.com/bnb-chain/greenfield/pull/474) chore: cleaning up ci jobs
