### PR TITLE
fix: wrong event emitted for leaving group

### DIFF
--- a/x/storage/keeper/keeper.go
+++ b/x/storage/keeper/keeper.go
@@ -1361,10 +1361,11 @@ func (k Keeper) LeaveGroup(
 		return err
 	}
 
-	if err := ctx.EventManager().EmitTypedEvents(&types.EventDeleteGroup{
-		Owner:     groupInfo.Owner,
-		GroupName: groupInfo.GroupName,
-		GroupId:   groupInfo.Id,
+	if err := ctx.EventManager().EmitTypedEvents(&types.EventLeaveGroup{
+		MemberAddress: member.String(),
+		Owner:         groupInfo.Owner,
+		GroupName:     groupInfo.GroupName,
+		GroupId:       groupInfo.Id,
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description

Wrong event is emitted for leaving group.

### Rationale

Bug fix

### Example

NA

### Changes

Notable changes: 
* NA
