### PR TITLE
fix: policy id not emit in deletepolicy event

### DIFF
--- a/x/permission/keeper/keeper.go
+++ b/x/permission/keeper/keeper.go
@@ -320,6 +320,7 @@ func (k Keeper) DeletePolicy(ctx sdk.Context, principal *types.Principal, resour
 			if policy.ExpirationTime != nil {
 				store.Delete(types.PolicyPrefixQueue(policy.ExpirationTime, policy.Id.Bytes()))
 			}
+			policyID = policy.Id
 		}
 	} else if principal.Type == types.PRINCIPAL_TYPE_GNFD_GROUP {
 		groupID, err := principal.GetGroupID()


### PR DESCRIPTION
### Description

fix the policy id  not emitted in deletepolicy event

### Rationale

NA

### Example

NA

### Changes

Notable changes: 
* NA
