### PR TITLE
fix: use versioned segment size parameter

### DIFF
--- a/x/challenge/abci.go
+++ b/x/challenge/abci.go
@@ -45,7 +45,6 @@ func EndBlocker(ctx sdk.Context, keeper k.Keeper) {
 		return
 	}
 
-	segmentSize := keeper.StorageKeeper.MaxSegmentSize(ctx)
 	expiredHeight := params.ChallengeKeepAlivePeriod + uint64(ctx.BlockHeight())
 
 	events := make([]proto.Message, 0)                      // for events
@@ -104,6 +103,12 @@ func EndBlocker(ctx sdk.Context, keeper k.Keeper) {
 		}
 
 		// random segment/piece index
+		segmentSize, err := keeper.StorageKeeper.MaxSegmentSize(ctx, objectInfo.CreateAt)
+		if err != nil {
+			ctx.Logger().Error("fail to get segment size", "timestamp", objectInfo.CreateAt,
+				"err", err.Error())
+			continue
+		}
 		segments := k.CalculateSegments(objectInfo.PayloadSize, segmentSize)
 		segmentIndex := k.RandomSegmentIndex(seed, segments)
 

--- a/x/challenge/abci_test.go
+++ b/x/challenge/abci_test.go
@@ -189,7 +189,7 @@ func (s *TestSuite) TestEndBlocker_ObjectNotExists() {
 
 func (s *TestSuite) TestEndBlocker_SuccessRandomChallenge() {
 	s.storageKeeper.EXPECT().GetObjectInfoCount(gomock.Any()).Return(sdk.NewUint(100))
-	s.storageKeeper.EXPECT().MaxSegmentSize(gomock.Any()).Return(uint64(10000)).AnyTimes()
+	s.storageKeeper.EXPECT().MaxSegmentSize(gomock.Any(), gomock.Any()).Return(uint64(10000), nil).AnyTimes()
 
 	existObject := &storagetypes.ObjectInfo{
 		Id:           math.NewUint(64),

--- a/x/challenge/keeper/msg_server_submit.go
+++ b/x/challenge/keeper/msg_server_submit.go
@@ -77,8 +77,12 @@ func (k msgServer) Submit(goCtx context.Context, msg *types.MsgSubmit) (*types.M
 	}
 
 	// generate segment index
+	segmentSize, err := k.Keeper.StorageKeeper.MaxSegmentSize(ctx, objectInfo.CreateAt)
+	if err != nil {
+		return nil, errors.Wrapf(types.ErrInvalidSegmentIndex, "cannot get segment size: %s", err.Error())
+	}
 	segmentIndex := msg.SegmentIndex
-	segments := CalculateSegments(objectInfo.PayloadSize, k.Keeper.StorageKeeper.MaxSegmentSize(ctx))
+	segments := CalculateSegments(objectInfo.PayloadSize, segmentSize)
 	if msg.RandomIndex {
 		segmentIndex = RandomSegmentIndex(ctx.BlockHeader().RandaoMix, segments)
 	} else {

--- a/x/challenge/keeper/msg_server_submit_test.go
+++ b/x/challenge/keeper/msg_server_submit_test.go
@@ -64,7 +64,7 @@ func (s *TestSuite) TestSubmit() {
 	s.storageKeeper.EXPECT().GetBucketInfo(gomock.Any(), gomock.Any()).
 		Return(nil, false).AnyTimes()
 
-	s.storageKeeper.EXPECT().MaxSegmentSize(gomock.Any()).Return(uint64(10000)).AnyTimes()
+	s.storageKeeper.EXPECT().MaxSegmentSize(gomock.Any(), gomock.Any()).Return(uint64(10000), nil).AnyTimes()
 
 	gvg := &virtualgrouptypes.GlobalVirtualGroup{PrimarySpId: 100, SecondarySpIds: []uint32{
 		1,

--- a/x/challenge/types/expected_keepers.go
+++ b/x/challenge/types/expected_keepers.go
@@ -28,7 +28,7 @@ type StorageKeeper interface {
 	GetObjectInfoById(ctx sdk.Context, objectId sdkmath.Uint) (*storage.ObjectInfo, bool)
 	GetObjectInfoCount(ctx sdk.Context) sdkmath.Uint
 	GetBucketInfo(ctx sdk.Context, bucketName string) (*storage.BucketInfo, bool)
-	MaxSegmentSize(ctx sdk.Context) (res uint64)
+	MaxSegmentSize(ctx sdk.Context, timestamp int64) (res uint64, err error)
 	GetObjectGVG(ctx sdk.Context, bucketID sdkmath.Uint, lvgID uint32) (*types.GlobalVirtualGroup, bool)
 	MustGetPrimarySPForBucket(ctx sdk.Context, bucketInfo *storage.BucketInfo) *sp.StorageProvider
 }

--- a/x/challenge/types/expected_keepers_mocks.go
+++ b/x/challenge/types/expected_keepers_mocks.go
@@ -248,17 +248,18 @@ func (mr *MockStorageKeeperMockRecorder) GetObjectInfoCount(ctx interface{}) *go
 }
 
 // MaxSegmentSize mocks base method.
-func (m *MockStorageKeeper) MaxSegmentSize(ctx types2.Context) uint64 {
+func (m *MockStorageKeeper) MaxSegmentSize(ctx types2.Context, timestamp int64) (uint64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MaxSegmentSize", ctx)
+	ret := m.ctrl.Call(m, "MaxSegmentSize", ctx, timestamp)
 	ret0, _ := ret[0].(uint64)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // MaxSegmentSize indicates an expected call of MaxSegmentSize.
-func (mr *MockStorageKeeperMockRecorder) MaxSegmentSize(ctx interface{}) *gomock.Call {
+func (mr *MockStorageKeeperMockRecorder) MaxSegmentSize(ctx, timestamp interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaxSegmentSize", reflect.TypeOf((*MockStorageKeeper)(nil).MaxSegmentSize), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaxSegmentSize", reflect.TypeOf((*MockStorageKeeper)(nil).MaxSegmentSize), ctx, timestamp)
 }
 
 // MustGetPrimarySPForBucket mocks base method.

--- a/x/storage/keeper/msg_server.go
+++ b/x/storage/keeper/msg_server.go
@@ -109,7 +109,7 @@ func (k msgServer) CreateObject(goCtx context.Context, msg *types.MsgCreateObjec
 
 	if len(msg.ExpectChecksums) != int(1+k.GetExpectSecondarySPNumForECObject(ctx, ctx.BlockTime().Unix())) {
 		return nil, gnfderrors.ErrInvalidChecksum.Wrapf("ExpectChecksums missing, expect: %d, actual: %d",
-			1+k.Keeper.RedundantParityChunkNum(ctx)+k.Keeper.RedundantParityChunkNum(ctx),
+			1+k.Keeper.RedundantParityChunkNum(ctx)+k.Keeper.RedundantDataChunkNum(ctx),
 			len(msg.ExpectChecksums))
 	}
 

--- a/x/storage/keeper/params.go
+++ b/x/storage/keeper/params.go
@@ -172,10 +172,12 @@ func (k Keeper) DiscontinueDeletionMax(ctx sdk.Context) (res uint64) {
 	return params.DiscontinueDeletionMax
 }
 
-func (k Keeper) MaxSegmentSize(ctx sdk.Context) (res uint64) {
-	p := k.GetParams(ctx)
-	params := p.GetVersionedParams()
-	return params.MaxSegmentSize
+func (k Keeper) MaxSegmentSize(ctx sdk.Context, timestamp int64) (res uint64, err error) {
+	params, err := k.GetVersionedParamsWithTs(ctx, timestamp)
+	if err != nil {
+		return 0, err
+	}
+	return params.MaxSegmentSize, err
 }
 
 func (k Keeper) RedundantDataChunkNum(ctx sdk.Context) (res uint32) {

--- a/x/storage/types/expected_keepers_mocks.go
+++ b/x/storage/types/expected_keepers_mocks.go
@@ -11,7 +11,6 @@ import (
 
 	math "cosmossdk.io/math"
 	resource "github.com/bnb-chain/greenfield/types/resource"
-	paymenttypes "github.com/bnb-chain/greenfield/x/payment/types"
 	types "github.com/bnb-chain/greenfield/x/payment/types"
 	types0 "github.com/bnb-chain/greenfield/x/permission/types"
 	types1 "github.com/bnb-chain/greenfield/x/sp/types"
@@ -345,6 +344,20 @@ func (mr *MockPaymentKeeperMockRecorder) IsPaymentAccountOwner(ctx, addr, owner 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPaymentAccountOwner", reflect.TypeOf((*MockPaymentKeeper)(nil).IsPaymentAccountOwner), ctx, addr, owner)
 }
 
+// MergeOutFlows mocks base method.
+func (m *MockPaymentKeeper) MergeOutFlows(flows []types.OutFlow) []types.OutFlow {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MergeOutFlows", flows)
+	ret0, _ := ret[0].([]types.OutFlow)
+	return ret0
+}
+
+// MergeOutFlows indicates an expected call of MergeOutFlows.
+func (mr *MockPaymentKeeperMockRecorder) MergeOutFlows(flows interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MergeOutFlows", reflect.TypeOf((*MockPaymentKeeper)(nil).MergeOutFlows), flows)
+}
+
 // UpdateStreamRecordByAddr mocks base method.
 func (m *MockPaymentKeeper) UpdateStreamRecordByAddr(ctx types3.Context, change *types.StreamRecordChange) (*types.StreamRecord, error) {
 	m.ctrl.T.Helper()
@@ -358,20 +371,6 @@ func (m *MockPaymentKeeper) UpdateStreamRecordByAddr(ctx types3.Context, change 
 func (mr *MockPaymentKeeperMockRecorder) UpdateStreamRecordByAddr(ctx, change interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStreamRecordByAddr", reflect.TypeOf((*MockPaymentKeeper)(nil).UpdateStreamRecordByAddr), ctx, change)
-}
-
-// MergeOutFlows mocks base method.
-func (m *MockPaymentKeeper) MergeOutFlows(flows []paymenttypes.OutFlow) []paymenttypes.OutFlow {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MergeOutFlows", flows)
-	ret0, _ := ret[0].([]paymenttypes.OutFlow)
-	return ret0
-}
-
-// MergeOutFlows indicates an expected call of MergeOutFlows.
-func (mr *MockPaymentKeeperMockRecorder) MergeOutFlows(flows interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MergeOutFlows", reflect.TypeOf((*MockPaymentKeeper)(nil).MergeOutFlows), flows)
 }
 
 // MockPermissionKeeper is a mock of PermissionKeeper interface.


### PR DESCRIPTION
### Description

When `segment size` parameter was refactored to versioned parameter, the challenge module was not updated accordingly.

### Rationale

Bug fix

### Example

NA

### Changes

Notable changes: 
* use versioned parameter
