### PR TITLE
release: draft release for v0.2.6-alpha.1  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.2.6-alpha.1
+This release contains 3 new bugfixes.
+
+Bugfixes:
+* [#478](https://github.com/bnb-chain/greenfield/pull/478) fix: wrong event emitted for leaving group
+* [#481](https://github.com/bnb-chain/greenfield/pull/481) fix: policy id not emit in deletepolicy event
+* [#482](https://github.com/bnb-chain/greenfield/pull/482) fix: use versioned segment size parameter
+
+Chores:
+* [#480](https://github.com/bnb-chain/greenfield/pull/480) chore: improve the validations of parameters
+
 ## v0.2.5
 This release contains all the changes for the v0.2.5 alpha versions.    
 

--- a/go.mod
+++ b/go.mod
@@ -178,7 +178,7 @@ replace (
 	github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v0.0.3
 	github.com/cometbft/cometbft-db => github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v0.2.5
+	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v0.2.6-alpha.1
 	github.com/cosmos/iavl => github.com/bnb-chain/greenfield-iavl v0.20.1
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 )

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,8 @@ github.com/bnb-chain/greenfield-cometbft v0.0.3 h1:tv8NMy3bzX/1urqXGQIIAZSLy83lo
 github.com/bnb-chain/greenfield-cometbft v0.0.3/go.mod h1:f35mk/r5ab6yvzlqEWZt68LfUje68sYgMpVlt2CUYMk=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1 h1:XcWulGacHVRiSCx90Q8Y//ajOrLNBQWR/KDB89dy3cU=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1/go.mod h1:ey1CiK4bYo1RBNJLRiVbYr5CMdSxci9S/AZRINLtppI=
-github.com/bnb-chain/greenfield-cosmos-sdk v0.2.5 h1:8zIn/ExfMHZVBbVwhILG9KYO1m3pZO8I8stpqbFgzkk=
-github.com/bnb-chain/greenfield-cosmos-sdk v0.2.5/go.mod h1:y3hDhQhil5hMIhwBTpu07RZBF30ZITkoE+GHhVZChtY=
+github.com/bnb-chain/greenfield-cosmos-sdk v0.2.6-alpha.1 h1:45vvOMYn2e9OXPoKlJeaJVLjgBaWbZfOZLFt0wIKnDY=
+github.com/bnb-chain/greenfield-cosmos-sdk v0.2.6-alpha.1/go.mod h1:y3hDhQhil5hMIhwBTpu07RZBF30ZITkoE+GHhVZChtY=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230816082903-b48770f5e210 h1:GHPbV2bC+gmuO6/sG0Tm8oGal3KKSRlyE+zPscDjlA8=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230816082903-b48770f5e210/go.mod h1:vhsZxXE9tYJeYB5JR4hPhd6Pc/uPf7j1T8IJ7p9FdeM=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230816082903-b48770f5e210 h1:FLVOn4+OVbsKi2+YJX5kmD27/4dRu4FW7xCXFhzDO5s=


### PR DESCRIPTION
### Description

This release contains 3 new bugfixes.

### Rationale
Bugfixes:
* [#478](https://github.com/bnb-chain/greenfield/pull/478) fix: wrong event emitted for leaving group
* [#481](https://github.com/bnb-chain/greenfield/pull/481) fix: policy id not emit in deletepolicy event
* [#482](https://github.com/bnb-chain/greenfield/pull/482) fix: use versioned segment size parameter

Chores:
* [#480](https://github.com/bnb-chain/greenfield/pull/480) chore: improve the validations of parameters

### Example

Please find detailed information in the PR

### Changes

Notable breaking changes:
none  	
