### PR TITLE
fix: hardfork issues for changing response and rw

### DIFF
--- a/x/challenge/abci_test.go
+++ b/x/challenge/abci_test.go
@@ -189,7 +189,7 @@ func (s *TestSuite) TestEndBlocker_ObjectNotExists() {
 
 func (s *TestSuite) TestEndBlocker_SuccessRandomChallenge() {
 	s.storageKeeper.EXPECT().GetObjectInfoCount(gomock.Any()).Return(sdk.NewUint(100))
-	s.storageKeeper.EXPECT().MaxSegmentSize(gomock.Any(), gomock.Any()).Return(uint64(10000), nil).AnyTimes()
+	s.storageKeeper.EXPECT().MaxSegmentSize(gomock.Any()).Return(uint64(10000)).AnyTimes()
 
 	existObject := &storagetypes.ObjectInfo{
 		Id:           math.NewUint(64),

--- a/x/challenge/keeper/msg_server_submit_test.go
+++ b/x/challenge/keeper/msg_server_submit_test.go
@@ -64,7 +64,7 @@ func (s *TestSuite) TestSubmit() {
 	s.storageKeeper.EXPECT().GetBucketInfo(gomock.Any(), gomock.Any()).
 		Return(nil, false).AnyTimes()
 
-	s.storageKeeper.EXPECT().MaxSegmentSize(gomock.Any(), gomock.Any()).Return(uint64(10000), nil).AnyTimes()
+	s.storageKeeper.EXPECT().MaxSegmentSize(gomock.Any()).Return(uint64(10000)).AnyTimes()
 
 	gvg := &virtualgrouptypes.GlobalVirtualGroup{PrimarySpId: 100, SecondarySpIds: []uint32{
 		1,

--- a/x/challenge/types/expected_keepers.go
+++ b/x/challenge/types/expected_keepers.go
@@ -28,7 +28,8 @@ type StorageKeeper interface {
 	GetObjectInfoById(ctx sdk.Context, objectId sdkmath.Uint) (*storage.ObjectInfo, bool)
 	GetObjectInfoCount(ctx sdk.Context) sdkmath.Uint
 	GetBucketInfo(ctx sdk.Context, bucketName string) (*storage.BucketInfo, bool)
-	MaxSegmentSize(ctx sdk.Context, timestamp int64) (res uint64, err error)
+	MaxSegmentSize(ctx sdk.Context) (res uint64)
+	MaxSegmentSizeAtTime(ctx sdk.Context, timestamp int64) (res uint64, err error)
 	GetObjectGVG(ctx sdk.Context, bucketID sdkmath.Uint, lvgID uint32) (*types.GlobalVirtualGroup, bool)
 	MustGetPrimarySPForBucket(ctx sdk.Context, bucketInfo *storage.BucketInfo) *sp.StorageProvider
 }

--- a/x/challenge/types/expected_keepers_mocks.go
+++ b/x/challenge/types/expected_keepers_mocks.go
@@ -248,18 +248,32 @@ func (mr *MockStorageKeeperMockRecorder) GetObjectInfoCount(ctx interface{}) *go
 }
 
 // MaxSegmentSize mocks base method.
-func (m *MockStorageKeeper) MaxSegmentSize(ctx types2.Context, timestamp int64) (uint64, error) {
+func (m *MockStorageKeeper) MaxSegmentSize(ctx types2.Context) uint64 {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MaxSegmentSize", ctx, timestamp)
+	ret := m.ctrl.Call(m, "MaxSegmentSize", ctx)
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// MaxSegmentSize indicates an expected call of MaxSegmentSize.
+func (mr *MockStorageKeeperMockRecorder) MaxSegmentSize(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaxSegmentSize", reflect.TypeOf((*MockStorageKeeper)(nil).MaxSegmentSize), ctx)
+}
+
+// MaxSegmentSizeAtTime mocks base method.
+func (m *MockStorageKeeper) MaxSegmentSizeAtTime(ctx types2.Context, timestamp int64) (uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MaxSegmentSizeAtTime", ctx, timestamp)
 	ret0, _ := ret[0].(uint64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// MaxSegmentSize indicates an expected call of MaxSegmentSize.
-func (mr *MockStorageKeeperMockRecorder) MaxSegmentSize(ctx, timestamp interface{}) *gomock.Call {
+// MaxSegmentSizeAtTime indicates an expected call of MaxSegmentSizeAtTime.
+func (mr *MockStorageKeeperMockRecorder) MaxSegmentSizeAtTime(ctx, timestamp interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaxSegmentSize", reflect.TypeOf((*MockStorageKeeper)(nil).MaxSegmentSize), ctx, timestamp)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaxSegmentSizeAtTime", reflect.TypeOf((*MockStorageKeeper)(nil).MaxSegmentSizeAtTime), ctx, timestamp)
 }
 
 // MustGetPrimarySPForBucket mocks base method.

--- a/x/permission/keeper/keeper.go
+++ b/x/permission/keeper/keeper.go
@@ -320,7 +320,9 @@ func (k Keeper) DeletePolicy(ctx sdk.Context, principal *types.Principal, resour
 			if policy.ExpirationTime != nil {
 				store.Delete(types.PolicyPrefixQueue(policy.ExpirationTime, policy.Id.Bytes()))
 			}
-			policyID = policy.Id
+			if ctx.IsUpgraded(upgradetypes.Nagqu) {
+				policyID = policy.Id // policy id is in the response, change it will lead to hardfork
+			}
 		}
 	} else if principal.Type == types.PRINCIPAL_TYPE_GNFD_GROUP {
 		groupID, err := principal.GetGroupID()

--- a/x/permission/keeper/keeper.go
+++ b/x/permission/keeper/keeper.go
@@ -320,9 +320,7 @@ func (k Keeper) DeletePolicy(ctx sdk.Context, principal *types.Principal, resour
 			if policy.ExpirationTime != nil {
 				store.Delete(types.PolicyPrefixQueue(policy.ExpirationTime, policy.Id.Bytes()))
 			}
-			if ctx.IsUpgraded(upgradetypes.Nagqu) {
-				policyID = policy.Id // policy id is in the response, change it will lead to hardfork
-			}
+			//policyID = policy.Id //TODO: policy id is in the response, change it will lead to hardfork
 		}
 	} else if principal.Type == types.PRINCIPAL_TYPE_GNFD_GROUP {
 		groupID, err := principal.GetGroupID()

--- a/x/storage/keeper/params.go
+++ b/x/storage/keeper/params.go
@@ -172,7 +172,13 @@ func (k Keeper) DiscontinueDeletionMax(ctx sdk.Context) (res uint64) {
 	return params.DiscontinueDeletionMax
 }
 
-func (k Keeper) MaxSegmentSize(ctx sdk.Context, timestamp int64) (res uint64, err error) {
+func (k Keeper) MaxSegmentSize(ctx sdk.Context) (res uint64) {
+	p := k.GetParams(ctx)
+	params := p.GetVersionedParams()
+	return params.MaxSegmentSize
+}
+
+func (k Keeper) MaxSegmentSizeAtTime(ctx sdk.Context, timestamp int64) (res uint64, err error) {
 	params, err := k.GetVersionedParamsWithTs(ctx, timestamp)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
### Description

1) changing the response `MsgDeletePolicy` is a hardfork
2) changing `MaxSegmentSize` before `Nagpu` is a hardfork

### Rationale

Fix

### Example

NA

### Changes

Notable changes: 
* revert `MsgDeletePolicy` change