### PR TITLE
release: draft release for v0.2.6-hf.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.2.6-hf.1
+This is a hotfix version to enable the chain to emit deposit events for user accounts and add local virtual group id for related events.
+
+Chores:
+* [#489](https://github.com/bnb-chain/greenfield/pull/489) chore: add deposit event for user account
+* [#490](https://github.com/bnb-chain/greenfield/pull/490) chore: add lvg id to related events
+
 ## v0.2.6
 This is a maintenance release to update the cosmos-sdk dependency to the latest version.
 


### PR DESCRIPTION
### Description

This is a hotfix version to enable the chain to emit deposit events for user accounts and add local virtual group id for related events.

### Rationale

Chores:
* [#489](https://github.com/bnb-chain/greenfield/pull/489) chore: add deposit event for user account
* [#490](https://github.com/bnb-chain/greenfield/pull/490) chore: add lvg id to related events

### Example

Please refer to individual PRs for detailed information.  

### Changes

Notable changes: 
none  