### PR TITLE
fix: make `handleCreateBucketSynPackage` forward compatible

### DIFF
--- a/x/storage/keeper/cross_app_bucket.go
+++ b/x/storage/keeper/cross_app_bucket.go
@@ -2,8 +2,6 @@ package keeper
 
 import (
 	"encoding/hex"
-	"fmt"
-
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -231,17 +229,6 @@ func (app *BucketApp) handleCreateBucketFailAckPackageV2(ctx sdk.Context, appCtx
 }
 
 func (app *BucketApp) handleCreateBucketSynPackage(ctx sdk.Context, appCtx *sdk.CrossChainAppContext, createBucketPackage *types.CreateBucketSynPackage) sdk.ExecuteResult {
-	if ctx.IsUpgraded(upgradetypes.Pampas) {
-		return sdk.ExecuteResult{
-			Payload: types.CreateBucketAckPackage{
-				Status:    types.StatusFail,
-				Creator:   createBucketPackage.Creator,
-				ExtraData: createBucketPackage.ExtraData,
-			}.MustSerialize(),
-			Err: fmt.Errorf("old CreateBucketSynPackage is not supported after pampas upgrade"),
-		}
-	}
-
 	err := createBucketPackage.ValidateBasic()
 	if err != nil {
 		return sdk.ExecuteResult{

--- a/x/storage/keeper/cross_app_bucket.go
+++ b/x/storage/keeper/cross_app_bucket.go
@@ -2,7 +2,9 @@ package keeper
 
 import (
 	"encoding/hex"
+
 	"cosmossdk.io/math"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/bnb-chain/greenfield/types/common"

--- a/x/storage/keeper/cross_app_bucket.go
+++ b/x/storage/keeper/cross_app_bucket.go
@@ -2,12 +2,14 @@ package keeper
 
 import (
 	"encoding/hex"
+	"fmt"
 
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/bnb-chain/greenfield/types/common"
 	"github.com/bnb-chain/greenfield/x/storage/types"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 )
 
 var _ sdk.CrossChainApplication = &BucketApp{}
@@ -57,7 +59,13 @@ func (app *BucketApp) ExecuteAckPackage(ctx sdk.Context, appCtx *sdk.CrossChainA
 }
 
 func (app *BucketApp) ExecuteFailAckPackage(ctx sdk.Context, appCtx *sdk.CrossChainAppContext, payload []byte) sdk.ExecuteResult {
-	pack, err := types.DeserializeCrossChainPackage(payload, types.BucketChannelId, sdk.FailAckCrossChainPackageType)
+	var pack interface{}
+	var err error
+	if ctx.IsUpgraded(upgradetypes.Pampas) {
+		pack, err = types.DeserializeCrossChainPackageV2(payload, types.BucketChannelId, sdk.FailAckCrossChainPackageType)
+	} else {
+		pack, err = types.DeserializeCrossChainPackage(payload, types.BucketChannelId, sdk.FailAckCrossChainPackageType)
+	}
 	if err != nil {
 		app.storageKeeper.Logger(ctx).Error("deserialize bucket cross chain package error", "payload", hex.EncodeToString(payload), "error", err.Error())
 		panic("deserialize bucket cross chain package error")
@@ -72,6 +80,9 @@ func (app *BucketApp) ExecuteFailAckPackage(ctx sdk.Context, appCtx *sdk.CrossCh
 	case *types.CreateBucketSynPackage:
 		operationType = types.OperationCreateBucket
 		result = app.handleCreateBucketFailAckPackage(ctx, appCtx, p)
+	case *types.CreateBucketSynPackageV2:
+		operationType = types.OperationCreateBucket
+		result = app.handleCreateBucketFailAckPackageV2(ctx, appCtx, p)
 	case *types.DeleteBucketSynPackage:
 		operationType = types.OperationDeleteBucket
 		result = app.handleDeleteBucketFailAckPackage(ctx, appCtx, p)
@@ -91,7 +102,13 @@ func (app *BucketApp) ExecuteFailAckPackage(ctx sdk.Context, appCtx *sdk.CrossCh
 }
 
 func (app *BucketApp) ExecuteSynPackage(ctx sdk.Context, appCtx *sdk.CrossChainAppContext, payload []byte) sdk.ExecuteResult {
-	pack, err := types.DeserializeCrossChainPackage(payload, types.BucketChannelId, sdk.SynCrossChainPackageType)
+	var pack interface{}
+	var err error
+	if ctx.IsUpgraded(upgradetypes.Pampas) {
+		pack, err = types.DeserializeCrossChainPackageV2(payload, types.BucketChannelId, sdk.FailAckCrossChainPackageType)
+	} else {
+		pack, err = types.DeserializeCrossChainPackage(payload, types.BucketChannelId, sdk.FailAckCrossChainPackageType)
+	}
 	if err != nil {
 		app.storageKeeper.Logger(ctx).Error("deserialize bucket cross chain package error", "payload", hex.EncodeToString(payload), "error", err.Error())
 		panic("deserialize bucket cross chain package error")
@@ -106,6 +123,9 @@ func (app *BucketApp) ExecuteSynPackage(ctx sdk.Context, appCtx *sdk.CrossChainA
 	case *types.CreateBucketSynPackage:
 		operationType = types.OperationCreateBucket
 		result = app.handleCreateBucketSynPackage(ctx, appCtx, p)
+	case *types.CreateBucketSynPackageV2:
+		operationType = types.OperationCreateBucket
+		result = app.handleCreateBucketSynPackageV2(ctx, appCtx, p)
 	case *types.DeleteBucketSynPackage:
 		operationType = types.OperationDeleteBucket
 		result = app.handleDeleteBucketSynPackage(ctx, appCtx, p)
@@ -204,7 +224,24 @@ func (app *BucketApp) handleCreateBucketFailAckPackage(ctx sdk.Context, appCtx *
 	return sdk.ExecuteResult{}
 }
 
+func (app *BucketApp) handleCreateBucketFailAckPackageV2(ctx sdk.Context, appCtx *sdk.CrossChainAppContext, synPackage *types.CreateBucketSynPackageV2) sdk.ExecuteResult {
+	app.storageKeeper.Logger(ctx).Error("received create bucket fail ack package ")
+
+	return sdk.ExecuteResult{}
+}
+
 func (app *BucketApp) handleCreateBucketSynPackage(ctx sdk.Context, appCtx *sdk.CrossChainAppContext, createBucketPackage *types.CreateBucketSynPackage) sdk.ExecuteResult {
+	if ctx.IsUpgraded(upgradetypes.Pampas) {
+		return sdk.ExecuteResult{
+			Payload: types.CreateBucketAckPackage{
+				Status:    types.StatusFail,
+				Creator:   createBucketPackage.Creator,
+				ExtraData: createBucketPackage.ExtraData,
+			}.MustSerialize(),
+			Err: fmt.Errorf("old CreateBucketSynPackage is not supported after pampas upgrade"),
+		}
+	}
+
 	err := createBucketPackage.ValidateBasic()
 	if err != nil {
 		return sdk.ExecuteResult{
@@ -235,9 +272,8 @@ func (app *BucketApp) handleCreateBucketSynPackage(ctx sdk.Context, appCtx *sdk.
 			ChargedReadQuota: createBucketPackage.ChargedReadQuota,
 			PaymentAddress:   createBucketPackage.PaymentAddress.String(),
 			PrimarySpApproval: &common.Approval{
-				ExpiredHeight:              createBucketPackage.PrimarySpApprovalExpiredHeight,
-				GlobalVirtualGroupFamilyId: createBucketPackage.GlobalVirtualGroupFamilyId,
-				Sig:                        createBucketPackage.PrimarySpApprovalSignature,
+				ExpiredHeight: createBucketPackage.PrimarySpApprovalExpiredHeight,
+				Sig:           createBucketPackage.PrimarySpApprovalSignature,
 			},
 			ApprovalMsgBytes: createBucketPackage.GetApprovalBytes(),
 		},
@@ -259,6 +295,65 @@ func (app *BucketApp) handleCreateBucketSynPackage(ctx sdk.Context, appCtx *sdk.
 			Id:        bucketId.BigInt(),
 			Creator:   createBucketPackage.Creator,
 			ExtraData: createBucketPackage.ExtraData,
+		}.MustSerialize(),
+	}
+}
+
+func (app *BucketApp) handleCreateBucketSynPackageV2(ctx sdk.Context, appCtx *sdk.CrossChainAppContext, createBucketPackageV2 *types.CreateBucketSynPackageV2) sdk.ExecuteResult {
+	err := createBucketPackageV2.ValidateBasic()
+	if err != nil {
+		return sdk.ExecuteResult{
+			Payload: types.CreateBucketAckPackage{
+				Status:    types.StatusFail,
+				Creator:   createBucketPackageV2.Creator,
+				ExtraData: createBucketPackageV2.ExtraData,
+			}.MustSerialize(),
+			Err: err,
+		}
+	}
+	app.storageKeeper.Logger(ctx).Info("process create bucket syn package v2", "bucket name", createBucketPackageV2.BucketName)
+
+	sourceType, err := app.storageKeeper.GetSourceTypeByChainId(ctx, appCtx.SrcChainId)
+	if err != nil {
+		return sdk.ExecuteResult{
+			Err: err,
+		}
+	}
+
+	bucketId, err := app.storageKeeper.CreateBucket(ctx,
+		createBucketPackageV2.Creator,
+		createBucketPackageV2.BucketName,
+		createBucketPackageV2.PrimarySpAddress,
+		&types.CreateBucketOptions{
+			Visibility:       types.VisibilityType(createBucketPackageV2.Visibility),
+			SourceType:       sourceType,
+			ChargedReadQuota: createBucketPackageV2.ChargedReadQuota,
+			PaymentAddress:   createBucketPackageV2.PaymentAddress.String(),
+			PrimarySpApproval: &common.Approval{
+				ExpiredHeight:              createBucketPackageV2.PrimarySpApprovalExpiredHeight,
+				GlobalVirtualGroupFamilyId: createBucketPackageV2.GlobalVirtualGroupFamilyId,
+				Sig:                        createBucketPackageV2.PrimarySpApprovalSignature,
+			},
+			ApprovalMsgBytes: createBucketPackageV2.GetApprovalBytes(),
+		},
+	)
+	if err != nil {
+		return sdk.ExecuteResult{
+			Payload: types.CreateBucketAckPackage{
+				Status:    types.StatusFail,
+				Creator:   createBucketPackageV2.Creator,
+				ExtraData: createBucketPackageV2.ExtraData,
+			}.MustSerialize(),
+			Err: err,
+		}
+	}
+
+	return sdk.ExecuteResult{
+		Payload: types.CreateBucketAckPackage{
+			Status:    types.StatusSuccess,
+			Id:        bucketId.BigInt(),
+			Creator:   createBucketPackageV2.Creator,
+			ExtraData: createBucketPackageV2.ExtraData,
 		}.MustSerialize(),
 	}
 }

--- a/x/storage/types/crosschain.go
+++ b/x/storage/types/crosschain.go
@@ -23,19 +23,16 @@ const (
 	GroupChannelId  sdk.ChannelID = 6
 
 	// bucket operation types
-
 	OperationMirrorBucket uint8 = 1
 	OperationCreateBucket uint8 = 2
 	OperationDeleteBucket uint8 = 3
 
 	// object operation types
-
 	OperationMirrorObject uint8 = 1
 	// OperationCreateObject uint8 = 2 // not used
 	OperationDeleteObject uint8 = 3
 
 	// group operation types
-
 	OperationMirrorGroup       uint8 = 1
 	OperationCreateGroup       uint8 = 2
 	OperationDeleteGroup       uint8 = 3
@@ -123,6 +120,7 @@ var (
 		},
 	}
 
+	// DeserializeFuncMapV2 used after Pamela upgrade
 	DeserializeFuncMapV2 = map[sdk.ChannelID]map[uint8][3]DeserializeFunc{
 		BucketChannelId: {
 			OperationMirrorBucket: {

--- a/x/storage/types/crosschain.go
+++ b/x/storage/types/crosschain.go
@@ -23,16 +23,19 @@ const (
 	GroupChannelId  sdk.ChannelID = 6
 
 	// bucket operation types
+
 	OperationMirrorBucket uint8 = 1
 	OperationCreateBucket uint8 = 2
 	OperationDeleteBucket uint8 = 3
 
 	// object operation types
+
 	OperationMirrorObject uint8 = 1
 	// OperationCreateObject uint8 = 2 // not used
 	OperationDeleteObject uint8 = 3
 
 	// group operation types
+
 	OperationMirrorGroup       uint8 = 1
 	OperationCreateGroup       uint8 = 2
 	OperationDeleteGroup       uint8 = 3
@@ -120,7 +123,7 @@ var (
 		},
 	}
 
-	// DeserializeFuncMapV2 used after Pamela upgrade
+	// DeserializeFuncMapV2 used after Pampas upgrade
 	DeserializeFuncMapV2 = map[sdk.ChannelID]map[uint8][3]DeserializeFunc{
 		BucketChannelId: {
 			OperationMirrorBucket: {

--- a/x/storage/types/crosschain.go
+++ b/x/storage/types/crosschain.go
@@ -68,59 +68,115 @@ func DeserializeRawCrossChainPackage(serializedPackage []byte) (*CrossChainPacka
 
 type DeserializeFunc func(serializedPackage []byte) (interface{}, error)
 
-var DeserializeFuncMap = map[sdk.ChannelID]map[uint8][3]DeserializeFunc{
-	BucketChannelId: {
-		OperationMirrorBucket: {
-			DeserializeMirrorBucketSynPackage,
-			DeserializeMirrorBucketAckPackage,
-			DeserializeMirrorBucketSynPackage,
+var (
+	DeserializeFuncMap = map[sdk.ChannelID]map[uint8][3]DeserializeFunc{
+		BucketChannelId: {
+			OperationMirrorBucket: {
+				DeserializeMirrorBucketSynPackage,
+				DeserializeMirrorBucketAckPackage,
+				DeserializeMirrorBucketSynPackage,
+			},
+			OperationCreateBucket: {
+				DeserializeCreateBucketSynPackage,
+				DeserializeCreateBucketAckPackage,
+				DeserializeCreateBucketSynPackage,
+			},
+			OperationDeleteBucket: {
+				DeserializeDeleteBucketSynPackage,
+				DeserializeDeleteBucketAckPackage,
+				DeserializeDeleteBucketSynPackage,
+			},
 		},
-		OperationCreateBucket: {
-			DeserializeCreateBucketSynPackage,
-			DeserializeCreateBucketAckPackage,
-			DeserializeCreateBucketSynPackage,
+		ObjectChannelId: {
+			OperationMirrorObject: {
+				DeserializeMirrorObjectSynPackage,
+				DeserializeMirrorObjectAckPackage,
+				DeserializeMirrorObjectSynPackage,
+			},
+			OperationDeleteObject: {
+				DeserializeDeleteObjectSynPackage,
+				DeserializeDeleteObjectAckPackage,
+				DeserializeDeleteObjectSynPackage,
+			},
 		},
-		OperationDeleteBucket: {
-			DeserializeDeleteBucketSynPackage,
-			DeserializeDeleteBucketAckPackage,
-			DeserializeDeleteBucketSynPackage,
+		GroupChannelId: {
+			OperationMirrorGroup: {
+				DeserializeMirrorGroupSynPackage,
+				DeserializeMirrorGroupAckPackage,
+				DeserializeMirrorGroupSynPackage,
+			},
+			OperationCreateGroup: {
+				DeserializeCreateGroupSynPackage,
+				DeserializeCreateGroupAckPackage,
+				DeserializeCreateGroupSynPackage,
+			},
+			OperationDeleteGroup: {
+				DeserializeDeleteGroupSynPackage,
+				DeserializeDeleteGroupAckPackage,
+				DeserializeDeleteGroupSynPackage,
+			},
+			OperationUpdateGroupMember: {
+				DeserializeUpdateGroupMemberSynPackage,
+				DeserializeUpdateGroupMemberAckPackage,
+				DeserializeUpdateGroupMemberSynPackage,
+			},
 		},
-	},
-	ObjectChannelId: {
-		OperationMirrorObject: {
-			DeserializeMirrorObjectSynPackage,
-			DeserializeMirrorObjectAckPackage,
-			DeserializeMirrorObjectSynPackage,
+	}
+
+	DeserializeFuncMapV2 = map[sdk.ChannelID]map[uint8][3]DeserializeFunc{
+		BucketChannelId: {
+			OperationMirrorBucket: {
+				DeserializeMirrorBucketSynPackage,
+				DeserializeMirrorBucketAckPackage,
+				DeserializeMirrorBucketSynPackage,
+			},
+			OperationCreateBucket: {
+				DeserializeCreateBucketSynPackageV2,
+				DeserializeCreateBucketAckPackage,
+				DeserializeCreateBucketSynPackageV2,
+			},
+			OperationDeleteBucket: {
+				DeserializeDeleteBucketSynPackage,
+				DeserializeDeleteBucketAckPackage,
+				DeserializeDeleteBucketSynPackage,
+			},
 		},
-		OperationDeleteObject: {
-			DeserializeDeleteObjectSynPackage,
-			DeserializeDeleteObjectAckPackage,
-			DeserializeDeleteObjectSynPackage,
+		ObjectChannelId: {
+			OperationMirrorObject: {
+				DeserializeMirrorObjectSynPackage,
+				DeserializeMirrorObjectAckPackage,
+				DeserializeMirrorObjectSynPackage,
+			},
+			OperationDeleteObject: {
+				DeserializeDeleteObjectSynPackage,
+				DeserializeDeleteObjectAckPackage,
+				DeserializeDeleteObjectSynPackage,
+			},
 		},
-	},
-	GroupChannelId: {
-		OperationMirrorGroup: {
-			DeserializeMirrorGroupSynPackage,
-			DeserializeMirrorGroupAckPackage,
-			DeserializeMirrorGroupSynPackage,
+		GroupChannelId: {
+			OperationMirrorGroup: {
+				DeserializeMirrorGroupSynPackage,
+				DeserializeMirrorGroupAckPackage,
+				DeserializeMirrorGroupSynPackage,
+			},
+			OperationCreateGroup: {
+				DeserializeCreateGroupSynPackage,
+				DeserializeCreateGroupAckPackage,
+				DeserializeCreateGroupSynPackage,
+			},
+			OperationDeleteGroup: {
+				DeserializeDeleteGroupSynPackage,
+				DeserializeDeleteGroupAckPackage,
+				DeserializeDeleteGroupSynPackage,
+			},
+			OperationUpdateGroupMember: {
+				DeserializeUpdateGroupMemberSynPackage,
+				DeserializeUpdateGroupMemberAckPackage,
+				DeserializeUpdateGroupMemberSynPackage,
+			},
 		},
-		OperationCreateGroup: {
-			DeserializeCreateGroupSynPackage,
-			DeserializeCreateGroupAckPackage,
-			DeserializeCreateGroupSynPackage,
-		},
-		OperationDeleteGroup: {
-			DeserializeDeleteGroupSynPackage,
-			DeserializeDeleteGroupAckPackage,
-			DeserializeDeleteGroupSynPackage,
-		},
-		OperationUpdateGroupMember: {
-			DeserializeUpdateGroupMemberSynPackage,
-			DeserializeUpdateGroupMemberAckPackage,
-			DeserializeUpdateGroupMemberSynPackage,
-		},
-	},
-}
+	}
+)
 
 func DeserializeCrossChainPackage(rawPack []byte, channelId sdk.ChannelID, packageType sdk.CrossChainPackageType) (interface{}, error) {
 	if packageType >= 3 {
@@ -133,6 +189,24 @@ func DeserializeCrossChainPackage(rawPack []byte, channelId sdk.ChannelID, packa
 	}
 
 	operationMap, ok := DeserializeFuncMap[channelId][pack.OperationType]
+	if !ok {
+		return nil, ErrInvalidCrossChainPackage
+	}
+
+	return operationMap[packageType](pack.Package)
+}
+
+func DeserializeCrossChainPackageV2(rawPack []byte, channelId sdk.ChannelID, packageType sdk.CrossChainPackageType) (interface{}, error) {
+	if packageType >= 3 {
+		return nil, ErrInvalidCrossChainPackage
+	}
+
+	pack, err := DeserializeRawCrossChainPackage(rawPack)
+	if err != nil {
+		return nil, err
+	}
+
+	operationMap, ok := DeserializeFuncMapV2[channelId][pack.OperationType]
 	if !ok {
 		return nil, ErrInvalidCrossChainPackage
 	}
@@ -347,6 +421,18 @@ type CreateBucketSynPackage struct {
 	PaymentAddress                 sdk.AccAddress
 	PrimarySpAddress               sdk.AccAddress
 	PrimarySpApprovalExpiredHeight uint64
+	PrimarySpApprovalSignature     []byte
+	ChargedReadQuota               uint64
+	ExtraData                      []byte
+}
+
+type CreateBucketSynPackageV2 struct {
+	Creator                        sdk.AccAddress
+	BucketName                     string
+	Visibility                     uint32
+	PaymentAddress                 sdk.AccAddress
+	PrimarySpAddress               sdk.AccAddress
+	PrimarySpApprovalExpiredHeight uint64
 	GlobalVirtualGroupFamilyId     uint32
 	PrimarySpApprovalSignature     []byte
 	ChargedReadQuota               uint64
@@ -354,6 +440,18 @@ type CreateBucketSynPackage struct {
 }
 
 type CreateBucketSynPackageStruct struct {
+	Creator                        common.Address
+	BucketName                     string
+	Visibility                     uint32
+	PaymentAddress                 common.Address
+	PrimarySpAddress               common.Address
+	PrimarySpApprovalExpiredHeight uint64
+	PrimarySpApprovalSignature     []byte
+	ChargedReadQuota               uint64
+	ExtraData                      []byte
+}
+
+type CreateBucketSynPackageV2Struct struct {
 	Creator                        common.Address
 	BucketName                     string
 	Visibility                     uint32
@@ -374,7 +472,6 @@ var (
 		{Name: "PaymentAddress", Type: "address"},
 		{Name: "PrimarySpAddress", Type: "address"},
 		{Name: "PrimarySpApprovalExpiredHeight", Type: "uint64"},
-		{Name: "GlobalVirtualGroupFamilyId", Type: "uint32"},
 		{Name: "PrimarySpApprovalSignature", Type: "bytes"},
 		{Name: "ChargedReadQuota", Type: "uint64"},
 		{Name: "ExtraData", Type: "bytes"},
@@ -382,6 +479,23 @@ var (
 
 	createBucketSynPackageStructArgs = abi.Arguments{
 		{Type: createBucketSynPackageStructType},
+	}
+
+	createBucketSynPackageV2StructType, _ = abi.NewType("tuple", "", []abi.ArgumentMarshaling{
+		{Name: "Creator", Type: "address"},
+		{Name: "BucketName", Type: "string"},
+		{Name: "Visibility", Type: "uint32"},
+		{Name: "PaymentAddress", Type: "address"},
+		{Name: "PrimarySpAddress", Type: "address"},
+		{Name: "PrimarySpApprovalExpiredHeight", Type: "uint64"},
+		{Name: "GlobalVirtualGroupFamilyId", Type: "uint32"},
+		{Name: "PrimarySpApprovalSignature", Type: "bytes"},
+		{Name: "ChargedReadQuota", Type: "uint64"},
+		{Name: "ExtraData", Type: "bytes"},
+	})
+
+	createBucketSynPackageV2StructArgs = abi.Arguments{
+		{Type: createBucketSynPackageV2StructType},
 	}
 )
 
@@ -393,7 +507,6 @@ func (p CreateBucketSynPackage) MustSerialize() []byte {
 		PaymentAddress:                 common.BytesToAddress(p.PaymentAddress),
 		PrimarySpAddress:               common.BytesToAddress(p.PrimarySpAddress),
 		PrimarySpApprovalExpiredHeight: p.PrimarySpApprovalExpiredHeight,
-		GlobalVirtualGroupFamilyId:     p.GlobalVirtualGroupFamilyId,
 		PrimarySpApprovalSignature:     p.PrimarySpApprovalSignature,
 		ChargedReadQuota:               p.ChargedReadQuota,
 		ExtraData:                      p.ExtraData,
@@ -412,9 +525,8 @@ func (p CreateBucketSynPackage) ValidateBasic() error {
 		PaymentAddress:   p.PaymentAddress.String(),
 		PrimarySpAddress: p.PrimarySpAddress.String(),
 		PrimarySpApproval: &gnfdcommon.Approval{
-			ExpiredHeight:              p.PrimarySpApprovalExpiredHeight,
-			GlobalVirtualGroupFamilyId: p.GlobalVirtualGroupFamilyId,
-			Sig:                        p.PrimarySpApprovalSignature,
+			ExpiredHeight: p.PrimarySpApprovalExpiredHeight,
+			Sig:           p.PrimarySpApprovalSignature,
 		},
 		ChargedReadQuota: p.ChargedReadQuota,
 	}
@@ -430,9 +542,8 @@ func (p CreateBucketSynPackage) GetApprovalBytes() []byte {
 		PaymentAddress:   p.PaymentAddress.String(),
 		PrimarySpAddress: p.PrimarySpAddress.String(),
 		PrimarySpApproval: &gnfdcommon.Approval{
-			ExpiredHeight:              p.PrimarySpApprovalExpiredHeight,
-			GlobalVirtualGroupFamilyId: p.GlobalVirtualGroupFamilyId,
-			Sig:                        p.PrimarySpApprovalSignature,
+			ExpiredHeight: p.PrimarySpApprovalExpiredHeight,
+			Sig:           p.PrimarySpApprovalSignature,
 		},
 		ChargedReadQuota: p.ChargedReadQuota,
 	}
@@ -452,6 +563,86 @@ func DeserializeCreateBucketSynPackage(serializedPackage []byte) (interface{}, e
 	}
 
 	tp := CreateBucketSynPackage{
+		pkgStruct.Creator.Bytes(),
+		pkgStruct.BucketName,
+		pkgStruct.Visibility,
+		pkgStruct.PaymentAddress.Bytes(),
+		pkgStruct.PrimarySpAddress.Bytes(),
+		pkgStruct.PrimarySpApprovalExpiredHeight,
+		pkgStruct.PrimarySpApprovalSignature,
+		pkgStruct.ChargedReadQuota,
+		pkgStruct.ExtraData,
+	}
+	return &tp, nil
+}
+
+func (p CreateBucketSynPackageV2) MustSerialize() []byte {
+	encodedBytes, err := createBucketSynPackageStructArgs.Pack(&CreateBucketSynPackageV2Struct{
+		Creator:                        common.BytesToAddress(p.Creator),
+		BucketName:                     p.BucketName,
+		Visibility:                     p.Visibility,
+		PaymentAddress:                 common.BytesToAddress(p.PaymentAddress),
+		PrimarySpAddress:               common.BytesToAddress(p.PrimarySpAddress),
+		PrimarySpApprovalExpiredHeight: p.PrimarySpApprovalExpiredHeight,
+		GlobalVirtualGroupFamilyId:     p.GlobalVirtualGroupFamilyId,
+		PrimarySpApprovalSignature:     p.PrimarySpApprovalSignature,
+		ChargedReadQuota:               p.ChargedReadQuota,
+		ExtraData:                      p.ExtraData,
+	})
+	if err != nil {
+		panic("encode create bucket syn package v2 error")
+	}
+	return encodedBytes
+}
+
+func (p CreateBucketSynPackageV2) ValidateBasic() error {
+	msg := MsgCreateBucket{
+		Creator:          p.Creator.String(),
+		BucketName:       p.BucketName,
+		Visibility:       VisibilityType(p.Visibility),
+		PaymentAddress:   p.PaymentAddress.String(),
+		PrimarySpAddress: p.PrimarySpAddress.String(),
+		PrimarySpApproval: &gnfdcommon.Approval{
+			ExpiredHeight:              p.PrimarySpApprovalExpiredHeight,
+			GlobalVirtualGroupFamilyId: p.GlobalVirtualGroupFamilyId,
+			Sig:                        p.PrimarySpApprovalSignature,
+		},
+		ChargedReadQuota: p.ChargedReadQuota,
+	}
+
+	return msg.ValidateBasic()
+}
+
+func (p CreateBucketSynPackageV2) GetApprovalBytes() []byte {
+	msg := MsgCreateBucket{
+		Creator:          p.Creator.String(),
+		BucketName:       p.BucketName,
+		Visibility:       VisibilityType(p.Visibility),
+		PaymentAddress:   p.PaymentAddress.String(),
+		PrimarySpAddress: p.PrimarySpAddress.String(),
+		PrimarySpApproval: &gnfdcommon.Approval{
+			ExpiredHeight:              p.PrimarySpApprovalExpiredHeight,
+			GlobalVirtualGroupFamilyId: p.GlobalVirtualGroupFamilyId,
+			Sig:                        p.PrimarySpApprovalSignature,
+		},
+		ChargedReadQuota: p.ChargedReadQuota,
+	}
+	return msg.GetApprovalBytes()
+}
+
+func DeserializeCreateBucketSynPackageV2(serializedPackage []byte) (interface{}, error) {
+	unpacked, err := createBucketSynPackageV2StructArgs.Unpack(serializedPackage)
+	if err != nil {
+		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "deserialize create bucket syn package v2 failed")
+	}
+
+	unpackedStruct := abi.ConvertType(unpacked[0], CreateBucketSynPackageV2Struct{})
+	pkgStruct, ok := unpackedStruct.(CreateBucketSynPackageV2Struct)
+	if !ok {
+		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "reflect create bucket syn package v2 failed")
+	}
+
+	tp := CreateBucketSynPackageV2{
 		pkgStruct.Creator.Bytes(),
 		pkgStruct.BucketName,
 		pkgStruct.Visibility,


### PR DESCRIPTION
### Description

This pr is to fix the forward incompatibility of `handleCreateBucketSynPackage`

### Rationale

To make the chain forward compatible

### Example

The chain can handle `CreateBucketSynPackage` with or without `GlobalVirtualGroupFamilyId`

### Changes

Notable changes: 
* add `handleCreateBucketSynPackageV2`
