### PR TITLE
fix: policy key is not GC while a expired policy is GC

### DIFF
--- a/e2e/tests/permission_test.go
+++ b/e2e/tests/permission_test.go
@@ -1911,7 +1911,60 @@ func (s *StorageTestSuite) TestGrantsPermissionToObjectWithWildcardInName() {
 	s.Require().True(strings.Contains(err.Error(), "No such object"))
 }
 
-func (s *StorageTestSuite) TestExpiredPolicyGCAndRePut() {
+func (s *StorageTestSuite) TestExpiredAccountPolicyGCAndRePut() {
+	var err error
+	ctx := context.Background()
+	user1 := s.GenAndChargeAccounts(1, 1000000)[0]
+
+	_, owner, bucketName, _, _, objectId := s.createObjectWithVisibility(storagetypes.VISIBILITY_TYPE_PUBLIC_READ)
+
+	principal := types.NewPrincipalWithAccount(user1.GetAddr())
+
+	// Put bucket policy
+	bucketStatement := &types.Statement{
+		Actions: []types.ActionType{types.ACTION_DELETE_BUCKET},
+		Effect:  types.EFFECT_ALLOW,
+	}
+	expirationTime := time.Now().Add(5 * time.Second)
+
+	msgPutBucketPolicy := storagetypes.NewMsgPutPolicy(owner.GetAddr(), types2.NewBucketGRN(bucketName).String(),
+		principal, []*types.Statement{bucketStatement}, &expirationTime)
+	s.SendTxBlock(owner, msgPutBucketPolicy)
+
+	// Query the policy which is enforced on bucket
+	grn1 := types2.NewBucketGRN(bucketName)
+	queryPolicyForAccountResp, err := s.Client.QueryPolicyForAccount(ctx, &storagetypes.QueryPolicyForAccountRequest{
+		Resource:         grn1.String(),
+		PrincipalAddress: user1.GetAddr().String(),
+	})
+	s.Require().NoError(err)
+	s.Require().Equal(objectId, queryPolicyForAccountResp.Policy.ResourceId)
+
+	// wait for policy expired
+	time.Sleep(5 * time.Second)
+
+	// query the policy, which is already GC, should get err.
+	_, err = s.Client.QueryPolicyForAccount(ctx, &storagetypes.QueryPolicyForAccountRequest{
+		Resource:         grn1.String(),
+		PrincipalAddress: user1.GetAddr().String(),
+	})
+	s.Require().Error(err)
+
+	// the user should be able to re-put policy for the bucket.
+	msgPutBucketPolicy = storagetypes.NewMsgPutPolicy(owner.GetAddr(), types2.NewBucketGRN(bucketName).String(),
+		principal, []*types.Statement{bucketStatement}, nil)
+	s.SendTxBlock(owner, msgPutBucketPolicy)
+
+	// Query the policy which is enforced on bucket.
+	queryPolicyForAccountResp, err = s.Client.QueryPolicyForAccount(ctx, &storagetypes.QueryPolicyForAccountRequest{
+		Resource:         grn1.String(),
+		PrincipalAddress: user1.GetAddr().String(),
+	})
+	s.Require().NoError(err)
+	s.Require().Equal(objectId, queryPolicyForAccountResp.Policy.ResourceId)
+}
+
+func (s *StorageTestSuite) TestExpiredGroupPolicyGCAndRePut() {
 	var err error
 	ctx := context.Background()
 	user1 := s.GenAndChargeAccounts(1, 1000000)[0]

--- a/e2e/tests/permission_test.go
+++ b/e2e/tests/permission_test.go
@@ -1942,19 +1942,20 @@ func (s *StorageTestSuite) TestExpiredPolicyGCAndRePut() {
 
 	// wait for policy expired
 	time.Sleep(5 * time.Second)
-	// Query the policy which is enforced on bucket and object
-	queryPolicyForAccountResp, err = s.Client.QueryPolicyForAccount(ctx, &storagetypes.QueryPolicyForAccountRequest{
+
+	// query the policy, which is already GC, should get err.
+	_, err = s.Client.QueryPolicyForAccount(ctx, &storagetypes.QueryPolicyForAccountRequest{
 		Resource:         grn1.String(),
 		PrincipalAddress: user1.GetAddr().String(),
 	})
 	s.Require().Error(err)
 
-	// the user should be able to re-put policy for the resource.
+	// the user should be able to re-put policy for the bucket.
 	msgPutBucketPolicy = storagetypes.NewMsgPutPolicy(owner.GetAddr(), types2.NewBucketGRN(bucketName).String(),
 		principal, []*types.Statement{bucketStatement}, nil)
 	s.SendTxBlock(owner, msgPutBucketPolicy)
 
-	// Query the policy which is enforced on bucket
+	// Query the policy which is enforced on bucket.
 	queryPolicyForAccountResp, err = s.Client.QueryPolicyForAccount(ctx, &storagetypes.QueryPolicyForAccountRequest{
 		Resource:         grn1.String(),
 		PrincipalAddress: user1.GetAddr().String(),

--- a/e2e/tests/permission_test.go
+++ b/e2e/tests/permission_test.go
@@ -1965,54 +1965,71 @@ func (s *StorageTestSuite) TestExpiredAccountPolicyGCAndRePut() {
 }
 
 func (s *StorageTestSuite) TestExpiredGroupPolicyGCAndRePut() {
-	var err error
 	ctx := context.Background()
-	user1 := s.GenAndChargeAccounts(1, 1000000)[0]
+	user := s.GenAndChargeAccounts(3, 10000)
+	_, owner, bucketName, bucketId, _, _ := s.createObjectWithVisibility(storagetypes.VISIBILITY_TYPE_PUBLIC_READ)
 
-	_, owner, bucketName, _, _, objectId := s.createObjectWithVisibility(storagetypes.VISIBILITY_TYPE_PUBLIC_READ)
+	// Create Group
+	testGroupName := "testGroup"
+	msgCreateGroup := storagetypes.NewMsgCreateGroup(owner.GetAddr(), testGroupName, "")
+	s.SendTxBlock(owner, msgCreateGroup)
+	membersToAdd := []*storagetypes.MsgGroupMember{
+		{Member: user[1].GetAddr().String()},
+	}
+	membersToDelete := []sdk.AccAddress{}
+	msgUpdateGroupMember := storagetypes.NewMsgUpdateGroupMember(owner.GetAddr(), owner.GetAddr(), testGroupName, membersToAdd, membersToDelete)
+	s.SendTxBlock(owner, msgUpdateGroupMember)
 
-	principal := types.NewPrincipalWithAccount(user1.GetAddr())
+	// Head Group
+	headGroupRequest := storagetypes.QueryHeadGroupRequest{GroupOwner: owner.GetAddr().String(), GroupName: testGroupName}
+	headGroupResponse, err := s.Client.HeadGroup(ctx, &headGroupRequest)
+	s.Require().NoError(err)
+	s.Require().Equal(headGroupResponse.GroupInfo.GroupName, testGroupName)
+	s.Require().True(owner.GetAddr().Equals(sdk.MustAccAddressFromHex(headGroupResponse.GroupInfo.Owner)))
+	s.T().Logf("GroupInfo: %s", headGroupResponse.GetGroupInfo().String())
 
-	// Put bucket policy
+	principal := types.NewPrincipalWithGroupId(headGroupResponse.GroupInfo.Id)
+	// Put bucket policy for group
+	expirationTime := time.Now().Add(5 * time.Second)
+
 	bucketStatement := &types.Statement{
 		Actions: []types.ActionType{types.ACTION_DELETE_BUCKET},
 		Effect:  types.EFFECT_ALLOW,
 	}
-	expirationTime := time.Now().Add(5 * time.Second)
-
 	msgPutBucketPolicy := storagetypes.NewMsgPutPolicy(owner.GetAddr(), types2.NewBucketGRN(bucketName).String(),
 		principal, []*types.Statement{bucketStatement}, &expirationTime)
 	s.SendTxBlock(owner, msgPutBucketPolicy)
 
-	// Query the policy which is enforced on bucket
-	grn1 := types2.NewBucketGRN(bucketName)
-	queryPolicyForAccountResp, err := s.Client.QueryPolicyForAccount(ctx, &storagetypes.QueryPolicyForAccountRequest{
-		Resource:         grn1.String(),
-		PrincipalAddress: user1.GetAddr().String(),
-	})
+	// Query bucket policy for group
+	grn := types2.NewBucketGRN(bucketName)
+	queryPolicyForGroupReq := storagetypes.QueryPolicyForGroupRequest{
+		Resource:         grn.String(),
+		PrincipalGroupId: headGroupResponse.GroupInfo.Id.String(),
+	}
+
+	queryPolicyForGroupResp, err := s.Client.QueryPolicyForGroup(ctx, &queryPolicyForGroupReq)
 	s.Require().NoError(err)
-	s.Require().Equal(objectId, queryPolicyForAccountResp.Policy.ResourceId)
+	s.Require().Equal(bucketId, queryPolicyForGroupResp.Policy.ResourceId)
+	s.Require().Equal(queryPolicyForGroupResp.Policy.ResourceType, resource.RESOURCE_TYPE_BUCKET)
+	s.Require().Equal(types.EFFECT_ALLOW, queryPolicyForGroupResp.Policy.Statements[0].Effect)
+	bucketPolicyId := queryPolicyForGroupResp.Policy.Id
 
 	// wait for policy expired
 	time.Sleep(5 * time.Second)
 
-	// query the policy, which is already GC, should get err.
-	_, err = s.Client.QueryPolicyForAccount(ctx, &storagetypes.QueryPolicyForAccountRequest{
-		Resource:         grn1.String(),
-		PrincipalAddress: user1.GetAddr().String(),
-	})
+	// policy is GC
+	_, err = s.Client.QueryPolicyById(ctx, &storagetypes.QueryPolicyByIdRequest{PolicyId: bucketPolicyId.String()})
 	s.Require().Error(err)
+	s.Require().ErrorContains(err, "No such Policy")
 
 	// the user should be able to re-put policy for the bucket.
 	msgPutBucketPolicy = storagetypes.NewMsgPutPolicy(owner.GetAddr(), types2.NewBucketGRN(bucketName).String(),
 		principal, []*types.Statement{bucketStatement}, nil)
 	s.SendTxBlock(owner, msgPutBucketPolicy)
 
-	// Query the policy which is enforced on bucket.
-	queryPolicyForAccountResp, err = s.Client.QueryPolicyForAccount(ctx, &storagetypes.QueryPolicyForAccountRequest{
-		Resource:         grn1.String(),
-		PrincipalAddress: user1.GetAddr().String(),
-	})
+	queryPolicyForGroupResp, err = s.Client.QueryPolicyForGroup(ctx, &queryPolicyForGroupReq)
 	s.Require().NoError(err)
-	s.Require().Equal(objectId, queryPolicyForAccountResp.Policy.ResourceId)
+	s.Require().Equal(bucketId, queryPolicyForGroupResp.Policy.ResourceId)
+	s.Require().Equal(queryPolicyForGroupResp.Policy.ResourceType, resource.RESOURCE_TYPE_BUCKET)
+	s.Require().Equal(types.EFFECT_ALLOW, queryPolicyForGroupResp.Policy.Statements[0].Effect)
 }

--- a/e2e/tests/permission_test.go
+++ b/e2e/tests/permission_test.go
@@ -1916,7 +1916,7 @@ func (s *StorageTestSuite) TestExpiredAccountPolicyGCAndRePut() {
 	ctx := context.Background()
 	user1 := s.GenAndChargeAccounts(1, 1000000)[0]
 
-	_, owner, bucketName, _, _, objectId := s.createObjectWithVisibility(storagetypes.VISIBILITY_TYPE_PUBLIC_READ)
+	_, owner, bucketName, bucketId, _, _ := s.createObjectWithVisibility(storagetypes.VISIBILITY_TYPE_PUBLIC_READ)
 
 	principal := types.NewPrincipalWithAccount(user1.GetAddr())
 
@@ -1938,7 +1938,7 @@ func (s *StorageTestSuite) TestExpiredAccountPolicyGCAndRePut() {
 		PrincipalAddress: user1.GetAddr().String(),
 	})
 	s.Require().NoError(err)
-	s.Require().Equal(objectId, queryPolicyForAccountResp.Policy.ResourceId)
+	s.Require().Equal(bucketId, queryPolicyForAccountResp.Policy.ResourceId)
 
 	// wait for policy expired
 	time.Sleep(5 * time.Second)
@@ -1961,7 +1961,7 @@ func (s *StorageTestSuite) TestExpiredAccountPolicyGCAndRePut() {
 		PrincipalAddress: user1.GetAddr().String(),
 	})
 	s.Require().NoError(err)
-	s.Require().Equal(objectId, queryPolicyForAccountResp.Policy.ResourceId)
+	s.Require().Equal(bucketId, queryPolicyForAccountResp.Policy.ResourceId)
 }
 
 func (s *StorageTestSuite) TestExpiredGroupPolicyGCAndRePut() {

--- a/x/permission/keeper/keeper.go
+++ b/x/permission/keeper/keeper.go
@@ -537,6 +537,8 @@ func (k Keeper) RemoveExpiredPolicies(ctx sdk.Context) {
 		k.cdc.MustUnmarshal(store.Get(types.GetPolicyByIDKey(policyId)), &policy)
 
 		store.Delete(types.GetPolicyByIDKey(policyId))
+		ctx.EventManager().EmitTypedEvents(&types.EventDeletePolicy{PolicyId: policyId}) //nolint: errcheck
+		count++
 
 		//1. the policy is an account policy, delete policyKey -> policyId.
 		//2. the policy is group policy within a policy group, delete the index in the policy group
@@ -565,8 +567,6 @@ func (k Keeper) RemoveExpiredPolicies(ctx sdk.Context) {
 					}
 				}
 			}
-			ctx.EventManager().EmitTypedEvents(&types.EventDeletePolicy{PolicyId: policyId}) //nolint: errcheck
-			count++
 		}
 	}
 }


### PR DESCRIPTION
### Description

When a account policy is expired, it should be automatically removed from the store with these two mappings:

1.  policyId -> policy
2. policyKey -> policyId

currently `policyKey -> policyId` is missing so that user would fail to re-put policy on the same resource.

When a group policy expired, also need to remove it from the policyGroup. 


### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
