### PR TITLE
fix: emit event when sp status is forced updated

### DIFF
--- a/x/sp/keeper/sp_status.go
+++ b/x/sp/keeper/sp_status.go
@@ -89,6 +89,12 @@ func (k Keeper) ForceUpdateMaintenanceRecords(ctx sdk.Context) {
 						sp.Status = types.STATUS_IN_SERVICE
 						k.SetStorageProvider(ctx, sp)
 						changed = true
+						_ = ctx.EventManager().EmitTypedEvents(&types.EventUpdateStorageProviderStatus{
+							SpId:      sp.Id,
+							SpAddress: sp.OperatorAddress,
+							PreStatus: types.STATUS_IN_MAINTENANCE.String(),
+							NewStatus: types.STATUS_IN_SERVICE.String(),
+						})
 					}
 				}
 			}


### PR DESCRIPTION
### Description

emit event when sp status is forced updated in endblock

### Rationale

for downstream service

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...
