### PR TITLE
feat: shuffle the result of `StorageProviders` query method

### DIFF
--- a/x/sp/keeper/grpc_query.go
+++ b/x/sp/keeper/grpc_query.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"math/rand"
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -30,6 +31,10 @@ func (k Keeper) StorageProviders(goCtx context.Context, req *types.QueryStorageP
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
+
+	rand.Shuffle(len(sps), func(i, j int) {
+		sps[i], sps[j] = sps[j], sps[i]
+	})
 
 	return &types.QueryStorageProvidersResponse{Sps: sps, Pagination: pageRes}, nil
 }


### PR DESCRIPTION
### Description

This pr is to optimize the `StorageProviders` method

### Rationale

To prevent traffic from being concentrated on the first sp, we randomly sorted the returned sps list

### Changes

Notable changes:
* shuffle the result of `StorageProviders` query method before return