### PR TITLE
feat: disable sp exit and bucket migration msg

### DIFF
--- a/app/upgrade.go
+++ b/app/upgrade.go
@@ -4,7 +4,6 @@ import (
 	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
-	"github.com/cosmos/cosmos-sdk/x/gashub/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
 	bridgemoduletypes "github.com/bnb-chain/greenfield/x/bridge/types"
@@ -80,8 +79,17 @@ func (app *App) registerPampasUpgradeHandler() {
 			app.CrossChainKeeper.SetChannelSendPermission(ctx, sdk.ChainID(app.appConfig.CrossChain.DestOpChainId), storagemoduletypes.ObjectChannelId, sdk.ChannelAllow)
 			app.CrossChainKeeper.SetChannelSendPermission(ctx, sdk.ChainID(app.appConfig.CrossChain.DestOpChainId), storagemoduletypes.GroupChannelId, sdk.ChannelAllow)
 
-			// register MsgRejectMigrateBucket Gas param
-			app.GashubKeeper.SetMsgGasParams(ctx, *types.NewMsgGasParamsWithFixedGas("/greenfield.storage.MsgRejectMigrateBucket", 1.2e3))
+			// disable sp exit
+			app.GashubKeeper.DeleteMsgGasParams(ctx, "/greenfield.virtualgroup.MsgSwapOut")
+			app.GashubKeeper.DeleteMsgGasParams(ctx, "/greenfield.virtualgroup.MsgCompleteSwapOut")
+			app.GashubKeeper.DeleteMsgGasParams(ctx, "/greenfield.virtualgroup.MsgCancelSwapOut")
+			app.GashubKeeper.DeleteMsgGasParams(ctx, "/greenfield.virtualgroup.MsgStorageProviderExit")
+			app.GashubKeeper.DeleteMsgGasParams(ctx, "/greenfield.virtualgroup.MsgCompleteStorageProviderExit")
+
+			// disable bucket migration.
+			app.GashubKeeper.DeleteMsgGasParams(ctx, "/greenfield.storage.MsgMigrateBucket")
+			app.GashubKeeper.DeleteMsgGasParams(ctx, "/greenfield.storage.MsgCancelMigrateBucket")
+			app.GashubKeeper.DeleteMsgGasParams(ctx, "/greenfield.storage.MsgCompleteMigrateBucket")
 
 			return app.mm.RunMigrations(ctx, app.configurator, fromVM)
 		})

--- a/e2e/tests/sp_test.go
+++ b/e2e/tests/sp_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/bnb-chain/greenfield/sdk/types"
 	"github.com/bnb-chain/greenfield/testutil/sample"
 	sptypes "github.com/bnb-chain/greenfield/x/sp/types"
-	virtualgroupmoduletypes "github.com/bnb-chain/greenfield/x/virtualgroup/types"
 )
 
 type StorageProviderTestSuite struct {
@@ -38,39 +37,39 @@ func (s *StorageProviderTestSuite) SetupSuite() {
 func (s *StorageProviderTestSuite) SetupTest() {
 }
 
-func (s *StorageProviderTestSuite) TestCreateStorageProvider() {
-	// Create a New SP
-	sp := s.BaseSuite.CreateNewStorageProvider()
-
-	// query sp by id
-	querySPResp, err := s.Client.StorageProvider(context.Background(), &sptypes.QueryStorageProviderRequest{
-		Id: sp.Info.Id,
-	})
-	s.Require().NoError(err)
-	s.Require().Equal(querySPResp.StorageProvider, querySPResp.StorageProvider)
-
-	// sp exit
-	msgSPExit := virtualgroupmoduletypes.MsgStorageProviderExit{
-		StorageProvider: sp.OperatorKey.GetAddr().String(),
-	}
-	s.SendTxBlock(sp.OperatorKey, &msgSPExit)
-
-	// 9 query sp status
-	querySPResp2, err := s.Client.StorageProvider(context.Background(), &sptypes.QueryStorageProviderRequest{Id: sp.Info.Id})
-	s.Require().NoError(err)
-	s.Require().Equal(querySPResp2.StorageProvider.Status, sptypes.STATUS_GRACEFUL_EXITING)
-
-	// 10 complete sp exit
-	msgCompleteSPExit := virtualgroupmoduletypes.MsgCompleteStorageProviderExit{
-		StorageProvider: sp.OperatorKey.GetAddr().String(),
-	}
-
-	s.SendTxBlock(sp.OperatorKey, &msgCompleteSPExit)
-
-	// 10 query sp
-	_, err = s.Client.StorageProvider(context.Background(), &sptypes.QueryStorageProviderRequest{Id: sp.Info.Id})
-	s.Require().Error(err)
-}
+//func (s *StorageProviderTestSuite) TestCreateStorageProvider() {
+//	// Create a New SP
+//	sp := s.BaseSuite.CreateNewStorageProvider()
+//
+//	// query sp by id
+//	querySPResp, err := s.Client.StorageProvider(context.Background(), &sptypes.QueryStorageProviderRequest{
+//		Id: sp.Info.Id,
+//	})
+//	s.Require().NoError(err)
+//	s.Require().Equal(querySPResp.StorageProvider, querySPResp.StorageProvider)
+//
+//	// sp exit
+//	msgSPExit := virtualgroupmoduletypes.MsgStorageProviderExit{
+//		StorageProvider: sp.OperatorKey.GetAddr().String(),
+//	}
+//	s.SendTxBlock(sp.OperatorKey, &msgSPExit)
+//
+//	// 9 query sp status
+//	querySPResp2, err := s.Client.StorageProvider(context.Background(), &sptypes.QueryStorageProviderRequest{Id: sp.Info.Id})
+//	s.Require().NoError(err)
+//	s.Require().Equal(querySPResp2.StorageProvider.Status, sptypes.STATUS_GRACEFUL_EXITING)
+//
+//	// 10 complete sp exit
+//	msgCompleteSPExit := virtualgroupmoduletypes.MsgCompleteStorageProviderExit{
+//		StorageProvider: sp.OperatorKey.GetAddr().String(),
+//	}
+//
+//	s.SendTxBlock(sp.OperatorKey, &msgCompleteSPExit)
+//
+//	// 10 query sp
+//	_, err = s.Client.StorageProvider(context.Background(), &sptypes.QueryStorageProviderRequest{Id: sp.Info.Id})
+//	s.Require().Error(err)
+//}
 
 func (s *StorageProviderTestSuite) TestEditStorageProvider() {
 	ctx := context.Background()

--- a/e2e/tests/storage_bill_test.go
+++ b/e2e/tests/storage_bill_test.go
@@ -1746,422 +1746,422 @@ func (s *PaymentTestSuite) TestStorageBill_UpdatePaymentAddress() {
 	s.SendTxBlockWithExpectErrorString(msgUpdateBucketInfo, user, "apply user flows list failed")
 }
 
-func (s *PaymentTestSuite) TestStorageBill_MigrateBucket() {
-	var err error
-	ctx := context.Background()
-	primarySP := s.PickStorageProvider()
-	gvg, found := primarySP.GetFirstGlobalVirtualGroup()
-	s.Require().True(found)
-	queryFamilyResponse, err := s.Client.GlobalVirtualGroupFamily(ctx, &virtualgrouptypes.QueryGlobalVirtualGroupFamilyRequest{
-		FamilyId: gvg.FamilyId,
-	})
-	s.Require().NoError(err)
-	family := queryFamilyResponse.GlobalVirtualGroupFamily
-	user := s.GenAndChargeAccounts(1, 10)[0]
+//func (s *PaymentTestSuite) TestStorageBill_MigrateBucket() {
+//	var err error
+//	ctx := context.Background()
+//	primarySP := s.PickStorageProvider()
+//	gvg, found := primarySP.GetFirstGlobalVirtualGroup()
+//	s.Require().True(found)
+//	queryFamilyResponse, err := s.Client.GlobalVirtualGroupFamily(ctx, &virtualgrouptypes.QueryGlobalVirtualGroupFamilyRequest{
+//		FamilyId: gvg.FamilyId,
+//	})
+//	s.Require().NoError(err)
+//	family := queryFamilyResponse.GlobalVirtualGroupFamily
+//	user := s.GenAndChargeAccounts(1, 10)[0]
+//
+//	streamAddresses := []string{
+//		user.GetAddr().String(),
+//		family.VirtualPaymentAddress,
+//		gvg.VirtualPaymentAddress,
+//		paymenttypes.ValidatorTaxPoolAddress.String(),
+//	}
+//
+//	streamAddresses0 := streamAddresses
+//	paymentParams, err := s.Client.PaymentQueryClient.Params(ctx, &paymenttypes.QueryParamsRequest{})
+//	s.T().Logf("paymentParams %s, err: %v", paymentParams, err)
+//	s.Require().NoError(err)
+//
+//	bucketName := s.createBucket(primarySP, gvg, user, 0)
+//	bucketInfo, err := s.Client.HeadBucket(context.Background(), &storagetypes.QueryHeadBucketRequest{
+//		BucketName: bucketName,
+//	})
+//	s.Require().NoError(err)
+//
+//	// create object with none zero payload size
+//	streamRecordsBefore := s.getStreamRecords(streamAddresses)
+//	_, _, objectName, objectId, checksums, payloadSize := s.createObject(user, bucketName, false)
+//
+//	// assertions
+//	streamRecordsAfter := s.getStreamRecords(streamAddresses)
+//	s.Require().Equal(streamRecordsAfter.User.StaticBalance, sdkmath.ZeroInt())
+//	lockFee := s.calculateLockFee(bucketName, objectName, payloadSize)
+//	s.Require().Equal(streamRecordsAfter.User.LockBalance.Sub(streamRecordsBefore.User.LockBalance), lockFee)
+//	s.Require().Equal(streamRecordsAfter.User.NetflowRate.Sub(streamRecordsBefore.User.NetflowRate).Int64(), int64(0))
+//	s.Require().Equal(streamRecordsAfter.GVGFamily.NetflowRate.Sub(streamRecordsBefore.GVGFamily.NetflowRate).Int64(), int64(0))
+//	s.Require().Equal(streamRecordsAfter.GVG.NetflowRate.Sub(streamRecordsBefore.GVG.NetflowRate).Int64(), int64(0))
+//	s.Require().Equal(streamRecordsAfter.Tax.NetflowRate.Sub(streamRecordsBefore.Tax.NetflowRate).Int64(), int64(0))
+//
+//	// case: seal object without price change
+//	s.sealObject(primarySP, gvg, bucketName, objectName, objectId, checksums)
+//
+//	// assertions
+//	streamRecordsAfter = s.getStreamRecords(streamAddresses)
+//	gvgFamilyRate, gvgRate, taxRate, userTotalRate := s.calculateStorageRates(bucketName, objectName, payloadSize, 0)
+//	s.T().Logf("gvgFamilyRate: %v, gvgRate: %v, taxRate: %v, userTotalRate: %v", gvgFamilyRate, gvgRate, taxRate, userTotalRate)
+//	s.Require().Equal(streamRecordsAfter.User.StaticBalance, sdkmath.ZeroInt())
+//	s.Require().Equal(streamRecordsAfter.User.LockBalance, sdkmath.ZeroInt())
+//	s.Require().Equal(streamRecordsAfter.User.NetflowRate.Sub(streamRecordsBefore.User.NetflowRate), userTotalRate.Neg())
+//	s.Require().Equal(streamRecordsAfter.GVGFamily.NetflowRate.Sub(streamRecordsBefore.GVGFamily.NetflowRate), gvgFamilyRate)
+//	s.Require().Equal(streamRecordsAfter.GVG.NetflowRate.Sub(streamRecordsBefore.GVG.NetflowRate), gvgRate)
+//	s.Require().Equal(streamRecordsAfter.Tax.NetflowRate.Sub(streamRecordsBefore.Tax.NetflowRate), taxRate)
+//	taxRate0 := taxRate
+//
+//	dstPrimarySP := s.CreateNewStorageProvider()
+//
+//	// update price
+//	priceRes, err := s.Client.QueryGlobalSpStorePriceByTime(ctx, &sptypes.QueryGlobalSpStorePriceByTimeRequest{
+//		Timestamp: 0,
+//	})
+//	s.Require().NoError(err)
+//	s.T().Log("price", priceRes.GlobalSpStorePrice)
+//
+//	s.updateGlobalSpPrice(priceRes.GlobalSpStorePrice.ReadPrice.MulInt64(2), priceRes.GlobalSpStorePrice.PrimaryStorePrice.MulInt64(10))
+//	defer s.updateGlobalSpPrice(priceRes.GlobalSpStorePrice.ReadPrice, priceRes.GlobalSpStorePrice.PrimaryStorePrice)
+//
+//	_, secondarySPIDs := s.GetSecondarySP(dstPrimarySP, primarySP)
+//	gvgID, _ := s.BaseSuite.CreateGlobalVirtualGroup(dstPrimarySP, 0, secondarySPIDs, 1)
+//	gvgResp, err := s.Client.VirtualGroupQueryClient.GlobalVirtualGroup(context.Background(), &virtualgrouptypes.QueryGlobalVirtualGroupRequest{
+//		GlobalVirtualGroupId: gvgID,
+//	})
+//	s.Require().NoError(err)
+//	dstGVG := gvgResp.GlobalVirtualGroup
+//	s.Require().True(found)
+//
+//	queryFamilyResponse, err = s.Client.GlobalVirtualGroupFamily(ctx, &virtualgrouptypes.QueryGlobalVirtualGroupFamilyRequest{
+//		FamilyId: dstGVG.FamilyId,
+//	})
+//	s.Require().NoError(err)
+//	family = queryFamilyResponse.GlobalVirtualGroupFamily
+//	streamAddresses = []string{
+//		user.GetAddr().String(),
+//		family.VirtualPaymentAddress,
+//		dstGVG.VirtualPaymentAddress,
+//		paymenttypes.ValidatorTaxPoolAddress.String(),
+//	}
+//	fundAddress := primarySP.FundingKey.GetAddr()
+//	streamRecordsBefore = s.getStreamRecords(streamAddresses)
+//
+//	queryBalanceRequest := banktypes.QueryBalanceRequest{Denom: s.Config.Denom, Address: fundAddress.String()}
+//	fundBalanceBefore, err := s.Client.BankQueryClient.Balance(context.Background(), &queryBalanceRequest)
+//	s.Require().NoError(err)
+//
+//	// MigrationBucket
+//	msgMigrationBucket, msgCompleteMigrationBucket := s.NewMigrateBucket(primarySP, dstPrimarySP, user, bucketName, gvg.FamilyId, dstGVG.FamilyId, bucketInfo.BucketInfo.Id)
+//	s.SendTxBlock(user, msgMigrationBucket)
+//	s.Require().NoError(err)
+//
+//	// complete MigrationBucket
+//	s.SendTxBlock(dstPrimarySP.OperatorKey, msgCompleteMigrationBucket)
+//	streamRecordsAfter = s.getStreamRecords(streamAddresses)
+//	fundBalanceAfter, err := s.Client.BankQueryClient.Balance(context.Background(), &queryBalanceRequest)
+//	s.Require().NoError(err)
+//	s.T().Logf("fundBalanceBefore: %v, fundBalanceAfter: %v, diff: %v", fundBalanceBefore, fundBalanceAfter, fundBalanceAfter.Balance.Amount.Sub(fundBalanceBefore.Balance.Amount))
+//	s.Require().True(fundBalanceAfter.Balance.Amount.Sub(fundBalanceBefore.Balance.Amount).GT(sdkmath.NewInt(0)), "migrate sp fund address need settle")
+//	gvgFamilyRate, gvgRate, taxRate, userTotalRate = s.calculateStorageRates(bucketName, objectName, payloadSize, time.Now().Unix())
+//	s.T().Logf("gvgFamilyRate: %v, gvgRate: %v, taxRate: %v, userTotalRate: %v", gvgFamilyRate, gvgRate, taxRate, userTotalRate)
+//	s.T().Logf("NetflowRate: %v, userTotalRate: %v, actual taxRate diff: %v, expect taxRate diff: %v", streamRecordsAfter.User.NetflowRate.Neg(), userTotalRate.Neg(), streamRecordsAfter.Tax.NetflowRate.Sub(streamRecordsBefore.Tax.NetflowRate), taxRate.Sub(taxRate0))
+//
+//	s.Require().Equal(streamRecordsAfter.User.StaticBalance, sdkmath.ZeroInt())
+//	s.Require().Equal(streamRecordsAfter.User.LockBalance, sdkmath.ZeroInt())
+//	s.Require().Equal(streamRecordsAfter.GVGFamily.NetflowRate.Sub(streamRecordsBefore.GVGFamily.NetflowRate), gvgFamilyRate)
+//	s.Require().Equal(streamRecordsAfter.GVG.NetflowRate.Sub(streamRecordsBefore.GVG.NetflowRate), gvgRate)
+//	// tax rate diff
+//	s.Require().Equal(streamRecordsAfter.Tax.NetflowRate.Sub(streamRecordsBefore.Tax.NetflowRate), taxRate.Sub(taxRate0))
+//	s.Require().Equal(streamRecordsAfter.User.NetflowRate.Neg(), userTotalRate.Abs())
+//
+//	// set price
+//	s.updateGlobalSpPrice(priceRes.GlobalSpStorePrice.ReadPrice.MulInt64(120), priceRes.GlobalSpStorePrice.PrimaryStorePrice.MulInt64(5000))
+//
+//	queryBalanceRequest.Address = dstPrimarySP.FundingKey.GetAddr().String()
+//	fundBalanceBefore, err = s.Client.BankQueryClient.Balance(context.Background(), &queryBalanceRequest)
+//	s.Require().NoError(err)
+//	streamRecordsBefore = s.getStreamRecords(streamAddresses0)
+//	// send msgMigrationBucket
+//	msgMigrationBucket, msgCompleteMigrationBucket = s.NewMigrateBucket(dstPrimarySP, primarySP, user, bucketName, dstGVG.FamilyId, gvg.FamilyId, bucketInfo.BucketInfo.Id)
+//
+//	s.SendTxBlock(user, msgMigrationBucket)
+//	s.Require().NoError(err)
+//	s.reduceBNBBalance(user, s.Validator, sdkmath.NewIntWithDecimal(1, 1))
+//
+//	s.SendTxBlockWithExpectErrorString(msgCompleteMigrationBucket, primarySP.OperatorKey, "apply stream record changes for user failed")
+//
+//	s.updateGlobalSpPrice(priceRes.GlobalSpStorePrice.ReadPrice.MulInt64(10), priceRes.GlobalSpStorePrice.PrimaryStorePrice.MulInt64(10))
+//	readPrice, primaryPrice, secondaryPrice := s.getPrices(time.Now().Unix())
+//	s.T().Logf("readPrice: %v, primaryPrice: %v,secondaryPrice: %v", readPrice, primaryPrice, secondaryPrice)
+//
+//	s.transferBNB(s.Validator, user, sdkmath.NewIntWithDecimal(10000, 18))
+//
+//	s.SendTxBlock(primarySP.OperatorKey, msgCompleteMigrationBucket)
+//	streamRecordsAfter = s.getStreamRecords(streamAddresses0)
+//	fundBalanceAfter, err = s.Client.BankQueryClient.Balance(context.Background(), &queryBalanceRequest)
+//	s.Require().NoError(err)
+//	s.T().Logf("fundBalanceBefore: %v, fundBalanceAfter: %v, diff: %v", fundBalanceBefore, fundBalanceAfter, fundBalanceAfter.Balance.Amount.Sub(fundBalanceBefore.Balance.Amount))
+//	s.Require().True(fundBalanceAfter.Balance.Amount.Sub(fundBalanceBefore.Balance.Amount).GT(sdkmath.NewInt(0)), "migrate sp fund address need settle")
+//	taxRate1 := taxRate
+//	gvgFamilyRate, gvgRate, taxRate, userTotalRate = s.calculateStorageRates(bucketName, objectName, payloadSize, time.Now().Unix())
+//	s.T().Logf("gvgFamilyRate: %v, gvgRate: %v, taxRate: %v, userTotalRate: %v", gvgFamilyRate, gvgRate, taxRate, userTotalRate)
+//	s.T().Logf("NetflowRate: %v, userTotalRate: %v, actual taxRate diff: %v, expect taxRate diff: %v", streamRecordsAfter.User.NetflowRate.Neg(), userTotalRate.Neg(), streamRecordsAfter.Tax.NetflowRate.Sub(streamRecordsBefore.Tax.NetflowRate), taxRate.Sub(taxRate0))
+//
+//	s.Require().Equal(streamRecordsAfter.User.StaticBalance, sdkmath.ZeroInt())
+//	s.Require().Equal(streamRecordsAfter.User.LockBalance, sdkmath.ZeroInt())
+//	s.Require().Equal(streamRecordsAfter.GVGFamily.NetflowRate.Sub(streamRecordsBefore.GVGFamily.NetflowRate), gvgFamilyRate)
+//	s.Require().Equal(streamRecordsAfter.GVG.NetflowRate.Sub(streamRecordsBefore.GVG.NetflowRate), gvgRate)
+//	// tax rate diff
+//	s.Require().Equal(streamRecordsAfter.Tax.NetflowRate.Sub(streamRecordsBefore.Tax.NetflowRate), taxRate.Sub(taxRate1))
+//	s.Require().Equal(streamRecordsAfter.User.NetflowRate.Neg(), userTotalRate.Abs())
+//}
 
-	streamAddresses := []string{
-		user.GetAddr().String(),
-		family.VirtualPaymentAddress,
-		gvg.VirtualPaymentAddress,
-		paymenttypes.ValidatorTaxPoolAddress.String(),
-	}
+//func (s *PaymentTestSuite) TestStorageBill_MigrateBucket_LockedFee_ThenDiscontinueBucket() {
+//	var err error
+//	ctx := context.Background()
+//	primarySP := s.PickStorageProvider()
+//	gvg, found := primarySP.GetFirstGlobalVirtualGroup()
+//	s.Require().True(found)
+//	queryFamilyResponse, err := s.Client.GlobalVirtualGroupFamily(ctx, &virtualgrouptypes.QueryGlobalVirtualGroupFamilyRequest{
+//		FamilyId: gvg.FamilyId,
+//	})
+//	s.Require().NoError(err)
+//	family := queryFamilyResponse.GlobalVirtualGroupFamily
+//	user := s.GenAndChargeAccounts(1, 10)[0]
+//
+//	streamAddresses := []string{
+//		user.GetAddr().String(),
+//		family.VirtualPaymentAddress,
+//		gvg.VirtualPaymentAddress,
+//		paymenttypes.ValidatorTaxPoolAddress.String(),
+//	}
+//
+//	paymentParams, err := s.Client.PaymentQueryClient.Params(ctx, &paymenttypes.QueryParamsRequest{})
+//	s.T().Logf("paymentParams %s, err: %v", paymentParams, err)
+//	s.Require().NoError(err)
+//
+//	bucketName := s.createBucket(primarySP, gvg, user, 0)
+//	bucketInfo, err := s.Client.HeadBucket(context.Background(), &storagetypes.QueryHeadBucketRequest{
+//		BucketName: bucketName,
+//	})
+//	s.Require().NoError(err)
+//
+//	// create object with none zero payload size
+//	streamRecordsBefore := s.getStreamRecords(streamAddresses)
+//	_, _, objectName, objectId, checksums, payloadSize := s.createObject(user, bucketName, false)
+//
+//	// assertions
+//	streamRecordsAfter := s.getStreamRecords(streamAddresses)
+//	s.Require().Equal(streamRecordsAfter.User.StaticBalance, sdkmath.ZeroInt())
+//	lockFee := s.calculateLockFee(bucketName, objectName, payloadSize)
+//	s.Require().Equal(streamRecordsAfter.User.LockBalance.Sub(streamRecordsBefore.User.LockBalance), lockFee)
+//	s.Require().Equal(streamRecordsAfter.User.NetflowRate.Sub(streamRecordsBefore.User.NetflowRate).Int64(), int64(0))
+//	s.Require().Equal(streamRecordsAfter.GVGFamily.NetflowRate.Sub(streamRecordsBefore.GVGFamily.NetflowRate).Int64(), int64(0))
+//	s.Require().Equal(streamRecordsAfter.GVG.NetflowRate.Sub(streamRecordsBefore.GVG.NetflowRate).Int64(), int64(0))
+//	s.Require().Equal(streamRecordsAfter.Tax.NetflowRate.Sub(streamRecordsBefore.Tax.NetflowRate).Int64(), int64(0))
+//
+//	// case: seal object
+//	s.sealObject(primarySP, gvg, bucketName, objectName, objectId, checksums)
+//
+//	// assertions
+//	streamRecordsAfter = s.getStreamRecords(streamAddresses)
+//	gvgFamilyRate, gvgRate, taxRate, userTotalRate := s.calculateStorageRates(bucketName, objectName, payloadSize, 0)
+//	s.T().Logf("gvgFamilyRate: %v, gvgRate: %v, taxRate: %v, userTotalRate: %v", gvgFamilyRate, gvgRate, taxRate, userTotalRate)
+//	s.Require().Equal(streamRecordsAfter.User.StaticBalance, sdkmath.ZeroInt())
+//	s.Require().Equal(streamRecordsAfter.User.LockBalance, sdkmath.ZeroInt())
+//	s.Require().Equal(streamRecordsAfter.User.NetflowRate.Sub(streamRecordsBefore.User.NetflowRate), userTotalRate.Neg())
+//	s.Require().Equal(streamRecordsAfter.GVGFamily.NetflowRate.Sub(streamRecordsBefore.GVGFamily.NetflowRate), gvgFamilyRate)
+//	s.Require().Equal(streamRecordsAfter.GVG.NetflowRate.Sub(streamRecordsBefore.GVG.NetflowRate), gvgRate)
+//	s.Require().Equal(streamRecordsAfter.Tax.NetflowRate.Sub(streamRecordsBefore.Tax.NetflowRate), taxRate)
+//	taxRate0 := taxRate
+//	dstPrimarySP := s.CreateNewStorageProvider()
+//
+//	// create a new object without seal
+//	s.createObject(user, bucketName, false)
+//
+//	// update price after lock
+//	priceRes, err := s.Client.QueryGlobalSpStorePriceByTime(ctx, &sptypes.QueryGlobalSpStorePriceByTimeRequest{
+//		Timestamp: 0,
+//	})
+//	s.Require().NoError(err)
+//	s.T().Log("price", priceRes.GlobalSpStorePrice)
+//
+//	s.updateGlobalSpPrice(priceRes.GlobalSpStorePrice.ReadPrice, priceRes.GlobalSpStorePrice.PrimaryStorePrice.MulInt64(10000))
+//	defer s.updateGlobalSpPrice(priceRes.GlobalSpStorePrice.ReadPrice, priceRes.GlobalSpStorePrice.PrimaryStorePrice)
+//
+//	_, secondarySPIDs := s.GetSecondarySP(dstPrimarySP, primarySP)
+//	gvgID, _ := s.BaseSuite.CreateGlobalVirtualGroup(dstPrimarySP, 0, secondarySPIDs, 1)
+//	gvgResp, err := s.Client.VirtualGroupQueryClient.GlobalVirtualGroup(context.Background(), &virtualgrouptypes.QueryGlobalVirtualGroupRequest{
+//		GlobalVirtualGroupId: gvgID,
+//	})
+//	s.Require().NoError(err)
+//	dstGVG := gvgResp.GlobalVirtualGroup
+//	s.Require().True(found)
+//
+//	queryFamilyResponse, err = s.Client.GlobalVirtualGroupFamily(ctx, &virtualgrouptypes.QueryGlobalVirtualGroupFamilyRequest{
+//		FamilyId: dstGVG.FamilyId,
+//	})
+//	s.Require().NoError(err)
+//	family = queryFamilyResponse.GlobalVirtualGroupFamily
+//	streamAddresses = []string{
+//		user.GetAddr().String(),
+//		family.VirtualPaymentAddress,
+//		dstGVG.VirtualPaymentAddress,
+//		paymenttypes.ValidatorTaxPoolAddress.String(),
+//	}
+//	fundAddress := primarySP.FundingKey.GetAddr()
+//	streamRecordsBefore = s.getStreamRecords(streamAddresses)
+//
+//	queryBalanceRequest := banktypes.QueryBalanceRequest{Denom: s.Config.Denom, Address: fundAddress.String()}
+//	fundBalanceBefore, err := s.Client.BankQueryClient.Balance(context.Background(), &queryBalanceRequest)
+//	s.Require().NoError(err)
+//
+//	// MigrateBucket
+//	msgMigrateBucket, msgCompleteMigrateBucket := s.NewMigrateBucket(primarySP, dstPrimarySP, user, bucketName, gvg.FamilyId, dstGVG.FamilyId, bucketInfo.BucketInfo.Id)
+//	s.SendTxBlock(user, msgMigrateBucket)
+//	s.Require().NoError(err)
+//
+//	// complete MigrateBucket
+//	s.SendTxBlock(dstPrimarySP.OperatorKey, msgCompleteMigrateBucket)
+//	streamRecordsAfter = s.getStreamRecords(streamAddresses)
+//	fundBalanceAfter, err := s.Client.BankQueryClient.Balance(context.Background(), &queryBalanceRequest)
+//	s.Require().NoError(err)
+//	s.T().Logf("fundBalanceBefore: %v, fundBalanceAfter: %v, diff: %v", fundBalanceBefore, fundBalanceAfter, fundBalanceAfter.Balance.Amount.Sub(fundBalanceBefore.Balance.Amount))
+//	s.Require().True(fundBalanceAfter.Balance.Amount.Sub(fundBalanceBefore.Balance.Amount).GT(sdkmath.NewInt(0)), "migrate sp fund address need settle")
+//	gvgFamilyRate, gvgRate, taxRate, userTotalRate = s.calculateStorageRates(bucketName, objectName, payloadSize, time.Now().Unix())
+//	s.T().Logf("gvgFamilyRate: %v, gvgRate: %v, taxRate: %v, userTotalRate: %v", gvgFamilyRate, gvgRate, taxRate, userTotalRate)
+//	s.T().Logf("NetflowRate: %v, userTotalRate: %v, actual taxRate diff: %v, expect taxRate diff: %v", streamRecordsAfter.User.NetflowRate.Neg(), userTotalRate.Neg(), streamRecordsAfter.Tax.NetflowRate.Sub(streamRecordsBefore.Tax.NetflowRate), taxRate.Sub(taxRate0))
+//
+//	s.Require().Equal(streamRecordsAfter.User.StaticBalance, sdkmath.ZeroInt())
+//	s.Require().Equal(streamRecordsAfter.GVGFamily.NetflowRate.Sub(streamRecordsBefore.GVGFamily.NetflowRate), gvgFamilyRate)
+//	s.Require().Equal(streamRecordsAfter.GVG.NetflowRate.Sub(streamRecordsBefore.GVG.NetflowRate), gvgRate)
+//	// tax rate diff
+//	s.Require().Equal(streamRecordsAfter.Tax.NetflowRate.Sub(streamRecordsBefore.Tax.NetflowRate), taxRate.Sub(taxRate0))
+//	s.Require().Equal(streamRecordsAfter.User.NetflowRate.Neg(), userTotalRate.Abs())
+//
+//	// force delete bucket
+//	headBucketResp, _ := s.Client.HeadBucket(ctx, &storagetypes.QueryHeadBucketRequest{BucketName: bucketName})
+//	s.T().Log("headBucketResp", core.YamlString(headBucketResp))
+//	msgDiscontinueBucket := storagetypes.NewMsgDiscontinueBucket(dstPrimarySP.GcKey.GetAddr(), bucketName, "test")
+//	txRes := s.SendTxBlock(dstPrimarySP.GcKey, msgDiscontinueBucket)
+//	deleteAt := filterDiscontinueBucketEventFromTx(txRes).DeleteAt
+//
+//	for {
+//		time.Sleep(200 * time.Millisecond)
+//		statusRes, err := s.TmClient.TmClient.Status(context.Background())
+//		s.Require().NoError(err)
+//		blockTime := statusRes.SyncInfo.LatestBlockTime.Unix()
+//
+//		s.T().Logf("current blockTime: %d, delete blockTime: %d", blockTime, deleteAt)
+//
+//		if blockTime > deleteAt {
+//			break
+//		}
+//	}
+//
+//	_, err = s.Client.HeadBucket(ctx, &storagetypes.QueryHeadBucketRequest{BucketName: bucketName})
+//	s.Require().ErrorContains(err, "No such bucket")
+//}
 
-	streamAddresses0 := streamAddresses
-	paymentParams, err := s.Client.PaymentQueryClient.Params(ctx, &paymenttypes.QueryParamsRequest{})
-	s.T().Logf("paymentParams %s, err: %v", paymentParams, err)
-	s.Require().NoError(err)
-
-	bucketName := s.createBucket(primarySP, gvg, user, 0)
-	bucketInfo, err := s.Client.HeadBucket(context.Background(), &storagetypes.QueryHeadBucketRequest{
-		BucketName: bucketName,
-	})
-	s.Require().NoError(err)
-
-	// create object with none zero payload size
-	streamRecordsBefore := s.getStreamRecords(streamAddresses)
-	_, _, objectName, objectId, checksums, payloadSize := s.createObject(user, bucketName, false)
-
-	// assertions
-	streamRecordsAfter := s.getStreamRecords(streamAddresses)
-	s.Require().Equal(streamRecordsAfter.User.StaticBalance, sdkmath.ZeroInt())
-	lockFee := s.calculateLockFee(bucketName, objectName, payloadSize)
-	s.Require().Equal(streamRecordsAfter.User.LockBalance.Sub(streamRecordsBefore.User.LockBalance), lockFee)
-	s.Require().Equal(streamRecordsAfter.User.NetflowRate.Sub(streamRecordsBefore.User.NetflowRate).Int64(), int64(0))
-	s.Require().Equal(streamRecordsAfter.GVGFamily.NetflowRate.Sub(streamRecordsBefore.GVGFamily.NetflowRate).Int64(), int64(0))
-	s.Require().Equal(streamRecordsAfter.GVG.NetflowRate.Sub(streamRecordsBefore.GVG.NetflowRate).Int64(), int64(0))
-	s.Require().Equal(streamRecordsAfter.Tax.NetflowRate.Sub(streamRecordsBefore.Tax.NetflowRate).Int64(), int64(0))
-
-	// case: seal object without price change
-	s.sealObject(primarySP, gvg, bucketName, objectName, objectId, checksums)
-
-	// assertions
-	streamRecordsAfter = s.getStreamRecords(streamAddresses)
-	gvgFamilyRate, gvgRate, taxRate, userTotalRate := s.calculateStorageRates(bucketName, objectName, payloadSize, 0)
-	s.T().Logf("gvgFamilyRate: %v, gvgRate: %v, taxRate: %v, userTotalRate: %v", gvgFamilyRate, gvgRate, taxRate, userTotalRate)
-	s.Require().Equal(streamRecordsAfter.User.StaticBalance, sdkmath.ZeroInt())
-	s.Require().Equal(streamRecordsAfter.User.LockBalance, sdkmath.ZeroInt())
-	s.Require().Equal(streamRecordsAfter.User.NetflowRate.Sub(streamRecordsBefore.User.NetflowRate), userTotalRate.Neg())
-	s.Require().Equal(streamRecordsAfter.GVGFamily.NetflowRate.Sub(streamRecordsBefore.GVGFamily.NetflowRate), gvgFamilyRate)
-	s.Require().Equal(streamRecordsAfter.GVG.NetflowRate.Sub(streamRecordsBefore.GVG.NetflowRate), gvgRate)
-	s.Require().Equal(streamRecordsAfter.Tax.NetflowRate.Sub(streamRecordsBefore.Tax.NetflowRate), taxRate)
-	taxRate0 := taxRate
-
-	dstPrimarySP := s.CreateNewStorageProvider()
-
-	// update price
-	priceRes, err := s.Client.QueryGlobalSpStorePriceByTime(ctx, &sptypes.QueryGlobalSpStorePriceByTimeRequest{
-		Timestamp: 0,
-	})
-	s.Require().NoError(err)
-	s.T().Log("price", priceRes.GlobalSpStorePrice)
-
-	s.updateGlobalSpPrice(priceRes.GlobalSpStorePrice.ReadPrice.MulInt64(2), priceRes.GlobalSpStorePrice.PrimaryStorePrice.MulInt64(10))
-	defer s.updateGlobalSpPrice(priceRes.GlobalSpStorePrice.ReadPrice, priceRes.GlobalSpStorePrice.PrimaryStorePrice)
-
-	_, secondarySPIDs := s.GetSecondarySP(dstPrimarySP, primarySP)
-	gvgID, _ := s.BaseSuite.CreateGlobalVirtualGroup(dstPrimarySP, 0, secondarySPIDs, 1)
-	gvgResp, err := s.Client.VirtualGroupQueryClient.GlobalVirtualGroup(context.Background(), &virtualgrouptypes.QueryGlobalVirtualGroupRequest{
-		GlobalVirtualGroupId: gvgID,
-	})
-	s.Require().NoError(err)
-	dstGVG := gvgResp.GlobalVirtualGroup
-	s.Require().True(found)
-
-	queryFamilyResponse, err = s.Client.GlobalVirtualGroupFamily(ctx, &virtualgrouptypes.QueryGlobalVirtualGroupFamilyRequest{
-		FamilyId: dstGVG.FamilyId,
-	})
-	s.Require().NoError(err)
-	family = queryFamilyResponse.GlobalVirtualGroupFamily
-	streamAddresses = []string{
-		user.GetAddr().String(),
-		family.VirtualPaymentAddress,
-		dstGVG.VirtualPaymentAddress,
-		paymenttypes.ValidatorTaxPoolAddress.String(),
-	}
-	fundAddress := primarySP.FundingKey.GetAddr()
-	streamRecordsBefore = s.getStreamRecords(streamAddresses)
-
-	queryBalanceRequest := banktypes.QueryBalanceRequest{Denom: s.Config.Denom, Address: fundAddress.String()}
-	fundBalanceBefore, err := s.Client.BankQueryClient.Balance(context.Background(), &queryBalanceRequest)
-	s.Require().NoError(err)
-
-	// MigrationBucket
-	msgMigrationBucket, msgCompleteMigrationBucket := s.NewMigrateBucket(primarySP, dstPrimarySP, user, bucketName, gvg.FamilyId, dstGVG.FamilyId, bucketInfo.BucketInfo.Id)
-	s.SendTxBlock(user, msgMigrationBucket)
-	s.Require().NoError(err)
-
-	// complete MigrationBucket
-	s.SendTxBlock(dstPrimarySP.OperatorKey, msgCompleteMigrationBucket)
-	streamRecordsAfter = s.getStreamRecords(streamAddresses)
-	fundBalanceAfter, err := s.Client.BankQueryClient.Balance(context.Background(), &queryBalanceRequest)
-	s.Require().NoError(err)
-	s.T().Logf("fundBalanceBefore: %v, fundBalanceAfter: %v, diff: %v", fundBalanceBefore, fundBalanceAfter, fundBalanceAfter.Balance.Amount.Sub(fundBalanceBefore.Balance.Amount))
-	s.Require().True(fundBalanceAfter.Balance.Amount.Sub(fundBalanceBefore.Balance.Amount).GT(sdkmath.NewInt(0)), "migrate sp fund address need settle")
-	gvgFamilyRate, gvgRate, taxRate, userTotalRate = s.calculateStorageRates(bucketName, objectName, payloadSize, time.Now().Unix())
-	s.T().Logf("gvgFamilyRate: %v, gvgRate: %v, taxRate: %v, userTotalRate: %v", gvgFamilyRate, gvgRate, taxRate, userTotalRate)
-	s.T().Logf("NetflowRate: %v, userTotalRate: %v, actual taxRate diff: %v, expect taxRate diff: %v", streamRecordsAfter.User.NetflowRate.Neg(), userTotalRate.Neg(), streamRecordsAfter.Tax.NetflowRate.Sub(streamRecordsBefore.Tax.NetflowRate), taxRate.Sub(taxRate0))
-
-	s.Require().Equal(streamRecordsAfter.User.StaticBalance, sdkmath.ZeroInt())
-	s.Require().Equal(streamRecordsAfter.User.LockBalance, sdkmath.ZeroInt())
-	s.Require().Equal(streamRecordsAfter.GVGFamily.NetflowRate.Sub(streamRecordsBefore.GVGFamily.NetflowRate), gvgFamilyRate)
-	s.Require().Equal(streamRecordsAfter.GVG.NetflowRate.Sub(streamRecordsBefore.GVG.NetflowRate), gvgRate)
-	// tax rate diff
-	s.Require().Equal(streamRecordsAfter.Tax.NetflowRate.Sub(streamRecordsBefore.Tax.NetflowRate), taxRate.Sub(taxRate0))
-	s.Require().Equal(streamRecordsAfter.User.NetflowRate.Neg(), userTotalRate.Abs())
-
-	// set price
-	s.updateGlobalSpPrice(priceRes.GlobalSpStorePrice.ReadPrice.MulInt64(120), priceRes.GlobalSpStorePrice.PrimaryStorePrice.MulInt64(5000))
-
-	queryBalanceRequest.Address = dstPrimarySP.FundingKey.GetAddr().String()
-	fundBalanceBefore, err = s.Client.BankQueryClient.Balance(context.Background(), &queryBalanceRequest)
-	s.Require().NoError(err)
-	streamRecordsBefore = s.getStreamRecords(streamAddresses0)
-	// send msgMigrationBucket
-	msgMigrationBucket, msgCompleteMigrationBucket = s.NewMigrateBucket(dstPrimarySP, primarySP, user, bucketName, dstGVG.FamilyId, gvg.FamilyId, bucketInfo.BucketInfo.Id)
-
-	s.SendTxBlock(user, msgMigrationBucket)
-	s.Require().NoError(err)
-	s.reduceBNBBalance(user, s.Validator, sdkmath.NewIntWithDecimal(1, 1))
-
-	s.SendTxBlockWithExpectErrorString(msgCompleteMigrationBucket, primarySP.OperatorKey, "apply stream record changes for user failed")
-
-	s.updateGlobalSpPrice(priceRes.GlobalSpStorePrice.ReadPrice.MulInt64(10), priceRes.GlobalSpStorePrice.PrimaryStorePrice.MulInt64(10))
-	readPrice, primaryPrice, secondaryPrice := s.getPrices(time.Now().Unix())
-	s.T().Logf("readPrice: %v, primaryPrice: %v,secondaryPrice: %v", readPrice, primaryPrice, secondaryPrice)
-
-	s.transferBNB(s.Validator, user, sdkmath.NewIntWithDecimal(10000, 18))
-
-	s.SendTxBlock(primarySP.OperatorKey, msgCompleteMigrationBucket)
-	streamRecordsAfter = s.getStreamRecords(streamAddresses0)
-	fundBalanceAfter, err = s.Client.BankQueryClient.Balance(context.Background(), &queryBalanceRequest)
-	s.Require().NoError(err)
-	s.T().Logf("fundBalanceBefore: %v, fundBalanceAfter: %v, diff: %v", fundBalanceBefore, fundBalanceAfter, fundBalanceAfter.Balance.Amount.Sub(fundBalanceBefore.Balance.Amount))
-	s.Require().True(fundBalanceAfter.Balance.Amount.Sub(fundBalanceBefore.Balance.Amount).GT(sdkmath.NewInt(0)), "migrate sp fund address need settle")
-	taxRate1 := taxRate
-	gvgFamilyRate, gvgRate, taxRate, userTotalRate = s.calculateStorageRates(bucketName, objectName, payloadSize, time.Now().Unix())
-	s.T().Logf("gvgFamilyRate: %v, gvgRate: %v, taxRate: %v, userTotalRate: %v", gvgFamilyRate, gvgRate, taxRate, userTotalRate)
-	s.T().Logf("NetflowRate: %v, userTotalRate: %v, actual taxRate diff: %v, expect taxRate diff: %v", streamRecordsAfter.User.NetflowRate.Neg(), userTotalRate.Neg(), streamRecordsAfter.Tax.NetflowRate.Sub(streamRecordsBefore.Tax.NetflowRate), taxRate.Sub(taxRate0))
-
-	s.Require().Equal(streamRecordsAfter.User.StaticBalance, sdkmath.ZeroInt())
-	s.Require().Equal(streamRecordsAfter.User.LockBalance, sdkmath.ZeroInt())
-	s.Require().Equal(streamRecordsAfter.GVGFamily.NetflowRate.Sub(streamRecordsBefore.GVGFamily.NetflowRate), gvgFamilyRate)
-	s.Require().Equal(streamRecordsAfter.GVG.NetflowRate.Sub(streamRecordsBefore.GVG.NetflowRate), gvgRate)
-	// tax rate diff
-	s.Require().Equal(streamRecordsAfter.Tax.NetflowRate.Sub(streamRecordsBefore.Tax.NetflowRate), taxRate.Sub(taxRate1))
-	s.Require().Equal(streamRecordsAfter.User.NetflowRate.Neg(), userTotalRate.Abs())
-}
-
-func (s *PaymentTestSuite) TestStorageBill_MigrateBucket_LockedFee_ThenDiscontinueBucket() {
-	var err error
-	ctx := context.Background()
-	primarySP := s.PickStorageProvider()
-	gvg, found := primarySP.GetFirstGlobalVirtualGroup()
-	s.Require().True(found)
-	queryFamilyResponse, err := s.Client.GlobalVirtualGroupFamily(ctx, &virtualgrouptypes.QueryGlobalVirtualGroupFamilyRequest{
-		FamilyId: gvg.FamilyId,
-	})
-	s.Require().NoError(err)
-	family := queryFamilyResponse.GlobalVirtualGroupFamily
-	user := s.GenAndChargeAccounts(1, 10)[0]
-
-	streamAddresses := []string{
-		user.GetAddr().String(),
-		family.VirtualPaymentAddress,
-		gvg.VirtualPaymentAddress,
-		paymenttypes.ValidatorTaxPoolAddress.String(),
-	}
-
-	paymentParams, err := s.Client.PaymentQueryClient.Params(ctx, &paymenttypes.QueryParamsRequest{})
-	s.T().Logf("paymentParams %s, err: %v", paymentParams, err)
-	s.Require().NoError(err)
-
-	bucketName := s.createBucket(primarySP, gvg, user, 0)
-	bucketInfo, err := s.Client.HeadBucket(context.Background(), &storagetypes.QueryHeadBucketRequest{
-		BucketName: bucketName,
-	})
-	s.Require().NoError(err)
-
-	// create object with none zero payload size
-	streamRecordsBefore := s.getStreamRecords(streamAddresses)
-	_, _, objectName, objectId, checksums, payloadSize := s.createObject(user, bucketName, false)
-
-	// assertions
-	streamRecordsAfter := s.getStreamRecords(streamAddresses)
-	s.Require().Equal(streamRecordsAfter.User.StaticBalance, sdkmath.ZeroInt())
-	lockFee := s.calculateLockFee(bucketName, objectName, payloadSize)
-	s.Require().Equal(streamRecordsAfter.User.LockBalance.Sub(streamRecordsBefore.User.LockBalance), lockFee)
-	s.Require().Equal(streamRecordsAfter.User.NetflowRate.Sub(streamRecordsBefore.User.NetflowRate).Int64(), int64(0))
-	s.Require().Equal(streamRecordsAfter.GVGFamily.NetflowRate.Sub(streamRecordsBefore.GVGFamily.NetflowRate).Int64(), int64(0))
-	s.Require().Equal(streamRecordsAfter.GVG.NetflowRate.Sub(streamRecordsBefore.GVG.NetflowRate).Int64(), int64(0))
-	s.Require().Equal(streamRecordsAfter.Tax.NetflowRate.Sub(streamRecordsBefore.Tax.NetflowRate).Int64(), int64(0))
-
-	// case: seal object
-	s.sealObject(primarySP, gvg, bucketName, objectName, objectId, checksums)
-
-	// assertions
-	streamRecordsAfter = s.getStreamRecords(streamAddresses)
-	gvgFamilyRate, gvgRate, taxRate, userTotalRate := s.calculateStorageRates(bucketName, objectName, payloadSize, 0)
-	s.T().Logf("gvgFamilyRate: %v, gvgRate: %v, taxRate: %v, userTotalRate: %v", gvgFamilyRate, gvgRate, taxRate, userTotalRate)
-	s.Require().Equal(streamRecordsAfter.User.StaticBalance, sdkmath.ZeroInt())
-	s.Require().Equal(streamRecordsAfter.User.LockBalance, sdkmath.ZeroInt())
-	s.Require().Equal(streamRecordsAfter.User.NetflowRate.Sub(streamRecordsBefore.User.NetflowRate), userTotalRate.Neg())
-	s.Require().Equal(streamRecordsAfter.GVGFamily.NetflowRate.Sub(streamRecordsBefore.GVGFamily.NetflowRate), gvgFamilyRate)
-	s.Require().Equal(streamRecordsAfter.GVG.NetflowRate.Sub(streamRecordsBefore.GVG.NetflowRate), gvgRate)
-	s.Require().Equal(streamRecordsAfter.Tax.NetflowRate.Sub(streamRecordsBefore.Tax.NetflowRate), taxRate)
-	taxRate0 := taxRate
-	dstPrimarySP := s.CreateNewStorageProvider()
-
-	// create a new object without seal
-	s.createObject(user, bucketName, false)
-
-	// update price after lock
-	priceRes, err := s.Client.QueryGlobalSpStorePriceByTime(ctx, &sptypes.QueryGlobalSpStorePriceByTimeRequest{
-		Timestamp: 0,
-	})
-	s.Require().NoError(err)
-	s.T().Log("price", priceRes.GlobalSpStorePrice)
-
-	s.updateGlobalSpPrice(priceRes.GlobalSpStorePrice.ReadPrice, priceRes.GlobalSpStorePrice.PrimaryStorePrice.MulInt64(10000))
-	defer s.updateGlobalSpPrice(priceRes.GlobalSpStorePrice.ReadPrice, priceRes.GlobalSpStorePrice.PrimaryStorePrice)
-
-	_, secondarySPIDs := s.GetSecondarySP(dstPrimarySP, primarySP)
-	gvgID, _ := s.BaseSuite.CreateGlobalVirtualGroup(dstPrimarySP, 0, secondarySPIDs, 1)
-	gvgResp, err := s.Client.VirtualGroupQueryClient.GlobalVirtualGroup(context.Background(), &virtualgrouptypes.QueryGlobalVirtualGroupRequest{
-		GlobalVirtualGroupId: gvgID,
-	})
-	s.Require().NoError(err)
-	dstGVG := gvgResp.GlobalVirtualGroup
-	s.Require().True(found)
-
-	queryFamilyResponse, err = s.Client.GlobalVirtualGroupFamily(ctx, &virtualgrouptypes.QueryGlobalVirtualGroupFamilyRequest{
-		FamilyId: dstGVG.FamilyId,
-	})
-	s.Require().NoError(err)
-	family = queryFamilyResponse.GlobalVirtualGroupFamily
-	streamAddresses = []string{
-		user.GetAddr().String(),
-		family.VirtualPaymentAddress,
-		dstGVG.VirtualPaymentAddress,
-		paymenttypes.ValidatorTaxPoolAddress.String(),
-	}
-	fundAddress := primarySP.FundingKey.GetAddr()
-	streamRecordsBefore = s.getStreamRecords(streamAddresses)
-
-	queryBalanceRequest := banktypes.QueryBalanceRequest{Denom: s.Config.Denom, Address: fundAddress.String()}
-	fundBalanceBefore, err := s.Client.BankQueryClient.Balance(context.Background(), &queryBalanceRequest)
-	s.Require().NoError(err)
-
-	// MigrateBucket
-	msgMigrateBucket, msgCompleteMigrateBucket := s.NewMigrateBucket(primarySP, dstPrimarySP, user, bucketName, gvg.FamilyId, dstGVG.FamilyId, bucketInfo.BucketInfo.Id)
-	s.SendTxBlock(user, msgMigrateBucket)
-	s.Require().NoError(err)
-
-	// complete MigrateBucket
-	s.SendTxBlock(dstPrimarySP.OperatorKey, msgCompleteMigrateBucket)
-	streamRecordsAfter = s.getStreamRecords(streamAddresses)
-	fundBalanceAfter, err := s.Client.BankQueryClient.Balance(context.Background(), &queryBalanceRequest)
-	s.Require().NoError(err)
-	s.T().Logf("fundBalanceBefore: %v, fundBalanceAfter: %v, diff: %v", fundBalanceBefore, fundBalanceAfter, fundBalanceAfter.Balance.Amount.Sub(fundBalanceBefore.Balance.Amount))
-	s.Require().True(fundBalanceAfter.Balance.Amount.Sub(fundBalanceBefore.Balance.Amount).GT(sdkmath.NewInt(0)), "migrate sp fund address need settle")
-	gvgFamilyRate, gvgRate, taxRate, userTotalRate = s.calculateStorageRates(bucketName, objectName, payloadSize, time.Now().Unix())
-	s.T().Logf("gvgFamilyRate: %v, gvgRate: %v, taxRate: %v, userTotalRate: %v", gvgFamilyRate, gvgRate, taxRate, userTotalRate)
-	s.T().Logf("NetflowRate: %v, userTotalRate: %v, actual taxRate diff: %v, expect taxRate diff: %v", streamRecordsAfter.User.NetflowRate.Neg(), userTotalRate.Neg(), streamRecordsAfter.Tax.NetflowRate.Sub(streamRecordsBefore.Tax.NetflowRate), taxRate.Sub(taxRate0))
-
-	s.Require().Equal(streamRecordsAfter.User.StaticBalance, sdkmath.ZeroInt())
-	s.Require().Equal(streamRecordsAfter.GVGFamily.NetflowRate.Sub(streamRecordsBefore.GVGFamily.NetflowRate), gvgFamilyRate)
-	s.Require().Equal(streamRecordsAfter.GVG.NetflowRate.Sub(streamRecordsBefore.GVG.NetflowRate), gvgRate)
-	// tax rate diff
-	s.Require().Equal(streamRecordsAfter.Tax.NetflowRate.Sub(streamRecordsBefore.Tax.NetflowRate), taxRate.Sub(taxRate0))
-	s.Require().Equal(streamRecordsAfter.User.NetflowRate.Neg(), userTotalRate.Abs())
-
-	// force delete bucket
-	headBucketResp, _ := s.Client.HeadBucket(ctx, &storagetypes.QueryHeadBucketRequest{BucketName: bucketName})
-	s.T().Log("headBucketResp", core.YamlString(headBucketResp))
-	msgDiscontinueBucket := storagetypes.NewMsgDiscontinueBucket(dstPrimarySP.GcKey.GetAddr(), bucketName, "test")
-	txRes := s.SendTxBlock(dstPrimarySP.GcKey, msgDiscontinueBucket)
-	deleteAt := filterDiscontinueBucketEventFromTx(txRes).DeleteAt
-
-	for {
-		time.Sleep(200 * time.Millisecond)
-		statusRes, err := s.TmClient.TmClient.Status(context.Background())
-		s.Require().NoError(err)
-		blockTime := statusRes.SyncInfo.LatestBlockTime.Unix()
-
-		s.T().Logf("current blockTime: %d, delete blockTime: %d", blockTime, deleteAt)
-
-		if blockTime > deleteAt {
-			break
-		}
-	}
-
-	_, err = s.Client.HeadBucket(ctx, &storagetypes.QueryHeadBucketRequest{BucketName: bucketName})
-	s.Require().ErrorContains(err, "No such bucket")
-}
-
-func (s *PaymentTestSuite) TestStorageBill_MigrateBucket_FrozenAccount_NotAllowed() {
-	var err error
-	ctx := context.Background()
-	primarySP := s.PickStorageProvider()
-	gvg, found := primarySP.GetFirstGlobalVirtualGroup()
-	s.Require().True(found)
-	queryFamilyResponse, err := s.Client.GlobalVirtualGroupFamily(ctx, &virtualgrouptypes.QueryGlobalVirtualGroupFamilyRequest{
-		FamilyId: gvg.FamilyId,
-	})
-	s.Require().NoError(err)
-	s.T().Log("queryFamilyResponse", core.YamlString(queryFamilyResponse))
-	user := s.GenAndChargeAccounts(1, 10)[0]
-
-	params := s.queryParams()
-	reserveTime := params.VersionedParams.ReserveTime
-	queryGetSpStoragePriceByTimeResp, err := s.Client.QueryGlobalSpStorePriceByTime(ctx, &sptypes.QueryGlobalSpStorePriceByTimeRequest{
-		Timestamp: 0,
-	})
-	s.T().Logf("queryGetSpStoragePriceByTimeResp %s, err: %v", queryGetSpStoragePriceByTimeResp, err)
-	s.Require().NoError(err)
-
-	readPrice := queryGetSpStoragePriceByTimeResp.GlobalSpStorePrice.ReadPrice
-	bucketChargedReadQuota := uint64(1000)
-	readRate := readPrice.MulInt(sdkmath.NewIntFromUint64(bucketChargedReadQuota)).TruncateInt()
-	readTaxRate := params.VersionedParams.ValidatorTaxRate.MulInt(readRate).TruncateInt()
-	readTotalRate := readRate.Add(readTaxRate)
-	paymentAccountBNBNeeded := readTotalRate.Mul(sdkmath.NewIntFromUint64(reserveTime))
-
-	// create payment account and deposit
-	msgCreatePaymentAccount := &paymenttypes.MsgCreatePaymentAccount{
-		Creator: user.GetAddr().String(),
-	}
-	_ = s.SendTxBlock(user, msgCreatePaymentAccount)
-	paymentAccountsReq := &paymenttypes.QueryPaymentAccountsByOwnerRequest{Owner: user.GetAddr().String()}
-	paymentAccounts, err := s.Client.PaymentQueryClient.PaymentAccountsByOwner(ctx, paymentAccountsReq)
-	s.Require().NoError(err)
-	s.T().Logf("paymentAccounts %s", core.YamlString(paymentAccounts))
-
-	paymentAddr := paymentAccounts.PaymentAccounts[0]
-	s.Require().Lenf(paymentAccounts.PaymentAccounts, 1, "paymentAccounts %s", core.YamlString(paymentAccounts))
-	msgDeposit := &paymenttypes.MsgDeposit{
-		Creator: user.GetAddr().String(),
-		To:      paymentAddr,
-		Amount:  paymentAccountBNBNeeded,
-	}
-	_ = s.SendTxBlock(user, msgDeposit)
-
-	bucketName := "ch" + storagetestutils.GenRandomBucketName()
-	msgCreateBucket := storagetypes.NewMsgCreateBucket(
-		user.GetAddr(), bucketName, storagetypes.VISIBILITY_TYPE_PRIVATE, primarySP.OperatorKey.GetAddr(),
-		sdk.MustAccAddressFromHex(paymentAddr), math.MaxUint, nil, bucketChargedReadQuota)
-	msgCreateBucket.PrimarySpApproval.GlobalVirtualGroupFamilyId = gvg.FamilyId
-	msgCreateBucket.PrimarySpApproval.Sig, err = primarySP.ApprovalKey.Sign(msgCreateBucket.GetApprovalBytes())
-	s.Require().NoError(err)
-	s.SendTxBlock(user, msgCreateBucket)
-
-	queryHeadBucketRequest := storagetypes.QueryHeadBucketRequest{
-		BucketName: bucketName,
-	}
-	_, err = s.Client.HeadBucket(context.Background(), &queryHeadBucketRequest)
-	s.Require().NoError(err)
-	bucketInfo, err := s.Client.HeadBucket(context.Background(), &storagetypes.QueryHeadBucketRequest{
-		BucketName: bucketName,
-	})
-	s.Require().NoError(err)
-
-	// wait until settle time
-	paymentAccountStreamRecord := s.getStreamRecord(paymentAddr)
-	retryCount := 0
-	for {
-		latestBlock, err := s.TmClient.TmClient.Block(ctx, nil)
-		s.Require().NoError(err)
-		currentTimestamp := latestBlock.Block.Time.Unix()
-		s.T().Logf("currentTimestamp %d, userStreamRecord.SettleTimestamp %d", currentTimestamp, paymentAccountStreamRecord.SettleTimestamp)
-		if currentTimestamp > paymentAccountStreamRecord.SettleTimestamp {
-			break
-		}
-		time.Sleep(time.Second)
-		retryCount++
-		if retryCount > 60 {
-			s.T().Fatalf("wait for settle time timeout")
-		}
-	}
-	// check auto settle
-	paymentAccountStreamRecordAfterAutoSettle := s.getStreamRecord(paymentAddr)
-	s.T().Logf("paymentAccountStreamRecordAfterAutoSettle %s", core.YamlString(paymentAccountStreamRecordAfterAutoSettle))
-	s.Require().Equal(paymentAccountStreamRecordAfterAutoSettle.Status, paymenttypes.STREAM_ACCOUNT_STATUS_FROZEN)
-	s.Require().Equal(paymentAccountStreamRecordAfterAutoSettle.NetflowRate.Int64(), int64(0))
-	s.Require().Equal(paymentAccountStreamRecordAfterAutoSettle.FrozenNetflowRate.Int64(), readTotalRate.Neg().Int64())
-
-	dstPrimarySP := s.CreateNewStorageProvider()
-	_, secondarySPIDs := s.GetSecondarySP(dstPrimarySP, primarySP)
-	gvgID, _ := s.BaseSuite.CreateGlobalVirtualGroup(dstPrimarySP, 0, secondarySPIDs, 1)
-	gvgResp, err := s.Client.VirtualGroupQueryClient.GlobalVirtualGroup(context.Background(), &virtualgrouptypes.QueryGlobalVirtualGroupRequest{
-		GlobalVirtualGroupId: gvgID,
-	})
-	s.Require().NoError(err)
-	dstGVG := gvgResp.GlobalVirtualGroup
-	s.Require().True(found)
-
-	// MigrateBucket
-	msgMigrateBucket, _ := s.NewMigrateBucket(primarySP, dstPrimarySP, user, bucketName, gvg.FamilyId, dstGVG.FamilyId, bucketInfo.BucketInfo.Id)
-	s.SendTxBlockWithExpectErrorString(msgMigrateBucket, user, "frozen")
-}
+//func (s *PaymentTestSuite) TestStorageBill_MigrateBucket_FrozenAccount_NotAllowed() {
+//	var err error
+//	ctx := context.Background()
+//	primarySP := s.PickStorageProvider()
+//	gvg, found := primarySP.GetFirstGlobalVirtualGroup()
+//	s.Require().True(found)
+//	queryFamilyResponse, err := s.Client.GlobalVirtualGroupFamily(ctx, &virtualgrouptypes.QueryGlobalVirtualGroupFamilyRequest{
+//		FamilyId: gvg.FamilyId,
+//	})
+//	s.Require().NoError(err)
+//	s.T().Log("queryFamilyResponse", core.YamlString(queryFamilyResponse))
+//	user := s.GenAndChargeAccounts(1, 10)[0]
+//
+//	params := s.queryParams()
+//	reserveTime := params.VersionedParams.ReserveTime
+//	queryGetSpStoragePriceByTimeResp, err := s.Client.QueryGlobalSpStorePriceByTime(ctx, &sptypes.QueryGlobalSpStorePriceByTimeRequest{
+//		Timestamp: 0,
+//	})
+//	s.T().Logf("queryGetSpStoragePriceByTimeResp %s, err: %v", queryGetSpStoragePriceByTimeResp, err)
+//	s.Require().NoError(err)
+//
+//	readPrice := queryGetSpStoragePriceByTimeResp.GlobalSpStorePrice.ReadPrice
+//	bucketChargedReadQuota := uint64(1000)
+//	readRate := readPrice.MulInt(sdkmath.NewIntFromUint64(bucketChargedReadQuota)).TruncateInt()
+//	readTaxRate := params.VersionedParams.ValidatorTaxRate.MulInt(readRate).TruncateInt()
+//	readTotalRate := readRate.Add(readTaxRate)
+//	paymentAccountBNBNeeded := readTotalRate.Mul(sdkmath.NewIntFromUint64(reserveTime))
+//
+//	// create payment account and deposit
+//	msgCreatePaymentAccount := &paymenttypes.MsgCreatePaymentAccount{
+//		Creator: user.GetAddr().String(),
+//	}
+//	_ = s.SendTxBlock(user, msgCreatePaymentAccount)
+//	paymentAccountsReq := &paymenttypes.QueryPaymentAccountsByOwnerRequest{Owner: user.GetAddr().String()}
+//	paymentAccounts, err := s.Client.PaymentQueryClient.PaymentAccountsByOwner(ctx, paymentAccountsReq)
+//	s.Require().NoError(err)
+//	s.T().Logf("paymentAccounts %s", core.YamlString(paymentAccounts))
+//
+//	paymentAddr := paymentAccounts.PaymentAccounts[0]
+//	s.Require().Lenf(paymentAccounts.PaymentAccounts, 1, "paymentAccounts %s", core.YamlString(paymentAccounts))
+//	msgDeposit := &paymenttypes.MsgDeposit{
+//		Creator: user.GetAddr().String(),
+//		To:      paymentAddr,
+//		Amount:  paymentAccountBNBNeeded,
+//	}
+//	_ = s.SendTxBlock(user, msgDeposit)
+//
+//	bucketName := "ch" + storagetestutils.GenRandomBucketName()
+//	msgCreateBucket := storagetypes.NewMsgCreateBucket(
+//		user.GetAddr(), bucketName, storagetypes.VISIBILITY_TYPE_PRIVATE, primarySP.OperatorKey.GetAddr(),
+//		sdk.MustAccAddressFromHex(paymentAddr), math.MaxUint, nil, bucketChargedReadQuota)
+//	msgCreateBucket.PrimarySpApproval.GlobalVirtualGroupFamilyId = gvg.FamilyId
+//	msgCreateBucket.PrimarySpApproval.Sig, err = primarySP.ApprovalKey.Sign(msgCreateBucket.GetApprovalBytes())
+//	s.Require().NoError(err)
+//	s.SendTxBlock(user, msgCreateBucket)
+//
+//	queryHeadBucketRequest := storagetypes.QueryHeadBucketRequest{
+//		BucketName: bucketName,
+//	}
+//	_, err = s.Client.HeadBucket(context.Background(), &queryHeadBucketRequest)
+//	s.Require().NoError(err)
+//	bucketInfo, err := s.Client.HeadBucket(context.Background(), &storagetypes.QueryHeadBucketRequest{
+//		BucketName: bucketName,
+//	})
+//	s.Require().NoError(err)
+//
+//	// wait until settle time
+//	paymentAccountStreamRecord := s.getStreamRecord(paymentAddr)
+//	retryCount := 0
+//	for {
+//		latestBlock, err := s.TmClient.TmClient.Block(ctx, nil)
+//		s.Require().NoError(err)
+//		currentTimestamp := latestBlock.Block.Time.Unix()
+//		s.T().Logf("currentTimestamp %d, userStreamRecord.SettleTimestamp %d", currentTimestamp, paymentAccountStreamRecord.SettleTimestamp)
+//		if currentTimestamp > paymentAccountStreamRecord.SettleTimestamp {
+//			break
+//		}
+//		time.Sleep(time.Second)
+//		retryCount++
+//		if retryCount > 60 {
+//			s.T().Fatalf("wait for settle time timeout")
+//		}
+//	}
+//	// check auto settle
+//	paymentAccountStreamRecordAfterAutoSettle := s.getStreamRecord(paymentAddr)
+//	s.T().Logf("paymentAccountStreamRecordAfterAutoSettle %s", core.YamlString(paymentAccountStreamRecordAfterAutoSettle))
+//	s.Require().Equal(paymentAccountStreamRecordAfterAutoSettle.Status, paymenttypes.STREAM_ACCOUNT_STATUS_FROZEN)
+//	s.Require().Equal(paymentAccountStreamRecordAfterAutoSettle.NetflowRate.Int64(), int64(0))
+//	s.Require().Equal(paymentAccountStreamRecordAfterAutoSettle.FrozenNetflowRate.Int64(), readTotalRate.Neg().Int64())
+//
+//	dstPrimarySP := s.CreateNewStorageProvider()
+//	_, secondarySPIDs := s.GetSecondarySP(dstPrimarySP, primarySP)
+//	gvgID, _ := s.BaseSuite.CreateGlobalVirtualGroup(dstPrimarySP, 0, secondarySPIDs, 1)
+//	gvgResp, err := s.Client.VirtualGroupQueryClient.GlobalVirtualGroup(context.Background(), &virtualgrouptypes.QueryGlobalVirtualGroupRequest{
+//		GlobalVirtualGroupId: gvgID,
+//	})
+//	s.Require().NoError(err)
+//	dstGVG := gvgResp.GlobalVirtualGroup
+//	s.Require().True(found)
+//
+//	// MigrateBucket
+//	msgMigrateBucket, _ := s.NewMigrateBucket(primarySP, dstPrimarySP, user, bucketName, gvg.FamilyId, dstGVG.FamilyId, bucketInfo.BucketInfo.Id)
+//	s.SendTxBlockWithExpectErrorString(msgMigrateBucket, user, "frozen")
+//}
 
 func (s *PaymentTestSuite) GetSecondarySP(sps ...*core.StorageProvider) ([]*core.StorageProvider, []uint32) {
 	var secondarySPs []*core.StorageProvider
@@ -2296,9 +2296,9 @@ func (s *PaymentTestSuite) reduceBNBBalance(user, to keys.KeyManager, leftBalanc
 	s.T().Logf("balance: %v", queryBalanceResponse.Balance.Amount)
 }
 
-func (s *PaymentTestSuite) transferBNB(from, to keys.KeyManager, amount sdkmath.Int) {
-	msgSend := banktypes.NewMsgSend(from.GetAddr(), to.GetAddr(), sdk.NewCoins(
-		sdk.NewCoin(s.Config.Denom, amount),
-	))
-	s.SendTxBlock(from, msgSend)
-}
+//func (s *PaymentTestSuite) transferBNB(from, to keys.KeyManager, amount sdkmath.Int) {
+//	msgSend := banktypes.NewMsgSend(from.GetAddr(), to.GetAddr(), sdk.NewCoins(
+//		sdk.NewCoin(s.Config.Denom, amount),
+//	))
+//	s.SendTxBlock(from, msgSend)
+//}

--- a/e2e/tests/storage_test.go
+++ b/e2e/tests/storage_test.go
@@ -29,7 +29,6 @@ import (
 	storageutils "github.com/bnb-chain/greenfield/testutil/storage"
 	sptypes "github.com/bnb-chain/greenfield/x/sp/types"
 	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
-	types2 "github.com/bnb-chain/greenfield/x/virtualgroup/types"
 )
 
 type StorageTestSuite struct {
@@ -1666,86 +1665,86 @@ func (s *StorageTestSuite) TestRejectSealObject() {
 	s.Require().True(strings.Contains(err.Error(), storagetypes.ErrNoSuchObject.Error()))
 }
 
-func (s *StorageTestSuite) TestMigrationBucket() {
-	// construct bucket and object
-	primarySP := s.BaseSuite.PickStorageProvider()
-	gvg, found := primarySP.GetFirstGlobalVirtualGroup()
-	s.Require().True(found)
-	user := s.GenAndChargeAccounts(1, 1000000)[0]
-	bucketName := storageutils.GenRandomBucketName()
-	objectName := storageutils.GenRandomObjectName()
-	_, _, _, bucketInfo := s.BaseSuite.CreateObject(user, primarySP, gvg.Id, bucketName, objectName)
-
-	var err error
-	dstPrimarySP := s.CreateNewStorageProvider()
-
-	// migrate bucket
-	msgMigrationBucket := storagetypes.NewMsgMigrateBucket(user.GetAddr(), bucketName, dstPrimarySP.Info.Id)
-	msgMigrationBucket.DstPrimarySpApproval.ExpiredHeight = math.MaxInt
-	msgMigrationBucket.DstPrimarySpApproval.Sig, err = dstPrimarySP.ApprovalKey.Sign(msgMigrationBucket.GetApprovalBytes())
-	s.SendTxBlock(user, msgMigrationBucket)
-	s.Require().NoError(err)
-
-	// cancel migration bucket
-	msgCancelMigrationBucket := storagetypes.NewMsgCancelMigrateBucket(user.GetAddr(), bucketName)
-	s.SendTxBlock(user, msgCancelMigrationBucket)
-	s.Require().NoError(err)
-
-	// complete migration bucket
-	var secondarySPIDs []uint32
-	var secondarySPs []*core.StorageProvider
-
-	for _, ssp := range s.StorageProviders {
-		if ssp.Info.Id != primarySP.Info.Id {
-			secondarySPIDs = append(secondarySPIDs, ssp.Info.Id)
-			secondarySPs = append(secondarySPs, ssp)
-		}
-		if len(secondarySPIDs) == 5 {
-			break
-		}
-	}
-	gvgID, _ := s.BaseSuite.CreateGlobalVirtualGroup(dstPrimarySP, 0, secondarySPIDs, 1)
-	gvgResp, err := s.Client.VirtualGroupQueryClient.GlobalVirtualGroup(context.Background(), &types2.QueryGlobalVirtualGroupRequest{
-		GlobalVirtualGroupId: gvgID,
-	})
-	s.Require().NoError(err)
-	dstGVG := gvgResp.GlobalVirtualGroup
-	s.Require().True(found)
-
-	// construct the signatures
-	var gvgMappings []*storagetypes.GVGMapping
-	gvgMappings = append(gvgMappings, &storagetypes.GVGMapping{SrcGlobalVirtualGroupId: gvg.Id, DstGlobalVirtualGroupId: dstGVG.Id})
-	for _, gvgMapping := range gvgMappings {
-		migrationBucketSignHash := storagetypes.NewSecondarySpMigrationBucketSignDoc(s.GetChainID(), bucketInfo.Id, dstPrimarySP.Info.Id, gvgMapping.SrcGlobalVirtualGroupId, gvgMapping.DstGlobalVirtualGroupId).GetBlsSignHash()
-		secondarySigs := make([][]byte, 0)
-		secondarySPBlsPubKeys := make([]bls.PublicKey, 0)
-		for _, ssp := range secondarySPs {
-			sig, err := core.BlsSignAndVerify(ssp, migrationBucketSignHash)
-			s.Require().NoError(err)
-			secondarySigs = append(secondarySigs, sig)
-			pk, err := bls.PublicKeyFromBytes(ssp.BlsKey.PubKey().Bytes())
-			s.Require().NoError(err)
-			secondarySPBlsPubKeys = append(secondarySPBlsPubKeys, pk)
-		}
-		aggBlsSig, err := core.BlsAggregateAndVerify(secondarySPBlsPubKeys, migrationBucketSignHash, secondarySigs)
-		s.Require().NoError(err)
-		gvgMapping.SecondarySpBlsSignature = aggBlsSig
-	}
-
-	msgCompleteMigrationBucket := storagetypes.NewMsgCompleteMigrateBucket(dstPrimarySP.OperatorKey.GetAddr(), bucketName, dstGVG.FamilyId, gvgMappings)
-	s.SendTxBlockWithExpectErrorString(msgCompleteMigrationBucket, dstPrimarySP.OperatorKey, "The bucket is not been migrating")
-
-	// send again
-	msgMigrationBucket = storagetypes.NewMsgMigrateBucket(user.GetAddr(), bucketName, dstPrimarySP.Info.Id)
-	msgMigrationBucket.DstPrimarySpApproval.ExpiredHeight = math.MaxInt
-	msgMigrationBucket.DstPrimarySpApproval.Sig, err = dstPrimarySP.ApprovalKey.Sign(msgMigrationBucket.GetApprovalBytes())
-	s.SendTxBlock(user, msgMigrationBucket)
-	s.Require().NoError(err)
-
-	// complete again
-	msgCompleteMigrationBucket = storagetypes.NewMsgCompleteMigrateBucket(dstPrimarySP.OperatorKey.GetAddr(), bucketName, dstGVG.FamilyId, gvgMappings)
-	s.SendTxBlock(dstPrimarySP.OperatorKey, msgCompleteMigrationBucket)
-}
+//func (s *StorageTestSuite) TestMigrationBucket() {
+//	// construct bucket and object
+//	primarySP := s.BaseSuite.PickStorageProvider()
+//	gvg, found := primarySP.GetFirstGlobalVirtualGroup()
+//	s.Require().True(found)
+//	user := s.GenAndChargeAccounts(1, 1000000)[0]
+//	bucketName := storageutils.GenRandomBucketName()
+//	objectName := storageutils.GenRandomObjectName()
+//	_, _, _, bucketInfo := s.BaseSuite.CreateObject(user, primarySP, gvg.Id, bucketName, objectName)
+//
+//	var err error
+//	dstPrimarySP := s.CreateNewStorageProvider()
+//
+//	// migrate bucket
+//	msgMigrationBucket := storagetypes.NewMsgMigrateBucket(user.GetAddr(), bucketName, dstPrimarySP.Info.Id)
+//	msgMigrationBucket.DstPrimarySpApproval.ExpiredHeight = math.MaxInt
+//	msgMigrationBucket.DstPrimarySpApproval.Sig, err = dstPrimarySP.ApprovalKey.Sign(msgMigrationBucket.GetApprovalBytes())
+//	s.SendTxBlock(user, msgMigrationBucket)
+//	s.Require().NoError(err)
+//
+//	// cancel migration bucket
+//	msgCancelMigrationBucket := storagetypes.NewMsgCancelMigrateBucket(user.GetAddr(), bucketName)
+//	s.SendTxBlock(user, msgCancelMigrationBucket)
+//	s.Require().NoError(err)
+//
+//	// complete migration bucket
+//	var secondarySPIDs []uint32
+//	var secondarySPs []*core.StorageProvider
+//
+//	for _, ssp := range s.StorageProviders {
+//		if ssp.Info.Id != primarySP.Info.Id {
+//			secondarySPIDs = append(secondarySPIDs, ssp.Info.Id)
+//			secondarySPs = append(secondarySPs, ssp)
+//		}
+//		if len(secondarySPIDs) == 5 {
+//			break
+//		}
+//	}
+//	gvgID, _ := s.BaseSuite.CreateGlobalVirtualGroup(dstPrimarySP, 0, secondarySPIDs, 1)
+//	gvgResp, err := s.Client.VirtualGroupQueryClient.GlobalVirtualGroup(context.Background(), &types2.QueryGlobalVirtualGroupRequest{
+//		GlobalVirtualGroupId: gvgID,
+//	})
+//	s.Require().NoError(err)
+//	dstGVG := gvgResp.GlobalVirtualGroup
+//	s.Require().True(found)
+//
+//	// construct the signatures
+//	var gvgMappings []*storagetypes.GVGMapping
+//	gvgMappings = append(gvgMappings, &storagetypes.GVGMapping{SrcGlobalVirtualGroupId: gvg.Id, DstGlobalVirtualGroupId: dstGVG.Id})
+//	for _, gvgMapping := range gvgMappings {
+//		migrationBucketSignHash := storagetypes.NewSecondarySpMigrationBucketSignDoc(s.GetChainID(), bucketInfo.Id, dstPrimarySP.Info.Id, gvgMapping.SrcGlobalVirtualGroupId, gvgMapping.DstGlobalVirtualGroupId).GetBlsSignHash()
+//		secondarySigs := make([][]byte, 0)
+//		secondarySPBlsPubKeys := make([]bls.PublicKey, 0)
+//		for _, ssp := range secondarySPs {
+//			sig, err := core.BlsSignAndVerify(ssp, migrationBucketSignHash)
+//			s.Require().NoError(err)
+//			secondarySigs = append(secondarySigs, sig)
+//			pk, err := bls.PublicKeyFromBytes(ssp.BlsKey.PubKey().Bytes())
+//			s.Require().NoError(err)
+//			secondarySPBlsPubKeys = append(secondarySPBlsPubKeys, pk)
+//		}
+//		aggBlsSig, err := core.BlsAggregateAndVerify(secondarySPBlsPubKeys, migrationBucketSignHash, secondarySigs)
+//		s.Require().NoError(err)
+//		gvgMapping.SecondarySpBlsSignature = aggBlsSig
+//	}
+//
+//	msgCompleteMigrationBucket := storagetypes.NewMsgCompleteMigrateBucket(dstPrimarySP.OperatorKey.GetAddr(), bucketName, dstGVG.FamilyId, gvgMappings)
+//	s.SendTxBlockWithExpectErrorString(msgCompleteMigrationBucket, dstPrimarySP.OperatorKey, "The bucket is not been migrating")
+//
+//	// send again
+//	msgMigrationBucket = storagetypes.NewMsgMigrateBucket(user.GetAddr(), bucketName, dstPrimarySP.Info.Id)
+//	msgMigrationBucket.DstPrimarySpApproval.ExpiredHeight = math.MaxInt
+//	msgMigrationBucket.DstPrimarySpApproval.Sig, err = dstPrimarySP.ApprovalKey.Sign(msgMigrationBucket.GetApprovalBytes())
+//	s.SendTxBlock(user, msgMigrationBucket)
+//	s.Require().NoError(err)
+//
+//	// complete again
+//	msgCompleteMigrationBucket = storagetypes.NewMsgCompleteMigrateBucket(dstPrimarySP.OperatorKey.GetAddr(), bucketName, dstGVG.FamilyId, gvgMappings)
+//	s.SendTxBlock(dstPrimarySP.OperatorKey, msgCompleteMigrationBucket)
+//}
 
 func (s *StorageTestSuite) TestUpdateStorageParams() {
 	// 1. create proposal
@@ -2011,66 +2010,66 @@ func (s *StorageTestSuite) TestMaintenanceSPCreateBucketAndObject() {
 	s.Require().Equal(sptypes.STATUS_IN_SERVICE, spResp.StorageProvider.Status)
 }
 
-func (s *StorageTestSuite) TestRejectMigrateBucket() {
-	// construct bucket and object
-	primarySP := s.BaseSuite.PickStorageProvider()
-	gvg, found := primarySP.GetFirstGlobalVirtualGroup()
-	s.Require().True(found)
-	user := s.GenAndChargeAccounts(1, 1000000)[0]
-	bucketName := storageutils.GenRandomBucketName()
-	objectName := storageutils.GenRandomObjectName()
-	s.BaseSuite.CreateObject(user, primarySP, gvg.Id, bucketName, objectName)
-
-	var err error
-	dstPrimarySP := s.CreateNewStorageProvider()
-
-	// migrate bucket
-	msgMigrationBucket := storagetypes.NewMsgMigrateBucket(user.GetAddr(), bucketName, dstPrimarySP.Info.Id)
-	msgMigrationBucket.DstPrimarySpApproval.ExpiredHeight = math.MaxInt
-	msgMigrationBucket.DstPrimarySpApproval.Sig, err = dstPrimarySP.ApprovalKey.Sign(msgMigrationBucket.GetApprovalBytes())
-	s.SendTxBlock(user, msgMigrationBucket)
-	s.Require().NoError(err)
-
-	ctx := context.Background()
-	queryHeadBucketRequest := storagetypes.QueryHeadBucketRequest{
-		BucketName: bucketName,
-	}
-	queryHeadBucketResponse, err := s.Client.HeadBucket(ctx, &queryHeadBucketRequest)
-	s.Require().NoError(err)
-	s.Require().Equal(queryHeadBucketResponse.BucketInfo.BucketName, bucketName)
-	s.Require().Equal(queryHeadBucketResponse.BucketInfo.BucketStatus, storagetypes.BUCKET_STATUS_MIGRATING)
-
-	// Dest SP reject the migration
-	rejectMigration := storagetypes.NewMsgRejectMigrateBucket(dstPrimarySP.OperatorKey.GetAddr(), bucketName)
-	s.SendTxBlock(dstPrimarySP.OperatorKey, rejectMigration)
-	s.Require().NoError(err)
-
-	queryHeadBucketRequest = storagetypes.QueryHeadBucketRequest{
-		BucketName: bucketName,
-	}
-	queryHeadBucketResponse, err = s.Client.HeadBucket(ctx, &queryHeadBucketRequest)
-	s.Require().NoError(err)
-	s.Require().Equal(queryHeadBucketResponse.BucketInfo.BucketStatus, storagetypes.BUCKET_STATUS_CREATED)
-
-	// migrate bucket again
-	msgMigrationBucket = storagetypes.NewMsgMigrateBucket(user.GetAddr(), bucketName, dstPrimarySP.Info.Id)
-	msgMigrationBucket.DstPrimarySpApproval.ExpiredHeight = math.MaxInt
-	msgMigrationBucket.DstPrimarySpApproval.Sig, err = dstPrimarySP.ApprovalKey.Sign(msgMigrationBucket.GetApprovalBytes())
-	s.SendTxBlock(user, msgMigrationBucket)
-	s.Require().NoError(err)
-
-	// cancel migration by user
-	msgCancelMigrationBucket := storagetypes.NewMsgCancelMigrateBucket(user.GetAddr(), bucketName)
-	s.SendTxBlock(user, msgCancelMigrationBucket)
-	s.Require().NoError(err)
-
-	queryHeadBucketResponse, err = s.Client.HeadBucket(ctx, &queryHeadBucketRequest)
-	s.Require().NoError(err)
-	s.Require().Equal(queryHeadBucketResponse.BucketInfo.BucketStatus, storagetypes.BUCKET_STATUS_CREATED)
-
-	// dest SP should fail to reject
-	s.Client.SetKeyManager(dstPrimarySP.OperatorKey)
-	_, err = s.Client.BroadcastTx(context.Background(), []sdk.Msg{rejectMigration}, nil)
-	s.Require().Error(err)
-	s.Require().Equal(queryHeadBucketResponse.BucketInfo.BucketStatus, storagetypes.BUCKET_STATUS_CREATED)
-}
+//func (s *StorageTestSuite) TestRejectMigrateBucket() {
+//	// construct bucket and object
+//	primarySP := s.BaseSuite.PickStorageProvider()
+//	gvg, found := primarySP.GetFirstGlobalVirtualGroup()
+//	s.Require().True(found)
+//	user := s.GenAndChargeAccounts(1, 1000000)[0]
+//	bucketName := storageutils.GenRandomBucketName()
+//	objectName := storageutils.GenRandomObjectName()
+//	s.BaseSuite.CreateObject(user, primarySP, gvg.Id, bucketName, objectName)
+//
+//	var err error
+//	dstPrimarySP := s.CreateNewStorageProvider()
+//
+//	// migrate bucket
+//	msgMigrationBucket := storagetypes.NewMsgMigrateBucket(user.GetAddr(), bucketName, dstPrimarySP.Info.Id)
+//	msgMigrationBucket.DstPrimarySpApproval.ExpiredHeight = math.MaxInt
+//	msgMigrationBucket.DstPrimarySpApproval.Sig, err = dstPrimarySP.ApprovalKey.Sign(msgMigrationBucket.GetApprovalBytes())
+//	s.SendTxBlock(user, msgMigrationBucket)
+//	s.Require().NoError(err)
+//
+//	ctx := context.Background()
+//	queryHeadBucketRequest := storagetypes.QueryHeadBucketRequest{
+//		BucketName: bucketName,
+//	}
+//	queryHeadBucketResponse, err := s.Client.HeadBucket(ctx, &queryHeadBucketRequest)
+//	s.Require().NoError(err)
+//	s.Require().Equal(queryHeadBucketResponse.BucketInfo.BucketName, bucketName)
+//	s.Require().Equal(queryHeadBucketResponse.BucketInfo.BucketStatus, storagetypes.BUCKET_STATUS_MIGRATING)
+//
+//	// Dest SP reject the migration
+//	rejectMigration := storagetypes.NewMsgRejectMigrateBucket(dstPrimarySP.OperatorKey.GetAddr(), bucketName)
+//	s.SendTxBlock(dstPrimarySP.OperatorKey, rejectMigration)
+//	s.Require().NoError(err)
+//
+//	queryHeadBucketRequest = storagetypes.QueryHeadBucketRequest{
+//		BucketName: bucketName,
+//	}
+//	queryHeadBucketResponse, err = s.Client.HeadBucket(ctx, &queryHeadBucketRequest)
+//	s.Require().NoError(err)
+//	s.Require().Equal(queryHeadBucketResponse.BucketInfo.BucketStatus, storagetypes.BUCKET_STATUS_CREATED)
+//
+//	// migrate bucket again
+//	msgMigrationBucket = storagetypes.NewMsgMigrateBucket(user.GetAddr(), bucketName, dstPrimarySP.Info.Id)
+//	msgMigrationBucket.DstPrimarySpApproval.ExpiredHeight = math.MaxInt
+//	msgMigrationBucket.DstPrimarySpApproval.Sig, err = dstPrimarySP.ApprovalKey.Sign(msgMigrationBucket.GetApprovalBytes())
+//	s.SendTxBlock(user, msgMigrationBucket)
+//	s.Require().NoError(err)
+//
+//	// cancel migration by user
+//	msgCancelMigrationBucket := storagetypes.NewMsgCancelMigrateBucket(user.GetAddr(), bucketName)
+//	s.SendTxBlock(user, msgCancelMigrationBucket)
+//	s.Require().NoError(err)
+//
+//	queryHeadBucketResponse, err = s.Client.HeadBucket(ctx, &queryHeadBucketRequest)
+//	s.Require().NoError(err)
+//	s.Require().Equal(queryHeadBucketResponse.BucketInfo.BucketStatus, storagetypes.BUCKET_STATUS_CREATED)
+//
+//	// dest SP should fail to reject
+//	s.Client.SetKeyManager(dstPrimarySP.OperatorKey)
+//	_, err = s.Client.BroadcastTx(context.Background(), []sdk.Msg{rejectMigration}, nil)
+//	s.Require().Error(err)
+//	s.Require().Equal(queryHeadBucketResponse.BucketInfo.BucketStatus, storagetypes.BUCKET_STATUS_CREATED)
+//}

--- a/e2e/tests/virtualgroup_test.go
+++ b/e2e/tests/virtualgroup_test.go
@@ -23,8 +23,6 @@ import (
 	"github.com/bnb-chain/greenfield/e2e/core"
 	"github.com/bnb-chain/greenfield/sdk/types"
 	storagetestutil "github.com/bnb-chain/greenfield/testutil/storage"
-	"github.com/bnb-chain/greenfield/types/common"
-	sptypes "github.com/bnb-chain/greenfield/x/sp/types"
 	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
 	virtualgroupmoduletypes "github.com/bnb-chain/greenfield/x/virtualgroup/types"
 )
@@ -357,204 +355,204 @@ func (s *VirtualGroupTestSuite) createObject() (string, string, *core.StoragePro
 	return bucketName, objectName, sp, secondarySps, gvg.FamilyId, gvg.Id
 }
 
-func (s *VirtualGroupTestSuite) TestSPExit() {
-	user := s.GenAndChargeAccounts(1, 1000000)[0]
-	// 1, create a new storage provider
-	sp := s.BaseSuite.CreateNewStorageProvider()
-	s.T().Logf("new SP Info: %s", sp.Info.String())
+//func (s *VirtualGroupTestSuite) TestSPExit() {
+//	user := s.GenAndChargeAccounts(1, 1000000)[0]
+//	// 1, create a new storage provider
+//	sp := s.BaseSuite.CreateNewStorageProvider()
+//	s.T().Logf("new SP Info: %s", sp.Info.String())
+//
+//	successorSp := s.BaseSuite.PickStorageProvider()
+//
+//	// 2, create a new gvg group for this storage provider
+//	var secondarySPIDs []uint32
+//	for _, ssp := range s.StorageProviders {
+//		if ssp.Info.Id != successorSp.Info.Id {
+//			secondarySPIDs = append(secondarySPIDs, ssp.Info.Id)
+//		}
+//		if len(secondarySPIDs) == 6 {
+//			break
+//		}
+//	}
+//
+//	gvgID, familyID := s.BaseSuite.CreateGlobalVirtualGroup(sp, 0, secondarySPIDs, 1)
+//
+//	// 3. create object
+//	s.BaseSuite.CreateObject(user, sp, gvgID, storagetestutil.GenRandomBucketName(), storagetestutil.GenRandomObjectName())
+//
+//	// 4. Create another gvg contains this new sp
+//	var anotherSP *core.StorageProvider
+//	for _, tsp := range s.StorageProviders {
+//		if tsp.Info.Id != sp.Info.Id && tsp.Info.Id != successorSp.Info.Id {
+//			anotherSP = tsp
+//			break
+//		}
+//	}
+//	var anotherSecondarySPIDs []uint32
+//	for _, ssp := range s.StorageProviders {
+//		if ssp.Info.Id != successorSp.Info.Id && ssp.Info.Id != anotherSP.Info.Id {
+//			anotherSecondarySPIDs = append(anotherSecondarySPIDs, ssp.Info.Id)
+//		}
+//		if len(anotherSecondarySPIDs) == 5 {
+//			break
+//		}
+//	}
+//	anotherSecondarySPIDs = append(anotherSecondarySPIDs, sp.Info.Id)
+//
+//	anotherGVGID, _ := s.BaseSuite.CreateGlobalVirtualGroup(anotherSP, 0, anotherSecondarySPIDs, 1)
+//
+//	// 5. sp exit
+//	s.SendTxBlock(sp.OperatorKey, &virtualgroupmoduletypes.MsgStorageProviderExit{
+//		StorageProvider: sp.OperatorKey.GetAddr().String(),
+//	})
+//
+//	resp, err := s.Client.StorageProvider(context.Background(), &sptypes.QueryStorageProviderRequest{Id: sp.Info.Id})
+//	s.Require().NoError(err)
+//	s.Require().Equal(resp.StorageProvider.Status, sptypes.STATUS_GRACEFUL_EXITING)
+//
+//	// 6. sp complete exit failed
+//	s.SendTxBlockWithExpectErrorString(
+//		&virtualgroupmoduletypes.MsgCompleteStorageProviderExit{StorageProvider: sp.OperatorKey.GetAddr().String()},
+//		sp.OperatorKey,
+//		"not swap out from all the family")
+//
+//	// 7. swap out, as primary sp
+//	msgSwapOut := virtualgroupmoduletypes.NewMsgSwapOut(sp.OperatorKey.GetAddr(), familyID, nil, successorSp.Info.Id)
+//	msgSwapOut.SuccessorSpApproval = &common.Approval{ExpiredHeight: math.MaxUint}
+//	msgSwapOut.SuccessorSpApproval.Sig, err = successorSp.ApprovalKey.Sign(msgSwapOut.GetApprovalBytes())
+//	s.Require().NoError(err)
+//	s.SendTxBlock(sp.OperatorKey, msgSwapOut)
+//
+//	// 9. cancel swap out
+//	msgCancelSwapOut := virtualgroupmoduletypes.NewMsgCancelSwapOut(sp.OperatorKey.GetAddr(), familyID, nil)
+//	s.Require().NoError(err)
+//	s.SendTxBlock(sp.OperatorKey, msgCancelSwapOut)
+//
+//	// 10. complete swap out, as primary sp
+//	msgCompleteSwapOut := virtualgroupmoduletypes.NewMsgCompleteSwapOut(successorSp.OperatorKey.GetAddr(), familyID, nil)
+//	s.Require().NoError(err)
+//	s.SendTxBlockWithExpectErrorString(msgCompleteSwapOut, successorSp.OperatorKey, "The swap info not found in blockchain")
+//
+//	// 11 swap again
+//	msgSwapOut = virtualgroupmoduletypes.NewMsgSwapOut(sp.OperatorKey.GetAddr(), familyID, nil, successorSp.Info.Id)
+//	msgSwapOut.SuccessorSpApproval = &common.Approval{ExpiredHeight: math.MaxUint}
+//	msgSwapOut.SuccessorSpApproval.Sig, err = successorSp.ApprovalKey.Sign(msgSwapOut.GetApprovalBytes())
+//	s.Require().NoError(err)
+//	s.SendTxBlock(sp.OperatorKey, msgSwapOut)
+//
+//	// 12. sp complete exit failed
+//	s.SendTxBlockWithExpectErrorString(
+//		&virtualgroupmoduletypes.MsgCompleteStorageProviderExit{StorageProvider: sp.OperatorKey.GetAddr().String()},
+//		sp.OperatorKey,
+//		"not swap out from all the family")
+//
+//	// 13. complete swap out, as primary sp
+//	msgCompleteSwapOut = virtualgroupmoduletypes.NewMsgCompleteSwapOut(successorSp.OperatorKey.GetAddr(), familyID, nil)
+//	s.Require().NoError(err)
+//	s.SendTxBlock(successorSp.OperatorKey, msgCompleteSwapOut)
+//
+//	// 14. exist failed
+//	s.SendTxBlockWithExpectErrorString(
+//		&virtualgroupmoduletypes.MsgCompleteStorageProviderExit{StorageProvider: sp.OperatorKey.GetAddr().String()},
+//		sp.OperatorKey,
+//		"not swap out from all the gvgs")
+//
+//	// 15. swap out, as secondary sp
+//	msgSwapOut2 := virtualgroupmoduletypes.NewMsgSwapOut(sp.OperatorKey.GetAddr(), 0, []uint32{anotherGVGID}, successorSp.Info.Id)
+//	msgSwapOut2.SuccessorSpApproval = &common.Approval{ExpiredHeight: math.MaxUint}
+//	msgSwapOut2.SuccessorSpApproval.Sig, err = successorSp.ApprovalKey.Sign(msgSwapOut2.GetApprovalBytes())
+//	s.Require().NoError(err)
+//	s.SendTxBlock(sp.OperatorKey, msgSwapOut2)
+//
+//	// 16. exist failed
+//	s.SendTxBlockWithExpectErrorString(
+//		&virtualgroupmoduletypes.MsgCompleteStorageProviderExit{StorageProvider: sp.OperatorKey.GetAddr().String()},
+//		sp.OperatorKey,
+//		"not swap out from all the gvgs")
+//
+//	// 17 cancel swap out as secondary sp
+//	msgCancelSwapOut = virtualgroupmoduletypes.NewMsgCancelSwapOut(sp.OperatorKey.GetAddr(), 0, []uint32{anotherGVGID})
+//	s.Require().NoError(err)
+//	s.SendTxBlock(sp.OperatorKey, msgCancelSwapOut)
+//
+//	// 18. swap
+//	msgCompleteSwapOut2 := virtualgroupmoduletypes.NewMsgCompleteSwapOut(successorSp.OperatorKey.GetAddr(), 0, []uint32{anotherGVGID})
+//	s.Require().NoError(err)
+//	s.SendTxBlockWithExpectErrorString(msgCompleteSwapOut2, successorSp.OperatorKey, "The swap info not found in blockchain")
+//
+//	// 19. swap out again, as secondary sp
+//	msgSwapOut2 = virtualgroupmoduletypes.NewMsgSwapOut(sp.OperatorKey.GetAddr(), 0, []uint32{anotherGVGID}, successorSp.Info.Id)
+//	msgSwapOut2.SuccessorSpApproval = &common.Approval{ExpiredHeight: math.MaxUint}
+//	msgSwapOut2.SuccessorSpApproval.Sig, err = successorSp.ApprovalKey.Sign(msgSwapOut2.GetApprovalBytes())
+//	s.Require().NoError(err)
+//	s.SendTxBlock(sp.OperatorKey, msgSwapOut2)
+//
+//	// 20 complete swap out
+//	msgCompleteSwapOut2 = virtualgroupmoduletypes.NewMsgCompleteSwapOut(successorSp.OperatorKey.GetAddr(), 0, []uint32{anotherGVGID})
+//	s.Require().NoError(err)
+//	s.SendTxBlock(successorSp.OperatorKey, msgCompleteSwapOut2)
+//
+//	// 18. sp complete exit success
+//	s.SendTxBlock(
+//		sp.OperatorKey,
+//		&virtualgroupmoduletypes.MsgCompleteStorageProviderExit{StorageProvider: sp.OperatorKey.GetAddr().String()},
+//	)
+//}
 
-	successorSp := s.BaseSuite.PickStorageProvider()
-
-	// 2, create a new gvg group for this storage provider
-	var secondarySPIDs []uint32
-	for _, ssp := range s.StorageProviders {
-		if ssp.Info.Id != successorSp.Info.Id {
-			secondarySPIDs = append(secondarySPIDs, ssp.Info.Id)
-		}
-		if len(secondarySPIDs) == 6 {
-			break
-		}
-	}
-
-	gvgID, familyID := s.BaseSuite.CreateGlobalVirtualGroup(sp, 0, secondarySPIDs, 1)
-
-	// 3. create object
-	s.BaseSuite.CreateObject(user, sp, gvgID, storagetestutil.GenRandomBucketName(), storagetestutil.GenRandomObjectName())
-
-	// 4. Create another gvg contains this new sp
-	var anotherSP *core.StorageProvider
-	for _, tsp := range s.StorageProviders {
-		if tsp.Info.Id != sp.Info.Id && tsp.Info.Id != successorSp.Info.Id {
-			anotherSP = tsp
-			break
-		}
-	}
-	var anotherSecondarySPIDs []uint32
-	for _, ssp := range s.StorageProviders {
-		if ssp.Info.Id != successorSp.Info.Id && ssp.Info.Id != anotherSP.Info.Id {
-			anotherSecondarySPIDs = append(anotherSecondarySPIDs, ssp.Info.Id)
-		}
-		if len(anotherSecondarySPIDs) == 5 {
-			break
-		}
-	}
-	anotherSecondarySPIDs = append(anotherSecondarySPIDs, sp.Info.Id)
-
-	anotherGVGID, _ := s.BaseSuite.CreateGlobalVirtualGroup(anotherSP, 0, anotherSecondarySPIDs, 1)
-
-	// 5. sp exit
-	s.SendTxBlock(sp.OperatorKey, &virtualgroupmoduletypes.MsgStorageProviderExit{
-		StorageProvider: sp.OperatorKey.GetAddr().String(),
-	})
-
-	resp, err := s.Client.StorageProvider(context.Background(), &sptypes.QueryStorageProviderRequest{Id: sp.Info.Id})
-	s.Require().NoError(err)
-	s.Require().Equal(resp.StorageProvider.Status, sptypes.STATUS_GRACEFUL_EXITING)
-
-	// 6. sp complete exit failed
-	s.SendTxBlockWithExpectErrorString(
-		&virtualgroupmoduletypes.MsgCompleteStorageProviderExit{StorageProvider: sp.OperatorKey.GetAddr().String()},
-		sp.OperatorKey,
-		"not swap out from all the family")
-
-	// 7. swap out, as primary sp
-	msgSwapOut := virtualgroupmoduletypes.NewMsgSwapOut(sp.OperatorKey.GetAddr(), familyID, nil, successorSp.Info.Id)
-	msgSwapOut.SuccessorSpApproval = &common.Approval{ExpiredHeight: math.MaxUint}
-	msgSwapOut.SuccessorSpApproval.Sig, err = successorSp.ApprovalKey.Sign(msgSwapOut.GetApprovalBytes())
-	s.Require().NoError(err)
-	s.SendTxBlock(sp.OperatorKey, msgSwapOut)
-
-	// 9. cancel swap out
-	msgCancelSwapOut := virtualgroupmoduletypes.NewMsgCancelSwapOut(sp.OperatorKey.GetAddr(), familyID, nil)
-	s.Require().NoError(err)
-	s.SendTxBlock(sp.OperatorKey, msgCancelSwapOut)
-
-	// 10. complete swap out, as primary sp
-	msgCompleteSwapOut := virtualgroupmoduletypes.NewMsgCompleteSwapOut(successorSp.OperatorKey.GetAddr(), familyID, nil)
-	s.Require().NoError(err)
-	s.SendTxBlockWithExpectErrorString(msgCompleteSwapOut, successorSp.OperatorKey, "The swap info not found in blockchain")
-
-	// 11 swap again
-	msgSwapOut = virtualgroupmoduletypes.NewMsgSwapOut(sp.OperatorKey.GetAddr(), familyID, nil, successorSp.Info.Id)
-	msgSwapOut.SuccessorSpApproval = &common.Approval{ExpiredHeight: math.MaxUint}
-	msgSwapOut.SuccessorSpApproval.Sig, err = successorSp.ApprovalKey.Sign(msgSwapOut.GetApprovalBytes())
-	s.Require().NoError(err)
-	s.SendTxBlock(sp.OperatorKey, msgSwapOut)
-
-	// 12. sp complete exit failed
-	s.SendTxBlockWithExpectErrorString(
-		&virtualgroupmoduletypes.MsgCompleteStorageProviderExit{StorageProvider: sp.OperatorKey.GetAddr().String()},
-		sp.OperatorKey,
-		"not swap out from all the family")
-
-	// 13. complete swap out, as primary sp
-	msgCompleteSwapOut = virtualgroupmoduletypes.NewMsgCompleteSwapOut(successorSp.OperatorKey.GetAddr(), familyID, nil)
-	s.Require().NoError(err)
-	s.SendTxBlock(successorSp.OperatorKey, msgCompleteSwapOut)
-
-	// 14. exist failed
-	s.SendTxBlockWithExpectErrorString(
-		&virtualgroupmoduletypes.MsgCompleteStorageProviderExit{StorageProvider: sp.OperatorKey.GetAddr().String()},
-		sp.OperatorKey,
-		"not swap out from all the gvgs")
-
-	// 15. swap out, as secondary sp
-	msgSwapOut2 := virtualgroupmoduletypes.NewMsgSwapOut(sp.OperatorKey.GetAddr(), 0, []uint32{anotherGVGID}, successorSp.Info.Id)
-	msgSwapOut2.SuccessorSpApproval = &common.Approval{ExpiredHeight: math.MaxUint}
-	msgSwapOut2.SuccessorSpApproval.Sig, err = successorSp.ApprovalKey.Sign(msgSwapOut2.GetApprovalBytes())
-	s.Require().NoError(err)
-	s.SendTxBlock(sp.OperatorKey, msgSwapOut2)
-
-	// 16. exist failed
-	s.SendTxBlockWithExpectErrorString(
-		&virtualgroupmoduletypes.MsgCompleteStorageProviderExit{StorageProvider: sp.OperatorKey.GetAddr().String()},
-		sp.OperatorKey,
-		"not swap out from all the gvgs")
-
-	// 17 cancel swap out as secondary sp
-	msgCancelSwapOut = virtualgroupmoduletypes.NewMsgCancelSwapOut(sp.OperatorKey.GetAddr(), 0, []uint32{anotherGVGID})
-	s.Require().NoError(err)
-	s.SendTxBlock(sp.OperatorKey, msgCancelSwapOut)
-
-	// 18. swap
-	msgCompleteSwapOut2 := virtualgroupmoduletypes.NewMsgCompleteSwapOut(successorSp.OperatorKey.GetAddr(), 0, []uint32{anotherGVGID})
-	s.Require().NoError(err)
-	s.SendTxBlockWithExpectErrorString(msgCompleteSwapOut2, successorSp.OperatorKey, "The swap info not found in blockchain")
-
-	// 19. swap out again, as secondary sp
-	msgSwapOut2 = virtualgroupmoduletypes.NewMsgSwapOut(sp.OperatorKey.GetAddr(), 0, []uint32{anotherGVGID}, successorSp.Info.Id)
-	msgSwapOut2.SuccessorSpApproval = &common.Approval{ExpiredHeight: math.MaxUint}
-	msgSwapOut2.SuccessorSpApproval.Sig, err = successorSp.ApprovalKey.Sign(msgSwapOut2.GetApprovalBytes())
-	s.Require().NoError(err)
-	s.SendTxBlock(sp.OperatorKey, msgSwapOut2)
-
-	// 20 complete swap out
-	msgCompleteSwapOut2 = virtualgroupmoduletypes.NewMsgCompleteSwapOut(successorSp.OperatorKey.GetAddr(), 0, []uint32{anotherGVGID})
-	s.Require().NoError(err)
-	s.SendTxBlock(successorSp.OperatorKey, msgCompleteSwapOut2)
-
-	// 18. sp complete exit success
-	s.SendTxBlock(
-		sp.OperatorKey,
-		&virtualgroupmoduletypes.MsgCompleteStorageProviderExit{StorageProvider: sp.OperatorKey.GetAddr().String()},
-	)
-}
-
-func (s *VirtualGroupTestSuite) TestSPExit_CreateAndDeleteBucket() {
-	user := s.GenAndChargeAccounts(1, 1000000)[0]
-	bucketName := storagetestutil.GenRandomBucketName()
-	objectName := storagetestutil.GenRandomObjectName()
-	// 1, create a new storage provider
-	sp := s.BaseSuite.CreateNewStorageProvider()
-	s.T().Logf("new SP Info: %s", sp.Info.String())
-
-	successorSp := s.BaseSuite.PickStorageProvider()
-
-	// 2, create a new gvg group for this storage provider
-	var secondarySPIDs []uint32
-	for _, ssp := range s.StorageProviders {
-		if ssp.Info.Id != successorSp.Info.Id {
-			secondarySPIDs = append(secondarySPIDs, ssp.Info.Id)
-		}
-		if len(secondarySPIDs) == 6 {
-			break
-		}
-	}
-
-	gvgID, _ := s.BaseSuite.CreateGlobalVirtualGroup(sp, 0, secondarySPIDs, 1)
-
-	// 3. create object
-	s.BaseSuite.CreateObject(user, sp, gvgID, bucketName, objectName)
-
-	// 4. sp apply exit
-	s.SendTxBlock(sp.OperatorKey, &virtualgroupmoduletypes.MsgStorageProviderExit{
-		StorageProvider: sp.OperatorKey.GetAddr().String(),
-	})
-
-	resp, err := s.Client.StorageProvider(context.Background(), &sptypes.QueryStorageProviderRequest{Id: sp.Info.Id})
-	s.Require().NoError(err)
-	s.Require().Equal(resp.StorageProvider.Status, sptypes.STATUS_GRACEFUL_EXITING)
-
-	// 5. sp complete exit failed
-	s.SendTxBlockWithExpectErrorString(
-		&virtualgroupmoduletypes.MsgCompleteStorageProviderExit{StorageProvider: sp.OperatorKey.GetAddr().String()},
-		sp.OperatorKey,
-		"not swap out from all the family")
-
-	// 6. delete object
-	s.SendTxBlock(user, storagetypes.NewMsgDeleteObject(user.GetAddr(), bucketName, objectName))
-
-	// 7. delete bucket
-	s.SendTxBlock(user, storagetypes.NewMsgDeleteBucket(user.GetAddr(), bucketName))
-
-	// 8. delete gvg
-	s.SendTxBlock(sp.OperatorKey, virtualgroupmoduletypes.NewMsgDeleteGlobalVirtualGroup(sp.OperatorKey.GetAddr(), gvgID))
-	// 8. sp complete exit success
-	s.SendTxBlock(
-		sp.OperatorKey,
-		&virtualgroupmoduletypes.MsgCompleteStorageProviderExit{StorageProvider: sp.OperatorKey.GetAddr().String()},
-	)
-}
+//func (s *VirtualGroupTestSuite) TestSPExit_CreateAndDeleteBucket() {
+//	user := s.GenAndChargeAccounts(1, 1000000)[0]
+//	bucketName := storagetestutil.GenRandomBucketName()
+//	objectName := storagetestutil.GenRandomObjectName()
+//	// 1, create a new storage provider
+//	sp := s.BaseSuite.CreateNewStorageProvider()
+//	s.T().Logf("new SP Info: %s", sp.Info.String())
+//
+//	successorSp := s.BaseSuite.PickStorageProvider()
+//
+//	// 2, create a new gvg group for this storage provider
+//	var secondarySPIDs []uint32
+//	for _, ssp := range s.StorageProviders {
+//		if ssp.Info.Id != successorSp.Info.Id {
+//			secondarySPIDs = append(secondarySPIDs, ssp.Info.Id)
+//		}
+//		if len(secondarySPIDs) == 6 {
+//			break
+//		}
+//	}
+//
+//	gvgID, _ := s.BaseSuite.CreateGlobalVirtualGroup(sp, 0, secondarySPIDs, 1)
+//
+//	// 3. create object
+//	s.BaseSuite.CreateObject(user, sp, gvgID, bucketName, objectName)
+//
+//	// 4. sp apply exit
+//	s.SendTxBlock(sp.OperatorKey, &virtualgroupmoduletypes.MsgStorageProviderExit{
+//		StorageProvider: sp.OperatorKey.GetAddr().String(),
+//	})
+//
+//	resp, err := s.Client.StorageProvider(context.Background(), &sptypes.QueryStorageProviderRequest{Id: sp.Info.Id})
+//	s.Require().NoError(err)
+//	s.Require().Equal(resp.StorageProvider.Status, sptypes.STATUS_GRACEFUL_EXITING)
+//
+//	// 5. sp complete exit failed
+//	s.SendTxBlockWithExpectErrorString(
+//		&virtualgroupmoduletypes.MsgCompleteStorageProviderExit{StorageProvider: sp.OperatorKey.GetAddr().String()},
+//		sp.OperatorKey,
+//		"not swap out from all the family")
+//
+//	// 6. delete object
+//	s.SendTxBlock(user, storagetypes.NewMsgDeleteObject(user.GetAddr(), bucketName, objectName))
+//
+//	// 7. delete bucket
+//	s.SendTxBlock(user, storagetypes.NewMsgDeleteBucket(user.GetAddr(), bucketName))
+//
+//	// 8. delete gvg
+//	s.SendTxBlock(sp.OperatorKey, virtualgroupmoduletypes.NewMsgDeleteGlobalVirtualGroup(sp.OperatorKey.GetAddr(), gvgID))
+//	// 8. sp complete exit success
+//	s.SendTxBlock(
+//		sp.OperatorKey,
+//		&virtualgroupmoduletypes.MsgCompleteStorageProviderExit{StorageProvider: sp.OperatorKey.GetAddr().String()},
+//	)
+//}
 
 func (s *VirtualGroupTestSuite) TestUpdateVirtualGroupParams() {
 	// 1. create proposal

--- a/x/storage/keeper/keeper.go
+++ b/x/storage/keeper/keeper.go
@@ -569,7 +569,6 @@ func (k Keeper) CreateObject(
 			operator.String(), bucketName)
 	}
 
-	// We use the last address in SecondarySpAddresses to store the creator so that it can be identified when canceling create
 	var creator sdk.AccAddress
 	if !operator.Equals(sdk.MustAccAddressFromHex(bucketInfo.Owner)) {
 		creator = operator


### PR DESCRIPTION
### Description

In order to disable SP Exit and Bucket migration features for now, this pr removes gas params for below msgs:

1. MsgSwapOut
2. MsgCompleteSwapOut
3. MsgCancelSwapOut
4. MsgStorageProviderExit
5. MsgCompleteStorageProviderExit
6. MsgMigrateBucket
7. MsgCancelMigrateBucket
8. MsgCompleteMigrateBucket

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...
