### PR TITLE
fix: restrict on creating GVG and allow empty family

### DIFF
--- a/deployment/localup/localup.sh
+++ b/deployment/localup/localup.sh
@@ -173,6 +173,7 @@ function generate_genesis() {
         sed -i -e "s/log_level = \"info\"/\log_level= \"debug\"/g" ${workspace}/.local/validator${i}/config/config.toml
         echo -e '[[upgrade]]\nname = "Nagqu"\nheight = 20\ninfo = ""' >> ${workspace}/.local/validator${i}/config/app.toml
         echo -e '[[upgrade]]\nname = "Pampas"\nheight = 20\ninfo = ""' >> ${workspace}/.local/validator${i}/config/app.toml
+        echo -e '[[upgrade]]\nname = "Eddystone"\nheight = 20\ninfo = ""' >> ${workspace}/.local/validator${i}/config/app.toml
     done
 
     # enable swagger API for validator0

--- a/x/virtualgroup/keeper/keeper.go
+++ b/x/virtualgroup/keeper/keeper.go
@@ -5,14 +5,13 @@ import (
 	"fmt"
 	math2 "math"
 
-	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
-
 	"cosmossdk.io/math"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/address"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
 	"github.com/bnb-chain/greenfield/internal/sequence"
 	sptypes "github.com/bnb-chain/greenfield/x/sp/types"
@@ -164,20 +163,15 @@ func (k Keeper) DeleteGVG(ctx sdk.Context, primarySp *sptypes.StorageProvider, g
 		return err
 	}
 
-	if len(gvgFamily.GlobalVirtualGroupIds) == 0 && k.paymentKeeper.IsEmptyNetFlow(ctx, sdk.MustAccAddressFromHex(gvgFamily.VirtualPaymentAddress)) {
-		// after Eddystone, the virtual group family can be empty.
-		if !ctx.IsUpgraded(upgradetypes.Eddystone) {
-			store.Delete(types.GetGVGFamilyKey(gvg.FamilyId))
-			if err := ctx.EventManager().EmitTypedEvents(&types.EventDeleteGlobalVirtualGroupFamily{
-				Id:          gvgFamily.Id,
-				PrimarySpId: gvgFamily.PrimarySpId,
-			}); err != nil {
-				return err
-			}
-		} else {
-			if err := k.SetGVGFamilyAndEmitUpdateEvent(ctx, gvgFamily); err != nil {
-				return err
-			}
+	if len(gvgFamily.GlobalVirtualGroupIds) == 0 &&
+		k.paymentKeeper.IsEmptyNetFlow(ctx, sdk.MustAccAddressFromHex(gvgFamily.VirtualPaymentAddress)) &&
+		!ctx.IsUpgraded(upgradetypes.Eddystone) {
+		store.Delete(types.GetGVGFamilyKey(gvg.FamilyId))
+		if err := ctx.EventManager().EmitTypedEvents(&types.EventDeleteGlobalVirtualGroupFamily{
+			Id:          gvgFamily.Id,
+			PrimarySpId: gvgFamily.PrimarySpId,
+		}); err != nil {
+			return err
 		}
 	} else {
 		if err := k.SetGVGFamilyAndEmitUpdateEvent(ctx, gvgFamily); err != nil {

--- a/x/virtualgroup/keeper/msg_server.go
+++ b/x/virtualgroup/keeper/msg_server.go
@@ -105,6 +105,23 @@ func (k msgServer) CreateGlobalVirtualGroup(goCtx context.Context, req *types.Ms
 		return nil, err
 	}
 
+	if ctx.IsUpgraded(upgradetypes.Eddystone) {
+		for _, gvgID := range gvgFamily.GlobalVirtualGroupIds {
+			gvg, found := k.GetGVG(ctx, gvgID)
+			if !found {
+				return nil, types.ErrGVGNotExist
+			}
+			for i, secondarySPId := range gvg.SecondarySpIds {
+				if secondarySPId != secondarySpIds[i] {
+					break
+				}
+				if i == len(secondarySpIds)-1 {
+					return nil, types.ErrDuplicateGVG.Wrapf("the global virtual group family already has a GVG with same SP in same order")
+				}
+			}
+		}
+	}
+
 	// Each family supports only a limited number of GVGS
 	if k.MaxGlobalVirtualGroupNumPerFamily(ctx) < uint32(len(gvgFamily.GlobalVirtualGroupIds)) {
 		return nil, types.ErrLimitationExceed.Wrapf("The gvg number within the family exceeds the limit.")

--- a/x/virtualgroup/types/errors.go
+++ b/x/virtualgroup/types/errors.go
@@ -22,6 +22,7 @@ var (
 	ErrLimitationExceed        = errors.Register(ModuleName, 1123, "limitation exceed.")
 	ErrDuplicateSecondarySP    = errors.Register(ModuleName, 1124, "the global virtual group has duplicate secondary sp.")
 	ErrInsufficientStaking     = errors.Register(ModuleName, 1125, "insufficient staking for gvg")
+	ErrDuplicateGVG            = errors.Register(ModuleName, 1126, "global virtual group is duplicate")
 
 	ErrInvalidDenom = errors.Register(ModuleName, 2000, "Invalid denom.")
 )


### PR DESCRIPTION
### Description

This pr contains 2 changes:
1. Creating a GVG should not be identical to others within a virtual group family. 
2. Deleting the last GVG in a Global Virtual Group Family will not result in the deletion of the family. 
    Previously, when a family is deleted, all buckets(empty bucket) related to such family still have the stale family info, but actually the family no longer exist, user is not able to re-create objet. This change will keep the empty family and user can  re-create object in the empty bucket. 

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...
