### PR TITLE
feat: add crosschain permission app

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -745,7 +745,7 @@ func (app *App) initBridge() {
 }
 
 func (app *App) initStorage() {
-	storagemodulekeeper.RegisterCrossApps(app.StorageKeeper, app.PermissionmoduleKeeper)
+	storagemodulekeeper.RegisterCrossApps(app.StorageKeeper)
 }
 
 func (app *App) initGov() {

--- a/app/app.go
+++ b/app/app.go
@@ -745,7 +745,7 @@ func (app *App) initBridge() {
 }
 
 func (app *App) initStorage() {
-	storagemodulekeeper.RegisterCrossApps(app.StorageKeeper)
+	storagemodulekeeper.RegisterCrossApps(app.StorageKeeper, app.PermissionmoduleKeeper)
 }
 
 func (app *App) initGov() {

--- a/x/storage/keeper/cross_app.go
+++ b/x/storage/keeper/cross_app.go
@@ -24,7 +24,7 @@ func RegisterCrossApps(keeper Keeper, permissionKeeper permissionmodulekeeper.Ke
 		panic(err)
 	}
 
-	permissionApp := NewPermissionApp(permissionKeeper)
+	permissionApp := NewPermissionApp(keeper, permissionKeeper)
 	err = keeper.crossChainKeeper.RegisterChannel(types.PermissionChannel, types.PermissionChannelId, permissionApp)
 	if err != nil {
 		panic(err)

--- a/x/storage/keeper/cross_app.go
+++ b/x/storage/keeper/cross_app.go
@@ -1,10 +1,11 @@
 package keeper
 
 import (
+	permissionmodulekeeper "github.com/bnb-chain/greenfield/x/permission/keeper"
 	"github.com/bnb-chain/greenfield/x/storage/types"
 )
 
-func RegisterCrossApps(keeper Keeper) {
+func RegisterCrossApps(keeper Keeper, permissionKeeper permissionmodulekeeper.Keeper) {
 	bucketApp := NewBucketApp(keeper)
 	err := keeper.crossChainKeeper.RegisterChannel(types.BucketChannel, types.BucketChannelId, bucketApp)
 	if err != nil {
@@ -19,6 +20,12 @@ func RegisterCrossApps(keeper Keeper) {
 
 	groupApp := NewGroupApp(keeper)
 	err = keeper.crossChainKeeper.RegisterChannel(types.GroupChannel, types.GroupChannelId, groupApp)
+	if err != nil {
+		panic(err)
+	}
+
+	permissionApp := NewPermissionApp(permissionKeeper)
+	err = keeper.crossChainKeeper.RegisterChannel(types.PermissionChannel, types.PermissionChannelId, permissionApp)
 	if err != nil {
 		panic(err)
 	}

--- a/x/storage/keeper/cross_app.go
+++ b/x/storage/keeper/cross_app.go
@@ -1,11 +1,10 @@
 package keeper
 
 import (
-	permissionmodulekeeper "github.com/bnb-chain/greenfield/x/permission/keeper"
 	"github.com/bnb-chain/greenfield/x/storage/types"
 )
 
-func RegisterCrossApps(keeper Keeper, permissionKeeper permissionmodulekeeper.Keeper) {
+func RegisterCrossApps(keeper Keeper) {
 	bucketApp := NewBucketApp(keeper)
 	err := keeper.crossChainKeeper.RegisterChannel(types.BucketChannel, types.BucketChannelId, bucketApp)
 	if err != nil {
@@ -24,7 +23,7 @@ func RegisterCrossApps(keeper Keeper, permissionKeeper permissionmodulekeeper.Ke
 		panic(err)
 	}
 
-	permissionApp := NewPermissionApp(keeper, permissionKeeper)
+	permissionApp := NewPermissionApp(keeper, keeper.permKeeper)
 	err = keeper.crossChainKeeper.RegisterChannel(types.PermissionChannel, types.PermissionChannelId, permissionApp)
 	if err != nil {
 		panic(err)

--- a/x/storage/keeper/cross_app_permission.go
+++ b/x/storage/keeper/cross_app_permission.go
@@ -1,11 +1,12 @@
 package keeper
 
 import (
-	"cosmossdk.io/math"
 	"encoding/json"
-	permtypes "github.com/bnb-chain/greenfield/x/permission/types"
+
+	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	permtypes "github.com/bnb-chain/greenfield/x/permission/types"
 	"github.com/bnb-chain/greenfield/x/storage/types"
 )
 

--- a/x/storage/keeper/cross_app_permission.go
+++ b/x/storage/keeper/cross_app_permission.go
@@ -1,0 +1,221 @@
+package keeper
+
+import (
+	"cosmossdk.io/math"
+	"encoding/json"
+	permtypes "github.com/bnb-chain/greenfield/x/permission/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/bnb-chain/greenfield/x/storage/types"
+)
+
+var _ sdk.CrossChainApplication = &PermissionApp{}
+
+type PermissionApp struct {
+	permissionKeeper types.PermissionKeeper
+}
+
+func NewPermissionApp(keeper types.PermissionKeeper) *PermissionApp {
+	return &PermissionApp{
+		permissionKeeper: keeper,
+	}
+}
+
+func (app *PermissionApp) ExecuteAckPackage(ctx sdk.Context, appCtx *sdk.CrossChainAppContext, payload []byte) sdk.ExecuteResult {
+	pack, err := types.DeserializeCrossChainPackage(payload, types.PermissionChannelId, sdk.AckCrossChainPackageType)
+	if err != nil {
+		panic("deserialize Policy cross chain package error")
+	}
+
+	var operationType uint8
+	var result sdk.ExecuteResult
+	switch p := pack.(type) {
+	case *types.CreatePolicyAckPackage:
+		operationType = types.OperationCreatePolicy
+		result = app.handleCreatePolicyAckPackage(ctx, appCtx, p)
+	case *types.DeletePolicyAckPackage:
+		operationType = types.OperationDeletePolicy
+		result = app.handleDeletePolicyAckPackage(ctx, appCtx, p)
+	default:
+		panic("unknown cross chain ack package type")
+	}
+
+	if len(result.Payload) != 0 {
+		wrapPayload := types.CrossChainPackage{
+			OperationType: operationType,
+			Package:       result.Payload,
+		}
+		result.Payload = wrapPayload.MustSerialize()
+	}
+
+	return result
+}
+
+func (app *PermissionApp) ExecuteFailAckPackage(ctx sdk.Context, appCtx *sdk.CrossChainAppContext, payload []byte) sdk.ExecuteResult {
+	pack, err := types.DeserializeCrossChainPackage(payload, types.PermissionChannelId, sdk.FailAckCrossChainPackageType)
+	if err != nil {
+		panic("deserialize Policy cross chain package error")
+	}
+
+	var operationType uint8
+	var result sdk.ExecuteResult
+	switch p := pack.(type) {
+	case *types.CreatePolicySynPackage:
+		operationType = types.OperationCreatePolicy
+		result = app.handleCreatePolicyFailAckPackage(ctx, appCtx, p)
+	case *types.DeletePolicySynPackage:
+		operationType = types.OperationDeletePolicy
+		result = app.handleDeletePolicyFailAckPackage(ctx, appCtx, p)
+	default:
+		panic("unknown cross chain ack package type")
+	}
+
+	if len(result.Payload) != 0 {
+		wrapPayload := types.CrossChainPackage{
+			OperationType: operationType,
+			Package:       result.Payload,
+		}
+		result.Payload = wrapPayload.MustSerialize()
+	}
+
+	return result
+}
+
+func (app *PermissionApp) ExecuteSynPackage(ctx sdk.Context, appCtx *sdk.CrossChainAppContext, payload []byte) sdk.ExecuteResult {
+	pack, err := types.DeserializeCrossChainPackage(payload, types.PermissionChannelId, sdk.SynCrossChainPackageType)
+	if err != nil {
+		panic("deserialize Policy cross chain package error")
+	}
+
+	var operationType uint8
+	var result sdk.ExecuteResult
+	switch p := pack.(type) {
+	case *types.CreatePolicySynPackage:
+		operationType = types.OperationCreatePolicy
+		result = app.handleCreatePolicySynPackage(ctx, p)
+	case *types.DeletePolicySynPackage:
+		operationType = types.OperationDeletePolicy
+		result = app.handleDeletePolicySynPackage(ctx, p)
+	default:
+		return sdk.ExecuteResult{
+			Err: types.ErrInvalidCrossChainPackage,
+		}
+	}
+
+	if len(result.Payload) != 0 {
+		wrapPayload := types.CrossChainPackage{
+			OperationType: operationType,
+			Package:       result.Payload,
+		}
+		result.Payload = wrapPayload.MustSerialize()
+	}
+
+	return result
+}
+
+func (app *PermissionApp) handleDeletePolicyAckPackage(ctx sdk.Context, appCtx *sdk.CrossChainAppContext, ackPackage *types.DeletePolicyAckPackage) sdk.ExecuteResult {
+	return sdk.ExecuteResult{}
+}
+
+func (app *PermissionApp) handleDeletePolicyFailAckPackage(ctx sdk.Context, appCtx *sdk.CrossChainAppContext, synPackage *types.DeletePolicySynPackage) sdk.ExecuteResult {
+	return sdk.ExecuteResult{}
+}
+
+func (app *PermissionApp) handleDeletePolicySynPackage(ctx sdk.Context, deletePolicyPackage *types.DeletePolicySynPackage) sdk.ExecuteResult {
+	err := deletePolicyPackage.ValidateBasic()
+	if err != nil {
+		return sdk.ExecuteResult{
+			Payload: types.DeletePolicyAckPackage{
+				Status:    types.StatusFail,
+				ExtraData: deletePolicyPackage.ExtraData,
+			}.MustSerialize(),
+			Err: err,
+		}
+	}
+
+	policy, found := app.permissionKeeper.GetPolicyByID(ctx, math.NewUintFromBigInt(deletePolicyPackage.Id))
+	if !found {
+		return sdk.ExecuteResult{
+			Payload: types.DeletePolicyAckPackage{
+				Status:    types.StatusFail,
+				ExtraData: deletePolicyPackage.ExtraData,
+			}.MustSerialize(),
+			Err: types.ErrNoSuchPolicy,
+		}
+	}
+
+	_, err = app.permissionKeeper.DeletePolicy(ctx, policy.Principal, policy.ResourceType, policy.ResourceId)
+	if err != nil {
+		return sdk.ExecuteResult{
+			Payload: types.DeletePolicyAckPackage{
+				Status:    types.StatusFail,
+				ExtraData: deletePolicyPackage.ExtraData,
+			}.MustSerialize(),
+			Err: err,
+		}
+	}
+
+	return sdk.ExecuteResult{
+		Payload: types.DeletePolicyAckPackage{
+			Status:    types.StatusSuccess,
+			Id:        policy.Id.BigInt(),
+			ExtraData: deletePolicyPackage.ExtraData,
+		}.MustSerialize(),
+	}
+}
+
+func (app *PermissionApp) handleCreatePolicyAckPackage(ctx sdk.Context, appCtx *sdk.CrossChainAppContext, ackPackage *types.CreatePolicyAckPackage) sdk.ExecuteResult {
+	return sdk.ExecuteResult{}
+}
+
+func (app *PermissionApp) handleCreatePolicyFailAckPackage(ctx sdk.Context, appCtx *sdk.CrossChainAppContext, ackPackage *types.CreatePolicySynPackage) sdk.ExecuteResult {
+	return sdk.ExecuteResult{}
+}
+
+func (app *PermissionApp) handleCreatePolicySynPackage(ctx sdk.Context, createPolicyPackage *types.CreatePolicySynPackage) sdk.ExecuteResult {
+	err := createPolicyPackage.ValidateBasic()
+	if err != nil {
+		return sdk.ExecuteResult{
+			Payload: types.CreatePolicyAckPackage{
+				Status:    types.StatusFail,
+				Creator:   createPolicyPackage.Operator,
+				ExtraData: createPolicyPackage.ExtraData,
+			}.MustSerialize(),
+			Err: err,
+		}
+	}
+
+	var policy permtypes.Policy
+	err = json.Unmarshal(createPolicyPackage.Data, &policy)
+	if err != nil {
+		return sdk.ExecuteResult{
+			Payload: types.CreatePolicyAckPackage{
+				Status:    types.StatusFail,
+				Creator:   createPolicyPackage.Operator,
+				ExtraData: createPolicyPackage.ExtraData,
+			}.MustSerialize(),
+			Err: err,
+		}
+	}
+
+	PolicyId, err := app.permissionKeeper.PutPolicy(ctx, &policy)
+	if err != nil {
+		return sdk.ExecuteResult{
+			Payload: types.CreatePolicyAckPackage{
+				Status:    types.StatusFail,
+				Creator:   createPolicyPackage.Operator,
+				ExtraData: createPolicyPackage.ExtraData,
+			}.MustSerialize(),
+			Err: err,
+		}
+	}
+
+	return sdk.ExecuteResult{
+		Payload: types.CreatePolicyAckPackage{
+			Status:    types.StatusSuccess,
+			Id:        PolicyId.BigInt(),
+			Creator:   createPolicyPackage.Operator,
+			ExtraData: createPolicyPackage.ExtraData,
+		}.MustSerialize(),
+	}
+}

--- a/x/storage/keeper/cross_app_permission.go
+++ b/x/storage/keeper/cross_app_permission.go
@@ -6,6 +6,9 @@ import (
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	types2 "github.com/bnb-chain/greenfield/types"
+	gnfderrors "github.com/bnb-chain/greenfield/types/errors"
+	gnfdresource "github.com/bnb-chain/greenfield/types/resource"
 	permtypes "github.com/bnb-chain/greenfield/x/permission/types"
 	"github.com/bnb-chain/greenfield/x/storage/types"
 )
@@ -13,73 +16,23 @@ import (
 var _ sdk.CrossChainApplication = &PermissionApp{}
 
 type PermissionApp struct {
+	storageKeeper    types.StorageKeeper
 	permissionKeeper types.PermissionKeeper
 }
 
-func NewPermissionApp(keeper types.PermissionKeeper) *PermissionApp {
+func NewPermissionApp(keeper types.StorageKeeper, permissionKeeper types.PermissionKeeper) *PermissionApp {
 	return &PermissionApp{
-		permissionKeeper: keeper,
+		storageKeeper:    keeper,
+		permissionKeeper: permissionKeeper,
 	}
 }
 
 func (app *PermissionApp) ExecuteAckPackage(ctx sdk.Context, appCtx *sdk.CrossChainAppContext, payload []byte) sdk.ExecuteResult {
-	pack, err := types.DeserializeCrossChainPackage(payload, types.PermissionChannelId, sdk.AckCrossChainPackageType)
-	if err != nil {
-		panic("deserialize Policy cross chain package error")
-	}
-
-	var operationType uint8
-	var result sdk.ExecuteResult
-	switch p := pack.(type) {
-	case *types.CreatePolicyAckPackage:
-		operationType = types.OperationCreatePolicy
-		result = app.handleCreatePolicyAckPackage(ctx, appCtx, p)
-	case *types.DeletePolicyAckPackage:
-		operationType = types.OperationDeletePolicy
-		result = app.handleDeletePolicyAckPackage(ctx, appCtx, p)
-	default:
-		panic("unknown cross chain ack package type")
-	}
-
-	if len(result.Payload) != 0 {
-		wrapPayload := types.CrossChainPackage{
-			OperationType: operationType,
-			Package:       result.Payload,
-		}
-		result.Payload = wrapPayload.MustSerialize()
-	}
-
-	return result
+	panic("invalid cross chain ack package")
 }
 
 func (app *PermissionApp) ExecuteFailAckPackage(ctx sdk.Context, appCtx *sdk.CrossChainAppContext, payload []byte) sdk.ExecuteResult {
-	pack, err := types.DeserializeCrossChainPackage(payload, types.PermissionChannelId, sdk.FailAckCrossChainPackageType)
-	if err != nil {
-		panic("deserialize Policy cross chain package error")
-	}
-
-	var operationType uint8
-	var result sdk.ExecuteResult
-	switch p := pack.(type) {
-	case *types.CreatePolicySynPackage:
-		operationType = types.OperationCreatePolicy
-		result = app.handleCreatePolicyFailAckPackage(ctx, appCtx, p)
-	case *types.DeletePolicySynPackage:
-		operationType = types.OperationDeletePolicy
-		result = app.handleDeletePolicyFailAckPackage(ctx, appCtx, p)
-	default:
-		panic("unknown cross chain ack package type")
-	}
-
-	if len(result.Payload) != 0 {
-		wrapPayload := types.CrossChainPackage{
-			OperationType: operationType,
-			Package:       result.Payload,
-		}
-		result.Payload = wrapPayload.MustSerialize()
-	}
-
-	return result
+	panic("invalid cross chain fail ack package")
 }
 
 func (app *PermissionApp) ExecuteSynPackage(ctx sdk.Context, appCtx *sdk.CrossChainAppContext, payload []byte) sdk.ExecuteResult {
@@ -145,6 +98,31 @@ func (app *PermissionApp) handleDeletePolicySynPackage(ctx sdk.Context, deletePo
 		}
 	}
 
+	resOwner, err := app.getResourceOwner(ctx, policy)
+	if err != nil {
+		return sdk.ExecuteResult{
+			Payload: types.CreatePolicyAckPackage{
+				Status:    types.StatusFail,
+				Creator:   deletePolicyPackage.Operator,
+				ExtraData: deletePolicyPackage.ExtraData,
+			}.MustSerialize(),
+			Err: err,
+		}
+	}
+
+	if !deletePolicyPackage.Operator.Equals(resOwner) {
+		return sdk.ExecuteResult{
+			Payload: types.CreatePolicyAckPackage{
+				Status:    types.StatusFail,
+				Creator:   deletePolicyPackage.Operator,
+				ExtraData: deletePolicyPackage.ExtraData,
+			}.MustSerialize(),
+			Err: types.ErrAccessDenied.Wrapf(
+				"Only resource owner can delete bucket policy, operator (%s), owner(%s)",
+				deletePolicyPackage.Operator.String(), resOwner.String()),
+		}
+	}
+
 	_, err = app.permissionKeeper.DeletePolicy(ctx, policy.Principal, policy.ResourceType, policy.ResourceId)
 	if err != nil {
 		return sdk.ExecuteResult{
@@ -199,6 +177,44 @@ func (app *PermissionApp) handleCreatePolicySynPackage(ctx sdk.Context, createPo
 		}
 	}
 
+	resOwner, err := app.getResourceOwner(ctx, &policy)
+	if err != nil {
+		return sdk.ExecuteResult{
+			Payload: types.CreatePolicyAckPackage{
+				Status:    types.StatusFail,
+				Creator:   createPolicyPackage.Operator,
+				ExtraData: createPolicyPackage.ExtraData,
+			}.MustSerialize(),
+			Err: err,
+		}
+	}
+
+	if !createPolicyPackage.Operator.Equals(resOwner) {
+		return sdk.ExecuteResult{
+			Payload: types.CreatePolicyAckPackage{
+				Status:    types.StatusFail,
+				Creator:   createPolicyPackage.Operator,
+				ExtraData: createPolicyPackage.ExtraData,
+			}.MustSerialize(),
+			Err: types.ErrAccessDenied.Wrapf(
+				"Only resource owner can put policy, operator (%s), owner(%s)",
+				createPolicyPackage.Operator.String(), resOwner.String()),
+		}
+	}
+
+	app.normalizePrincipal(ctx, policy.Principal)
+	err = app.validatePrincipal(ctx, resOwner, policy.Principal)
+	if err != nil {
+		return sdk.ExecuteResult{
+			Payload: types.CreatePolicyAckPackage{
+				Status:    types.StatusFail,
+				Creator:   createPolicyPackage.Operator,
+				ExtraData: createPolicyPackage.ExtraData,
+			}.MustSerialize(),
+			Err: err,
+		}
+	}
+
 	PolicyId, err := app.permissionKeeper.PutPolicy(ctx, &policy)
 	if err != nil {
 		return sdk.ExecuteResult{
@@ -219,4 +235,74 @@ func (app *PermissionApp) handleCreatePolicySynPackage(ctx sdk.Context, createPo
 			ExtraData: createPolicyPackage.ExtraData,
 		}.MustSerialize(),
 	}
+}
+
+func (app *PermissionApp) getResourceOwner(ctx sdk.Context, policy *permtypes.Policy) (resOwner sdk.AccAddress, err error) {
+	switch policy.ResourceType {
+	case gnfdresource.RESOURCE_TYPE_BUCKET:
+		bucketInfo, found := app.storageKeeper.GetBucketInfoById(ctx, policy.ResourceId)
+		if !found {
+			return resOwner, types.ErrNoSuchBucket
+		}
+		resOwner = sdk.MustAccAddressFromHex(bucketInfo.Owner)
+	case gnfdresource.RESOURCE_TYPE_OBJECT:
+		objectInfo, found := app.storageKeeper.GetObjectInfoById(ctx, policy.ResourceId)
+		if !found {
+			return resOwner, types.ErrNoSuchObject
+		}
+		resOwner = sdk.MustAccAddressFromHex(objectInfo.Owner)
+	case gnfdresource.RESOURCE_TYPE_GROUP:
+		groupInfo, found := app.storageKeeper.GetGroupInfoById(ctx, policy.ResourceId)
+		if !found {
+			return resOwner, types.ErrNoSuchGroup
+		}
+		resOwner = sdk.MustAccAddressFromHex(groupInfo.Owner)
+	default:
+		return resOwner, gnfderrors.ErrInvalidGRN.Wrap("Unknown resource type in greenfield resource name")
+	}
+	return resOwner, nil
+}
+
+func (app *PermissionApp) normalizePrincipal(ctx sdk.Context, principal *permtypes.Principal) {
+	if principal.Type == permtypes.PRINCIPAL_TYPE_GNFD_GROUP {
+		if _, err := math.ParseUint(principal.Value); err == nil {
+			return
+		}
+		var grn types2.GRN
+		if err := grn.ParseFromString(principal.Value, false); err != nil {
+			return
+		}
+		groupOwner, groupName, err := grn.GetGroupOwnerAndAccount()
+		if err != nil {
+			return
+		}
+
+		if groupInfo, found := app.storageKeeper.GetGroupInfo(ctx, groupOwner, groupName); found {
+			principal.Value = groupInfo.Id.String()
+		}
+	}
+}
+
+func (app *PermissionApp) validatePrincipal(ctx sdk.Context, resOwner sdk.AccAddress, principal *permtypes.Principal) error {
+	if principal.Type == permtypes.PRINCIPAL_TYPE_GNFD_ACCOUNT {
+		principalAccAddress, err := principal.GetAccountAddress()
+		if err != nil {
+			return err
+		}
+		if principalAccAddress.Equals(resOwner) {
+			return gnfderrors.ErrInvalidPrincipal.Wrapf("principal account can not be the bucket owner")
+		}
+	} else if principal.Type == permtypes.PRINCIPAL_TYPE_GNFD_GROUP {
+		groupID, err := math.ParseUint(principal.Value)
+		if err != nil {
+			return err
+		}
+		_, found := app.storageKeeper.GetGroupInfoById(ctx, groupID)
+		if !found {
+			return types.ErrNoSuchGroup
+		}
+	} else {
+		return permtypes.ErrInvalidPrincipal.Wrapf("Unknown principal type.")
+	}
+	return nil
 }

--- a/x/storage/keeper/cross_app_permission.go
+++ b/x/storage/keeper/cross_app_permission.go
@@ -67,14 +67,6 @@ func (app *PermissionApp) ExecuteSynPackage(ctx sdk.Context, appCtx *sdk.CrossCh
 	return result
 }
 
-func (app *PermissionApp) handleDeletePolicyAckPackage(ctx sdk.Context, appCtx *sdk.CrossChainAppContext, ackPackage *types.DeletePolicyAckPackage) sdk.ExecuteResult {
-	return sdk.ExecuteResult{}
-}
-
-func (app *PermissionApp) handleDeletePolicyFailAckPackage(ctx sdk.Context, appCtx *sdk.CrossChainAppContext, synPackage *types.DeletePolicySynPackage) sdk.ExecuteResult {
-	return sdk.ExecuteResult{}
-}
-
 func (app *PermissionApp) handleDeletePolicySynPackage(ctx sdk.Context, deletePolicyPackage *types.DeletePolicySynPackage) sdk.ExecuteResult {
 	err := deletePolicyPackage.ValidateBasic()
 	if err != nil {
@@ -141,14 +133,6 @@ func (app *PermissionApp) handleDeletePolicySynPackage(ctx sdk.Context, deletePo
 			ExtraData: deletePolicyPackage.ExtraData,
 		}.MustSerialize(),
 	}
-}
-
-func (app *PermissionApp) handleCreatePolicyAckPackage(ctx sdk.Context, appCtx *sdk.CrossChainAppContext, ackPackage *types.CreatePolicyAckPackage) sdk.ExecuteResult {
-	return sdk.ExecuteResult{}
-}
-
-func (app *PermissionApp) handleCreatePolicyFailAckPackage(ctx sdk.Context, appCtx *sdk.CrossChainAppContext, ackPackage *types.CreatePolicySynPackage) sdk.ExecuteResult {
-	return sdk.ExecuteResult{}
 }
 
 func (app *PermissionApp) handleCreatePolicySynPackage(ctx sdk.Context, createPolicyPackage *types.CreatePolicySynPackage) sdk.ExecuteResult {

--- a/x/storage/keeper/cross_app_permission.go
+++ b/x/storage/keeper/cross_app_permission.go
@@ -1,8 +1,6 @@
 package keeper
 
 import (
-	"encoding/json"
-
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -148,7 +146,7 @@ func (app *PermissionApp) handleCreatePolicySynPackage(ctx sdk.Context, createPo
 	}
 
 	var policy permtypes.Policy
-	err = json.Unmarshal(createPolicyPackage.Data, &policy)
+	err = policy.Unmarshal(createPolicyPackage.Data)
 	if err != nil {
 		return sdk.ExecuteResult{
 			Payload: types.CreatePolicyAckPackage{

--- a/x/storage/keeper/cross_app_permission_test.go
+++ b/x/storage/keeper/cross_app_permission_test.go
@@ -1,0 +1,72 @@
+package keeper_test
+
+import (
+	"encoding/json"
+	"math/big"
+	"math/rand"
+
+	"cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/golang/mock/gomock"
+
+	"github.com/bnb-chain/greenfield/testutil/sample"
+	"github.com/bnb-chain/greenfield/x/permission/types"
+	"github.com/bnb-chain/greenfield/x/storage/keeper"
+	storageTypes "github.com/bnb-chain/greenfield/x/storage/types"
+)
+
+func (s *TestSuite) TestSynCreatePolicy() {
+	ctrl := gomock.NewController(s.T())
+	permissionKeeper := storageTypes.NewMockPermissionKeeper(ctrl)
+
+	resourceIds := []math.Uint{math.NewUint(rand.Uint64()), math.NewUint(rand.Uint64()), math.NewUint(rand.Uint64())}
+	// policy without expiry
+	policy := types.Policy{
+		Principal: &types.Principal{
+			Type:  types.PRINCIPAL_TYPE_GNFD_ACCOUNT,
+			Value: sample.RandAccAddressHex(),
+		},
+		ResourceType:   1,
+		ResourceId:     resourceIds[0],
+		Statements:     nil,
+		ExpirationTime: nil,
+	}
+
+	app := keeper.NewPermissionApp(permissionKeeper)
+	data, err := json.Marshal(&policy)
+	s.NoError(err)
+
+	synPackage := storageTypes.CreatePolicySynPackage{
+		Operator:  sample.RandAccAddress(),
+		Data:      data,
+		ExtraData: []byte("extra data"),
+	}
+	serializedSynPackage := synPackage.MustSerialize()
+	serializedSynPackage = append([]byte{storageTypes.OperationCreatePolicy}, serializedSynPackage...)
+
+	// normal case
+	permissionKeeper.EXPECT().PutPolicy(gomock.Any(), gomock.Any()).Return(math.NewUint(0), nil)
+	res := app.ExecuteSynPackage(s.ctx, &sdk.CrossChainAppContext{}, serializedSynPackage)
+	s.Require().NoError(res.Err)
+}
+
+func (s *TestSuite) TestSynDeletePolicy() {
+	ctrl := gomock.NewController(s.T())
+	permissionKeeper := storageTypes.NewMockPermissionKeeper(ctrl)
+
+	app := keeper.NewPermissionApp(permissionKeeper)
+	synPackage := storageTypes.DeleteBucketSynPackage{
+		Operator:  sample.RandAccAddress(),
+		Id:        big.NewInt(10),
+		ExtraData: []byte("extra data"),
+	}
+
+	serializedSynPackage := synPackage.MustSerialize()
+	serializedSynPackage = append([]byte{storageTypes.OperationDeletePolicy}, serializedSynPackage...)
+
+	// case 1: No such Policy
+	permissionKeeper.EXPECT().GetPolicyByID(gomock.Any(), gomock.Any()).Return(&types.Policy{}, false)
+	res := app.ExecuteSynPackage(s.ctx, &sdk.CrossChainAppContext{}, serializedSynPackage)
+	s.Require().ErrorIs(res.Err, storageTypes.ErrNoSuchPolicy)
+	s.Require().NotEmpty(res.Payload)
+}

--- a/x/storage/keeper/cross_app_permission_test.go
+++ b/x/storage/keeper/cross_app_permission_test.go
@@ -45,10 +45,10 @@ func (s *TestSuite) TestSynCreatePolicy() {
 	serializedSynPackage := synPackage.MustSerialize()
 	serializedSynPackage = append([]byte{storageTypes.OperationCreatePolicy}, serializedSynPackage...)
 
-	// normal case
-	permissionKeeper.EXPECT().PutPolicy(gomock.Any(), gomock.Any()).Return(math.NewUint(0), nil)
+	// case 1: bucket not found
+	storageKeeper.EXPECT().GetBucketInfoById(gomock.Any(), gomock.Any()).Return(nil, false)
 	res := app.ExecuteSynPackage(s.ctx, &sdk.CrossChainAppContext{}, serializedSynPackage)
-	s.Require().NoError(res.Err)
+	s.Require().ErrorIs(res.Err, storageTypes.ErrNoSuchBucket)
 }
 
 func (s *TestSuite) TestSynDeletePolicy() {

--- a/x/storage/keeper/cross_app_permission_test.go
+++ b/x/storage/keeper/cross_app_permission_test.go
@@ -1,7 +1,6 @@
 package keeper_test
 
 import (
-	"encoding/json"
 	"math/big"
 	"math/rand"
 
@@ -34,7 +33,7 @@ func (s *TestSuite) TestSynCreatePolicy() {
 	}
 
 	app := keeper.NewPermissionApp(storageKeeper, permissionKeeper)
-	data, err := json.Marshal(&policy)
+	data, err := policy.Marshal()
 	s.NoError(err)
 
 	synPackage := storageTypes.CreatePolicySynPackage{

--- a/x/storage/keeper/cross_app_permission_test.go
+++ b/x/storage/keeper/cross_app_permission_test.go
@@ -17,6 +17,7 @@ import (
 
 func (s *TestSuite) TestSynCreatePolicy() {
 	ctrl := gomock.NewController(s.T())
+	storageKeeper := storageTypes.NewMockStorageKeeper(ctrl)
 	permissionKeeper := storageTypes.NewMockPermissionKeeper(ctrl)
 
 	resourceIds := []math.Uint{math.NewUint(rand.Uint64()), math.NewUint(rand.Uint64()), math.NewUint(rand.Uint64())}
@@ -32,7 +33,7 @@ func (s *TestSuite) TestSynCreatePolicy() {
 		ExpirationTime: nil,
 	}
 
-	app := keeper.NewPermissionApp(permissionKeeper)
+	app := keeper.NewPermissionApp(storageKeeper, permissionKeeper)
 	data, err := json.Marshal(&policy)
 	s.NoError(err)
 
@@ -52,9 +53,10 @@ func (s *TestSuite) TestSynCreatePolicy() {
 
 func (s *TestSuite) TestSynDeletePolicy() {
 	ctrl := gomock.NewController(s.T())
+	storageKeeper := storageTypes.NewMockStorageKeeper(ctrl)
 	permissionKeeper := storageTypes.NewMockPermissionKeeper(ctrl)
 
-	app := keeper.NewPermissionApp(permissionKeeper)
+	app := keeper.NewPermissionApp(storageKeeper, permissionKeeper)
 	synPackage := storageTypes.DeleteBucketSynPackage{
 		Operator:  sample.RandAccAddress(),
 		Id:        big.NewInt(10),

--- a/x/storage/keeper/permission.go
+++ b/x/storage/keeper/permission.go
@@ -225,8 +225,8 @@ func (k Keeper) PutPolicy(ctx sdk.Context, operator sdk.AccAddress, grn types2.G
 			"Only resource owner can put policy, operator (%s), owner(%s)",
 			operator.String(), resOwner.String())
 	}
-	k.normalizePrincipal(ctx, policy.Principal)
-	err = k.validatePrincipal(ctx, resOwner, policy.Principal)
+	k.NormalizePrincipal(ctx, policy.Principal)
+	err = k.ValidatePrincipal(ctx, resOwner, policy.Principal)
 	if err != nil {
 		return math.ZeroUint(), err
 	}
@@ -250,7 +250,7 @@ func (k Keeper) DeletePolicy(
 	return k.permKeeper.DeletePolicy(ctx, principal, grn.ResourceType(), resID)
 }
 
-func (k Keeper) normalizePrincipal(ctx sdk.Context, principal *permtypes.Principal) {
+func (k Keeper) NormalizePrincipal(ctx sdk.Context, principal *permtypes.Principal) {
 	if principal.Type == permtypes.PRINCIPAL_TYPE_GNFD_GROUP {
 		if _, err := math.ParseUint(principal.Value); err == nil {
 			return
@@ -270,7 +270,7 @@ func (k Keeper) normalizePrincipal(ctx sdk.Context, principal *permtypes.Princip
 	}
 }
 
-func (k Keeper) validatePrincipal(ctx sdk.Context, resOwner sdk.AccAddress, principal *permtypes.Principal) error {
+func (k Keeper) ValidatePrincipal(ctx sdk.Context, resOwner sdk.AccAddress, principal *permtypes.Principal) error {
 	if principal.Type == permtypes.PRINCIPAL_TYPE_GNFD_ACCOUNT {
 		principalAccAddress, err := principal.GetAccountAddress()
 		if err != nil {

--- a/x/storage/types/crosschain.go
+++ b/x/storage/types/crosschain.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"encoding/json"
 	"math/big"
 	time "time"
 
@@ -12,7 +11,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	gnfdcommon "github.com/bnb-chain/greenfield/types/common"
-	permtypes "github.com/bnb-chain/greenfield/x/permission/types"
 )
 
 const (
@@ -1412,14 +1410,8 @@ var (
 )
 
 func (p CreatePolicySynPackage) ValidateBasic() error {
-	if p.Operator.Empty() {
+	if p.Operator.Empty() || len(p.Data) == 0 {
 		return sdkerrors.ErrInvalidAddress
-	}
-
-	var policy permtypes.Policy
-	err := json.Unmarshal(p.Data, &policy)
-	if err != nil {
-		return err
 	}
 
 	return nil

--- a/x/storage/types/crosschain.go
+++ b/x/storage/types/crosschain.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"encoding/json"
-	permtypes "github.com/bnb-chain/greenfield/x/permission/types"
 	"math/big"
 	time "time"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	gnfdcommon "github.com/bnb-chain/greenfield/types/common"
+	permtypes "github.com/bnb-chain/greenfield/x/permission/types"
 )
 
 const (

--- a/x/storage/types/expected_keepers.go
+++ b/x/storage/types/expected_keepers.go
@@ -108,6 +108,7 @@ type StorageKeeper interface {
 		primarySpAcc sdk.AccAddress, opts *CreateBucketOptions) (sdkmath.Uint, error)
 	DeleteBucket(ctx sdk.Context, operator sdk.AccAddress, bucketName string, opts DeleteBucketOptions) error
 	GetGroupInfoById(ctx sdk.Context, groupId sdkmath.Uint) (*GroupInfo, bool)
+	GetGroupInfo(ctx sdk.Context, ownerAddr sdk.AccAddress, groupName string) (*GroupInfo, bool)
 	DeleteGroup(ctx sdk.Context, operator sdk.AccAddress, groupName string, opts DeleteGroupOptions) error
 	CreateGroup(
 		ctx sdk.Context, owner sdk.AccAddress,

--- a/x/storage/types/expected_keepers.go
+++ b/x/storage/types/expected_keepers.go
@@ -121,4 +121,7 @@ type StorageKeeper interface {
 	DeleteObject(
 		ctx sdk.Context, operator sdk.AccAddress, bucketName, objectName string, opts DeleteObjectOptions) error
 	GetSourceTypeByChainId(ctx sdk.Context, chainId sdk.ChainID) (SourceType, error)
+
+	NormalizePrincipal(ctx sdk.Context, principal *permtypes.Principal)
+	ValidatePrincipal(ctx sdk.Context, resOwner sdk.AccAddress, principal *permtypes.Principal) error
 }

--- a/x/storage/types/expected_keepers_mocks.go
+++ b/x/storage/types/expected_keepers_mocks.go
@@ -897,6 +897,30 @@ type MockStorageKeeper struct {
 	recorder *MockStorageKeeperMockRecorder
 }
 
+func (m *MockStorageKeeper) NormalizePrincipal(ctx types3.Context, principal *types0.Principal) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "NormalizePrincipal", ctx, principal)
+}
+
+// NormalizePrincipal indicates an expected call of NormalizePrincipal.
+func (mr *MockStorageKeeperMockRecorder) NormalizePrincipal(ctx types3.Context, principal *types0.Principal) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NormalizePrincipal", reflect.TypeOf((*MockStorageKeeper)(nil).NormalizePrincipal), ctx, principal)
+}
+
+func (m *MockStorageKeeper) ValidatePrincipal(ctx types3.Context, resOwner types3.AccAddress, principal *types0.Principal) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidatePrincipal", ctx, resOwner, principal)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// NormalizePrincipal indicates an expected call of NormalizePrincipal.
+func (mr *MockStorageKeeperMockRecorder) ValidatePrincipal(ctx types3.Context, resOwner types3.AccAddress, principal *types0.Principal) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidatePrincipal", reflect.TypeOf((*MockStorageKeeper)(nil).ValidatePrincipal), ctx, resOwner, principal)
+}
+
 // MockStorageKeeperMockRecorder is the mock recorder for MockStorageKeeper.
 type MockStorageKeeperMockRecorder struct {
 	mock *MockStorageKeeper

--- a/x/storage/types/expected_keepers_mocks.go
+++ b/x/storage/types/expected_keepers_mocks.go
@@ -1010,6 +1010,14 @@ func (m *MockStorageKeeper) GetGroupInfoById(ctx types3.Context, groupId math.Ui
 	return ret0, ret1
 }
 
+func (m *MockStorageKeeper) GetGroupInfo(ctx types3.Context, ownerAddr types3.AccAddress, groupName string) (*GroupInfo, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetGroupInfo", ctx, ownerAddr, groupName)
+	ret0, _ := ret[0].(*GroupInfo)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
 // GetGroupInfoById indicates an expected call of GetGroupInfoById.
 func (mr *MockStorageKeeperMockRecorder) GetGroupInfoById(ctx, groupId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()

--- a/x/storage/types/options.go
+++ b/x/storage/types/options.go
@@ -76,3 +76,13 @@ type RenewGroupMemberOptions struct {
 type DeleteGroupOptions struct {
 	SourceType SourceType
 }
+
+type CreatePolicyOptions struct {
+	SourceType SourceType
+	Extra      string
+	Tags       *ResourceTags
+}
+
+type DeletePolicyOptions struct {
+	SourceType SourceType
+}


### PR DESCRIPTION
### Description

Currently, Greenfield supports creating buckets and groups from the smart contracts deployed on BSC/opBNB. This means that the owner of a bucket can be a contract address. However, contract addresses cannot upload objects or put policies under the bucket, resulting in empty buckets owned by smart contracts.
To address this issue, we are going to introduce the cross-chain permission module. With this BEP, smart contracts can grant EOA addresses the ability to upload objects under their buckets, and even support additional functions.

### Rationale
In the current framework, users could only change resource permission on Greenfield. The proposal allows Greenfield users to change resource permission directly on the BSC/opBNB network.

### Changes

Notable changes: 
* add permission module
* ...
