### PR TITLE
docs: fix mainnet/testnet config

### DIFF
--- a/asset/configs/mainnet_config/app.toml
+++ b/asset/configs/mainnet_config/app.toml
@@ -258,3 +258,5 @@ max-txs = "5000"
 src-chain-id = 1017
 # chain-id for bsc destination chain
 dest-bsc-chain-id = 56
+# chain-id for op bnb destination chain
+dest-op-chain-id = 204

--- a/asset/configs/testnet_config/app.toml
+++ b/asset/configs/testnet_config/app.toml
@@ -263,3 +263,5 @@ max-txs = "5000"
 src-chain-id = 5600
 # chain-id for bsc destination chain
 dest-bsc-chain-id = 97
+# chain-id for op bnb destination chain
+dest-op-chain-id = 5611


### PR DESCRIPTION
### Description

 fix mainnet/testnet config

### Rationale

Missing `dest-op-chain-id` configuration in app.toml

### Example

n/a

### Changes

Notable changes: 
* assets

### Potential Impacts
n/a
