### PR TITLE
docs: add v1.2.2 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## v1.2.2
+This release introduces the Manchurian upgrade to the mainnet.
+
 ## v1.2.1
 This release fixes the bugs within resource tags.
 


### PR DESCRIPTION
### Description

add v1.2.2 changelog

### Rationale

## v1.2.2
This release introduces the Manchurian upgrade to the mainnet.

### Example

n/a

### Changes

Notable changes: 
* changelog

### Potential Impacts
* no
