### PR TITLE
fix: seal object validate if secondary SP in_service

### DIFF
--- a/x/storage/keeper/keeper.go
+++ b/x/storage/keeper/keeper.go
@@ -780,7 +780,7 @@ func (k Keeper) SealObject(
 	}
 	// validate seal object bls aggregated sig from secondary sps
 	secondarySpsSealObjectBlsSignHash := types.NewSecondarySpSealObjectSignDoc(ctx.ChainID(), gvg.Id, objectInfo.Id, types.GenerateHash(objectInfo.Checksums[:])).GetBlsSignHash()
-	err := k.VerifyGVGSecondarySPsBlsSignature(ctx, gvg, secondarySpsSealObjectBlsSignHash, opts.SecondarySpBlsSignatures)
+	err := k.VerifyGVGSecondarySPsBlsSignatureAndStatus(ctx, gvg, secondarySpsSealObjectBlsSignHash, opts.SecondarySpBlsSignatures)
 	if err != nil {
 		return err
 	}

--- a/x/storage/keeper/msg_server.go
+++ b/x/storage/keeper/msg_server.go
@@ -718,7 +718,7 @@ func (k Keeper) verifyGVGSignatures(ctx sdk.Context, bucketID math.Uint, dstSP *
 		}
 		// validate the aggregated bls signature
 		migrationBucketSignDocBlsSignHash := storagetypes.NewSecondarySpMigrationBucketSignDoc(ctx.ChainID(), bucketID, dstSP.Id, newLvg2gvg.SrcGlobalVirtualGroupId, dstGVG.Id).GetBlsSignHash()
-		err := k.VerifyGVGSecondarySPsBlsSignature(ctx, dstGVG, migrationBucketSignDocBlsSignHash, newLvg2gvg.SecondarySpBlsSignature)
+		err := k.VerifyGVGSecondarySPsBlsSignatureAndStatus(ctx, dstGVG, migrationBucketSignDocBlsSignHash, newLvg2gvg.SecondarySpBlsSignature)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### Description

seal object validate if secondary SP in_service, in case that SP is exiting but still need to severs as a secondary SP. 

### Rationale

SP not in_service should not serve users new object requests. 

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...
