### PR TITLE
release: prepare for release v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## v1.3.0
-This release introduces the Hulunbeier upgrade to the testnet.
+This release introduces the Hulunbeier upgrade to the Testnet and Mainnet.
 
 Features:
 * [#542](https://github.com/bnb-chain/greenfield/pull/542) feat: add crosschain permission app

--- a/go.mod
+++ b/go.mod
@@ -180,7 +180,7 @@ replace (
 	github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v1.1.0
 	github.com/cometbft/cometbft-db => github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v1.2.2-0.20240102032738-3661d43faf8f
+	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v1.3.0
 	github.com/cosmos/iavl => github.com/bnb-chain/greenfield-iavl v0.20.1
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	github.com/wercker/journalhook => github.com/wercker/journalhook v0.0.0-20230927020745-64542ffa4117

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,8 @@ github.com/bnb-chain/greenfield-cometbft v1.1.0 h1:jqnkDWIZW6f/rUn5/pE26YZMT9xzp
 github.com/bnb-chain/greenfield-cometbft v1.1.0/go.mod h1:NZ2/ZJK2HYe3++0CsPiw4LTG6UrC6pH7fQ3VOz6pqJw=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1 h1:XcWulGacHVRiSCx90Q8Y//ajOrLNBQWR/KDB89dy3cU=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1/go.mod h1:ey1CiK4bYo1RBNJLRiVbYr5CMdSxci9S/AZRINLtppI=
-github.com/bnb-chain/greenfield-cosmos-sdk v1.2.2-0.20240102032738-3661d43faf8f h1:cU9Zsbmiy5NKDmaYU8kS8uZR0J1AyQrq5RR1EJgVO+k=
-github.com/bnb-chain/greenfield-cosmos-sdk v1.2.2-0.20240102032738-3661d43faf8f/go.mod h1:Yrvq+J1Lsm7OHFX+M/AZWBTGt1TRHUTC4VYOMlvW3fs=
+github.com/bnb-chain/greenfield-cosmos-sdk v1.3.0 h1:jgSxXxHyUNRfVqesuq8Zw6TkRMflY7u+x/bMq8i2ktc=
+github.com/bnb-chain/greenfield-cosmos-sdk v1.3.0/go.mod h1:Yrvq+J1Lsm7OHFX+M/AZWBTGt1TRHUTC4VYOMlvW3fs=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230816082903-b48770f5e210 h1:GHPbV2bC+gmuO6/sG0Tm8oGal3KKSRlyE+zPscDjlA8=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230816082903-b48770f5e210/go.mod h1:vhsZxXE9tYJeYB5JR4hPhd6Pc/uPf7j1T8IJ7p9FdeM=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230816082903-b48770f5e210 h1:FLVOn4+OVbsKi2+YJX5kmD27/4dRu4FW7xCXFhzDO5s=


### PR DESCRIPTION
### Description

this pr prepares for release v1.3.0, introduces the Hulunbeier upgrade to Testnet and Mainnet.

## Rationale

Features:
* [#542](https://github.com/bnb-chain/greenfield/pull/542) feat: add crosschain permission app
* [#534](https://github.com/bnb-chain/greenfield/pull/534) feat: implement Msgs for SP exit

Bugfixes:
* [#552](https://github.com/bnb-chain/greenfield/pull/552) fix: resource account policy key collision

Chore:
* [#551](https://github.com/bnb-chain/greenfield/pull/551) chore: fix typo and update doc