### PR TITLE
fix: revert the modifications to resource naming rules (#568)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,6 @@ require (
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
 	github.com/99designs/keyring v1.2.1 // indirect
 	github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d // indirect
-	github.com/StackExchange/wmi v0.0.0-20210224194228-fe8f1750fd46 // indirect
 	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/speakeasy v0.1.1-0.20220910012023-760eaf8b6816 // indirect
@@ -66,7 +65,6 @@ require (
 	github.com/creachadair/taskgroup v0.4.2 // indirect
 	github.com/danieljoos/wincred v1.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/deckarep/golang-set v1.8.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 // indirect
 	github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f // indirect
 	github.com/dgraph-io/badger/v2 v2.2007.4 // indirect
@@ -82,7 +80,6 @@ require (
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-playground/universal-translator v0.18.0 // indirect
-	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/gogo/googleapis v1.4.1 // indirect
@@ -92,7 +89,6 @@ require (
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/orderedcode v0.0.1 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/handlers v1.5.1 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
@@ -139,12 +135,10 @@ require (
 	github.com/prysmaticlabs/eth2-types v0.0.0-20210303084904-c9735a06829d // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
-	github.com/rjeczalik/notify v0.9.1 // indirect
 	github.com/rs/cors v1.8.3 // indirect
 	github.com/rs/zerolog v1.29.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sasha-s/go-deadlock v0.3.1 // indirect
-	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/afero v1.9.3 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
@@ -155,7 +149,6 @@ require (
 	github.com/thomaso-mirodin/intmath v0.0.0-20160323211736-5dc6d854e46e // indirect
 	github.com/tidwall/btree v1.6.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.10 // indirect
-	github.com/tklauser/numcpus v0.4.0 // indirect
 	github.com/ugorji/go/codec v1.2.7 // indirect
 	github.com/urfave/cli/v2 v2.10.2 // indirect
 	github.com/wealdtech/go-bytesutil v1.1.1 // indirect
@@ -175,7 +168,6 @@ require (
 	google.golang.org/genproto v0.0.0-20230711160842-782d3b101e98 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230711160842-782d3b101e98 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	nhooyr.io/websocket v1.8.6 // indirect
 	pgregory.net/rapid v0.5.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -205,7 +205,6 @@ github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8
 github.com/cenkalti/backoff/v4 v4.1.3/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
-github.com/cespare/cp v1.1.1 h1:nCb6ZLdB7NRaqsm91JtQTAme2SKJzXVsdPIPkyJr1MU=
 github.com/cespare/cp v1.1.1/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
@@ -298,8 +297,6 @@ github.com/davidlazar/go-crypto v0.0.0-20170701192655-dcfb0a7ac018/go.mod h1:rQY
 github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c/go.mod h1:6UhI8N9EjYm1c2odKpFpAYeR8dsBeM7PtzQhRgxRr9U=
 github.com/deckarep/golang-set v0.0.0-20180603214616-504e848d77ea/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14yDtF28KmMOgQ=
 github.com/deckarep/golang-set v1.7.1/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14yDtF28KmMOgQ=
-github.com/deckarep/golang-set v1.8.0 h1:sk9/l/KqpunDwP7pSjUg0keiOOLEnOBHzykLrsPppp4=
-github.com/deckarep/golang-set v1.8.0/go.mod h1:5nI87KwE7wgsBU1F4GKAw2Qod7p5kyS383rP6+o6qqo=
 github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK09Y2A4Xv7EE0=
 github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1/go.mod h1:hyedUtir6IdtD/7lIxGeCxkaw7y45JueMRL4DIyJDKs=
@@ -343,7 +340,6 @@ github.com/eapache/go-resiliency v1.2.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5m
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/eclipse/paho.mqtt.golang v1.2.0/go.mod h1:H9keYFcgq3Qr5OUJm/JZI/i6U7joQ8SYLhZwfeOo6Ts=
-github.com/edsrzf/mmap-go v1.0.0 h1:CEBF7HpRnUCSJgGUb5h1Gm7e3VkmVDrR8lvWVLtrOFw=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/dot v0.11.0/go.mod h1:DeV7GvQtIw4h2u73RKBkkFdvVAz0D9fzeJrgPW6gy/s=
@@ -573,7 +569,6 @@ github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.5/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go v2.0.0+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/googleapis/gax-go/v2 v2.0.3/go.mod h1:LLvjysVCY1JZeum8Z6l8qUty8fiNwE08qbEPm1M08qg=
@@ -658,9 +653,7 @@ github.com/hdevalence/ed25519consensus v0.1.0/go.mod h1:w3BHWjwJbFU29IRHL1Iqkw3s
 github.com/herumi/bls-eth-go-binary v0.0.0-20210130185500-57372fb27371/go.mod h1:luAnRm3OsMQeokhGzpYmc0ZKwawY7o87PUEP11Z7r7U=
 github.com/herumi/bls-eth-go-binary v0.0.0-20210917013441-d37c07cfda4e h1:wCMygKUQhmcQAjlk2Gquzq6dLmyMv2kF+llRspoRgrk=
 github.com/herumi/bls-eth-go-binary v0.0.0-20210917013441-d37c07cfda4e/go.mod h1:luAnRm3OsMQeokhGzpYmc0ZKwawY7o87PUEP11Z7r7U=
-github.com/holiman/bloomfilter/v2 v2.0.3 h1:73e0e/V0tCydx14a0SCYS/EWCxgwLZ18CZcZKVu0fao=
 github.com/holiman/bloomfilter/v2 v2.0.3/go.mod h1:zpoh+gs7qcpqrHr3dB55AMiJwo0iURXE7ZOP9L9hSkA=
-github.com/holiman/uint256 v1.2.0 h1:gpSYcPLWGv4sG43I2mVLiDZCNDh/EpGjSk8tmtxitHM=
 github.com/holiman/uint256 v1.2.0/go.mod h1:y4ga/t+u+Xwd7CpDgZESaRcWy0I7XMlTMA25ApIH5Jw=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/go-assert v1.1.5 h1:fjemmA7sSfYHJD7CUqs9qTwwfdNAx7/j2/ZlHXzNB3c=
@@ -1243,7 +1236,6 @@ github.com/retailnext/hllpp v1.0.1-0.20180308014038-101a6d2f8b52/go.mod h1:RDpi1
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
-github.com/rjeczalik/notify v0.9.1 h1:CLCKso/QK1snAlnhNR/CNvNiFU2saUtjV0bx3EwNeCE=
 github.com/rjeczalik/notify v0.9.1/go.mod h1:rKwnCoCGeuQnwBtTSPL9Dad03Vh2n40ePRrjvIXnJho=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
@@ -2043,7 +2035,6 @@ gopkg.in/jcmturner/dnsutils.v1 v1.0.1/go.mod h1:m3v+5svpVOhtFAP/wSz+yzh4Mc0Fg7eR
 gopkg.in/jcmturner/goidentity.v3 v3.0.0/go.mod h1:oG2kH0IvSYNIu80dVAyu/yoefjq1mNfM5bm88whjWx4=
 gopkg.in/jcmturner/gokrb5.v7 v7.5.0/go.mod h1:l8VISx+WGYp+Fp7KRbsiUuXTTOnxIc3Tuvyavf11/WM=
 gopkg.in/jcmturner/rpc.v1 v1.1.0/go.mod h1:YIdkC4XfD6GXbzje11McwsDuOlZQSb9W4vfLvuNnlv8=
-gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce h1:+JknDZhAj8YMt7GC73Ei8pv4MzjDUNPHgQWJdtMAaDU=
 gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce/go.mod h1:5AcXVHNjg+BDxry382+8OKon8SEWiKktQR07RKPsv1c=
 gopkg.in/olebedev/go-duktape.v3 v3.0.0-20200619000410-60c24ae608a6/go.mod h1:uAJfkITjFhyEEuUfm7bsmCZRbW5WRq8s9EY8HZ6hCns=
 gopkg.in/redis.v4 v4.2.4/go.mod h1:8KREHdypkCEojGKQcjMqAODMICIVwZAONWq8RowTITA=

--- a/types/grn.go
+++ b/types/grn.go
@@ -157,7 +157,7 @@ func (r *GRN) ParseFromString(res string, wildcards bool) error {
 			return gnfderrors.ErrInvalidGRN.Wrapf("Not allowed '/' in bucket resource name")
 		}
 		if !wildcards {
-			err = s3util.CheckValidBucketNameByCharacterLength(r.name)
+			err = s3util.CheckValidBucketName(r.name)
 			if err != nil {
 				return gnfderrors.ErrInvalidGRN.Wrapf("invalid bucketName: %s, err: %s", r.name, err)
 			}
@@ -179,7 +179,7 @@ func (r *GRN) ParseFromString(res string, wildcards bool) error {
 			return gnfderrors.ErrInvalidGRN.Wrapf("invalid group owner account, err : %s", err)
 		}
 		if !wildcards {
-			err = s3util.CheckValidGroupNameByCharacterLength(name)
+			err = s3util.CheckValidGroupName(name)
 			if err != nil {
 				return gnfderrors.ErrInvalidGRN.Wrapf("invalid group name, err : %s", err)
 			}
@@ -200,11 +200,11 @@ func (r *GRN) parseBucketAndObjectName(name string) (string, string, error) {
 	if !found {
 		return "", "", gnfderrors.ErrInvalidGRN.Wrapf("object name not found, grn: %s", name)
 	}
-	err := s3util.CheckValidBucketNameByCharacterLength(bucketName)
+	err := s3util.CheckValidBucketName(bucketName)
 	if err != nil {
 		return "", "", gnfderrors.ErrInvalidGRN.Wrapf("invalid bucketName, err: %s", err)
 	}
-	err = s3util.CheckValidObjectNameByCharacterLength(objectName)
+	err = s3util.CheckValidObjectName(objectName)
 	if err != nil {
 		return "", "", gnfderrors.ErrInvalidGRN.Wrapf("invalid objectName, err: %s", err)
 	}

--- a/types/s3util/s3util.go
+++ b/types/s3util/s3util.go
@@ -24,10 +24,10 @@ func CheckValidBucketName(bucketName string) (err error) {
 		return errors.Wrap(gnfderrors.ErrInvalidBucketName, "Bucket name cannot be empty")
 	}
 	if len(bucketName) < 3 {
-		return errors.Wrap(gnfderrors.ErrInvalidBucketName, "Bucket name cannot be shorter than 3 characters")
+		return errors.Wrap(gnfderrors.ErrInvalidBucketName, "Bucket name cannot be shorter than 3 bytes")
 	}
 	if len(bucketName) > 63 {
-		return errors.Wrap(gnfderrors.ErrInvalidBucketName, "Bucket name cannot be longer than 63 characters")
+		return errors.Wrap(gnfderrors.ErrInvalidBucketName, "Bucket name cannot be longer than 63 bytes")
 	}
 	if ipAddress.MatchString(bucketName) {
 		return errors.Wrap(gnfderrors.ErrInvalidBucketName, "Bucket name cannot be an ip address")
@@ -42,16 +42,25 @@ func CheckValidBucketName(bucketName string) (err error) {
 	return nil
 }
 
+const (
+	// Bad path components to be rejected by the path validity handler.
+	dotdotComponent = ".."
+	dotComponent    = "."
+
+	// SlashSeparator - slash separator.
+	SlashSeparator = "/"
+)
+
 // CheckValidObjectName checks if we have a valid input object name.
 //
-// - http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html
+//	http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html
 func CheckValidObjectName(objectName string) error {
 	// check the length of objectName
 	if len(objectName) == 0 || strings.TrimSpace(objectName) == "" {
 		return errors.Wrap(gnfderrors.ErrInvalidObjectName, "Object name cannot be empty")
 	}
 	if len(objectName) > 1024 {
-		return errors.Wrap(gnfderrors.ErrInvalidObjectName, "Object name cannot be longer than 1024 characters")
+		return errors.Wrap(gnfderrors.ErrInvalidObjectName, "Object name cannot be longer than 1024 bytes")
 	}
 
 	// check bad path component
@@ -77,10 +86,10 @@ func CheckValidGroupName(groupName string) error {
 		return errors.Wrap(gnfderrors.ErrInvalidGroupName, "Group name cannot be empty")
 	}
 	if len(groupName) < 3 {
-		return errors.Wrap(gnfderrors.ErrInvalidGroupName, "Group name cannot be shorter than 3 characters")
+		return errors.Wrap(gnfderrors.ErrInvalidGroupName, "Group name cannot be shorter than 3 bytes")
 	}
 	if len(groupName) > 63 {
-		return errors.Wrap(gnfderrors.ErrInvalidGroupName, "Group name cannot be longer than 63 characters")
+		return errors.Wrap(gnfderrors.ErrInvalidGroupName, "Group name cannot be longer than 63 bytes")
 	}
 	if !utf8.ValidString(groupName) {
 		return errors.Wrap(gnfderrors.ErrInvalidGroupName, "Group name with non UTF-8 strings is not supported")
@@ -88,88 +97,6 @@ func CheckValidGroupName(groupName string) error {
 
 	return nil
 }
-
-// CheckValidBucketNameByCharacterLength - checks if we have a valid input bucket name.
-// This is a stricter version.
-// - http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html
-func CheckValidBucketNameByCharacterLength(bucketName string) (err error) {
-	if len(bucketName) == 0 || strings.TrimSpace(bucketName) == "" {
-		return errors.Wrap(gnfderrors.ErrInvalidBucketName, "Bucket name cannot be empty")
-	}
-	if utf8.RuneCountInString(bucketName) < 3 {
-		return errors.Wrap(gnfderrors.ErrInvalidBucketName, "Bucket name cannot be shorter than 3 characters")
-	}
-	if utf8.RuneCountInString(bucketName) > 63 {
-		return errors.Wrap(gnfderrors.ErrInvalidBucketName, "Bucket name cannot be longer than 63 characters")
-	}
-	if ipAddress.MatchString(bucketName) {
-		return errors.Wrap(gnfderrors.ErrInvalidBucketName, "Bucket name cannot be an ip address")
-	}
-	if strings.Contains(bucketName, "..") || strings.Contains(bucketName, ".-") || strings.Contains(bucketName, "-.") {
-		return errors.Wrap(gnfderrors.ErrInvalidBucketName, "Bucket name contains invalid characters")
-	}
-	if !validBucketName.MatchString(bucketName) {
-		return errors.Wrap(gnfderrors.ErrInvalidBucketName, "Bucket name contains invalid characters")
-	}
-
-	return nil
-}
-
-// CheckValidObjectNameByCharacterLength checks if we have a valid input object name.
-//
-// - http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html
-func CheckValidObjectNameByCharacterLength(objectName string) error {
-	// check the length of objectName
-	if len(objectName) == 0 || strings.TrimSpace(objectName) == "" {
-		return errors.Wrap(gnfderrors.ErrInvalidObjectName, "Object name cannot be empty")
-	}
-	if utf8.RuneCountInString(objectName) > 1024 {
-		return errors.Wrap(gnfderrors.ErrInvalidObjectName, "Object name cannot be longer than 1024 characters")
-	}
-
-	// check bad path component
-	if hasBadPathComponent(objectName) {
-		return errors.Wrap(gnfderrors.ErrInvalidObjectName, "Object name with a bad path component is not supported")
-	}
-	// check UTF-8 strings
-	if !utf8.ValidString(objectName) {
-		return errors.Wrap(gnfderrors.ErrInvalidObjectName, "Object name with non UTF-8 strings is not supported")
-	}
-
-	if strings.Contains(objectName, `//`) {
-		// the error description and the judgement condition are not consistent
-		// `Contains` is not the same as `HasPrefix`
-		return errors.Wrap(gnfderrors.ErrInvalidObjectName, "Object name contains a \"//\" is not supported")
-	}
-
-	return nil
-}
-
-func CheckValidGroupNameByCharacterLength(groupName string) error {
-	if len(groupName) == 0 || strings.TrimSpace(groupName) == "" {
-		return errors.Wrap(gnfderrors.ErrInvalidGroupName, "Group name cannot be empty")
-	}
-	if utf8.RuneCountInString(groupName) < 3 {
-		return errors.Wrap(gnfderrors.ErrInvalidGroupName, "Group name cannot be shorter than 3 characters")
-	}
-	if utf8.RuneCountInString(groupName) > 63 {
-		return errors.Wrap(gnfderrors.ErrInvalidGroupName, "Group name cannot be longer than 63 characters")
-	}
-	if !utf8.ValidString(groupName) {
-		return errors.Wrap(gnfderrors.ErrInvalidGroupName, "Group name with non UTF-8 strings is not supported")
-	}
-
-	return nil
-}
-
-const (
-	// Bad path components to be rejected by the path validity handler.
-	dotDotComponent = ".."
-	dotComponent    = "."
-
-	// SlashSeparator - slash separator.
-	SlashSeparator = "/"
-)
 
 // Check if the incoming path has bad path components,
 // such as ".." and "."
@@ -177,7 +104,7 @@ func hasBadPathComponent(path string) bool {
 	path = strings.TrimSpace(path)
 	for _, p := range strings.Split(path, SlashSeparator) {
 		switch strings.TrimSpace(p) {
-		case dotDotComponent:
+		case dotdotComponent:
 			return true
 		case dotComponent:
 			return true

--- a/x/challenge/client/cli/tx_submit.go
+++ b/x/challenge/client/cli/tx_submit.go
@@ -29,12 +29,12 @@ func CmdSubmit() *cobra.Command {
 			}
 
 			argBucketName := strings.TrimSpace(args[1])
-			if err := s3util.CheckValidBucketNameByCharacterLength(argBucketName); err != nil {
+			if err := s3util.CheckValidBucketName(argBucketName); err != nil {
 				return fmt.Errorf("bucket-name %s not a valid bucket name, please input a valid bucket-name", argBucketName)
 			}
 
 			argObjectName := strings.TrimSpace(args[2])
-			if err := s3util.CheckValidObjectNameByCharacterLength(argObjectName); err != nil {
+			if err := s3util.CheckValidObjectName(argObjectName); err != nil {
 				return fmt.Errorf("object-name %s not a valid object name, please input a valid object-name", argObjectName)
 			}
 

--- a/x/challenge/types/message_submit.go
+++ b/x/challenge/types/message_submit.go
@@ -4,7 +4,6 @@ import (
 	"cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
 	"github.com/bnb-chain/greenfield/types/s3util"
 )
@@ -56,25 +55,12 @@ func (msg *MsgSubmit) ValidateBasic() error {
 		return errors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid sp operator address (%s)", err)
 	}
 
-	return nil
-}
+	if err = s3util.CheckValidBucketName(msg.BucketName); err != nil {
+		return err
+	}
 
-func (msg *MsgSubmit) ValidateRuntime(ctx sdk.Context) error {
-	var err error
-	if ctx.IsUpgraded(upgradetypes.Ural) {
-		if err = s3util.CheckValidBucketNameByCharacterLength(msg.BucketName); err != nil {
-			return err
-		}
-		if err = s3util.CheckValidObjectNameByCharacterLength(msg.ObjectName); err != nil {
-			return err
-		}
-	} else {
-		if err = s3util.CheckValidBucketName(msg.BucketName); err != nil {
-			return err
-		}
-		if err = s3util.CheckValidObjectName(msg.ObjectName); err != nil {
-			return err
-		}
+	if err = s3util.CheckValidObjectName(msg.ObjectName); err != nil {
+		return err
 	}
 
 	return nil

--- a/x/challenge/types/message_submit_test.go
+++ b/x/challenge/types/message_submit_test.go
@@ -3,8 +3,6 @@ package types
 import (
 	"testing"
 
-	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/require"
 
@@ -67,14 +65,7 @@ func TestMsgSubmit_ValidateBasic(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.msg.ValidateBasic()
 			if tt.err != nil {
-				if err != nil {
-					require.ErrorIs(t, err, tt.err)
-				} else {
-					upgradeChecker := func(sdk.Context, string) bool { return true }
-					ctx := sdk.NewContext(nil, tmproto.Header{}, false, upgradeChecker, nil)
-					err = tt.msg.ValidateRuntime(ctx)
-					require.ErrorIs(t, err, tt.err)
-				}
+				require.ErrorIs(t, err, tt.err)
 				return
 			}
 			require.NoError(t, err)

--- a/x/storage/keeper/cross_app_bucket.go
+++ b/x/storage/keeper/cross_app_bucket.go
@@ -206,31 +206,31 @@ func (app *BucketApp) handleMirrorBucketFailAckPackage(ctx sdk.Context, appCtx *
 }
 
 func (app *BucketApp) handleMirrorBucketSynPackage(ctx sdk.Context, header *sdk.CrossChainAppContext, synPackage *types.MirrorBucketSynPackage) sdk.ExecuteResult {
-	app.storageKeeper.Logger(ctx).Error("received mirror bucket syn package")
+	app.storageKeeper.Logger(ctx).Error("received mirror bucket syn package ")
 
 	return sdk.ExecuteResult{}
 }
 
 func (app *BucketApp) handleCreateBucketAckPackage(ctx sdk.Context, appCtx *sdk.CrossChainAppContext, ackPackage *types.CreateBucketAckPackage) sdk.ExecuteResult {
-	app.storageKeeper.Logger(ctx).Error("received create bucket ack package")
+	app.storageKeeper.Logger(ctx).Error("received create bucket ack package ")
 
 	return sdk.ExecuteResult{}
 }
 
 func (app *BucketApp) handleCreateBucketFailAckPackage(ctx sdk.Context, appCtx *sdk.CrossChainAppContext, synPackage *types.CreateBucketSynPackage) sdk.ExecuteResult {
-	app.storageKeeper.Logger(ctx).Error("received create bucket fail ack package")
+	app.storageKeeper.Logger(ctx).Error("received create bucket fail ack package ")
 
 	return sdk.ExecuteResult{}
 }
 
 func (app *BucketApp) handleCreateBucketFailAckPackageV2(ctx sdk.Context, appCtx *sdk.CrossChainAppContext, synPackage *types.CreateBucketSynPackageV2) sdk.ExecuteResult {
-	app.storageKeeper.Logger(ctx).Error("received create bucket fail ack package")
+	app.storageKeeper.Logger(ctx).Error("received create bucket fail ack package ")
 
 	return sdk.ExecuteResult{}
 }
 
 func (app *BucketApp) handleCreateBucketSynPackage(ctx sdk.Context, appCtx *sdk.CrossChainAppContext, createBucketPackage *types.CreateBucketSynPackage) sdk.ExecuteResult {
-	err := createBucketPackage.ValidateBasic(ctx)
+	err := createBucketPackage.ValidateBasic()
 	if err != nil {
 		return sdk.ExecuteResult{
 			Payload: types.CreateBucketAckPackage{
@@ -288,7 +288,7 @@ func (app *BucketApp) handleCreateBucketSynPackage(ctx sdk.Context, appCtx *sdk.
 }
 
 func (app *BucketApp) handleCreateBucketSynPackageV2(ctx sdk.Context, appCtx *sdk.CrossChainAppContext, createBucketPackageV2 *types.CreateBucketSynPackageV2) sdk.ExecuteResult {
-	err := createBucketPackageV2.ValidateBasic(ctx)
+	err := createBucketPackageV2.ValidateBasic()
 	if err != nil {
 		return sdk.ExecuteResult{
 			Payload: types.CreateBucketAckPackage{

--- a/x/storage/keeper/cross_app_bucket_test.go
+++ b/x/storage/keeper/cross_app_bucket_test.go
@@ -58,17 +58,12 @@ func (s *TestSuite) TestSynCreateBucket() {
 	storageKeeper.EXPECT().Logger(gomock.Any()).Return(s.ctx.Logger()).AnyTimes()
 
 	app := keeper.NewBucketApp(storageKeeper)
-	createSynPackage := types.CreateBucketSynPackageV2{
-		Creator:                        sample.RandAccAddress(),
-		BucketName:                     "bucketname",
-		Visibility:                     0,
-		PaymentAddress:                 sample.RandAccAddress(),
-		PrimarySpAddress:               sample.RandAccAddress(),
-		PrimarySpApprovalExpiredHeight: 0,
-		GlobalVirtualGroupFamilyId:     0,
-		PrimarySpApprovalSignature:     nil,
-		ChargedReadQuota:               0,
-		ExtraData:                      []byte("extra data"),
+	createSynPackage := types.CreateBucketSynPackage{
+		Creator:          sample.RandAccAddress(),
+		BucketName:       "bucketname",
+		ExtraData:        []byte("extra data"),
+		PaymentAddress:   sample.RandAccAddress(),
+		PrimarySpAddress: sample.RandAccAddress(),
 	}
 	serializedSynPackage := createSynPackage.MustSerialize()
 	serializedSynPackage = append([]byte{types.OperationCreateBucket}, serializedSynPackage...)
@@ -233,24 +228,19 @@ func (s *TestSuite) TestFailAckCreateBucket() {
 	storageKeeper.EXPECT().Logger(gomock.Any()).Return(s.ctx.Logger()).AnyTimes()
 
 	app := keeper.NewBucketApp(storageKeeper)
-	createSynPackage := types.CreateBucketSynPackageV2{
-		Creator:                        sample.RandAccAddress(),
-		BucketName:                     "bucketname",
-		Visibility:                     0,
-		PaymentAddress:                 sample.RandAccAddress(),
-		PrimarySpAddress:               sample.RandAccAddress(),
-		PrimarySpApprovalExpiredHeight: 0,
-		GlobalVirtualGroupFamilyId:     0,
-		PrimarySpApprovalSignature:     nil,
-		ChargedReadQuota:               0,
-		ExtraData:                      []byte("extra data"),
+	createSynPackage := types.CreateBucketSynPackage{
+		Creator:          sample.RandAccAddress(),
+		BucketName:       "bucketname",
+		ExtraData:        []byte("extra data"),
+		PaymentAddress:   sample.RandAccAddress(),
+		PrimarySpAddress: sample.RandAccAddress(),
 	}
 	serializedSynPackage := createSynPackage.MustSerialize()
 	serializedSynPackage = append([]byte{types.OperationCreateBucket}, serializedSynPackage...)
 
 	storageKeeper.EXPECT().GetSourceTypeByChainId(gomock.Any(), gomock.Any()).Return(types.SOURCE_TYPE_BSC_CROSS_CHAIN, nil).AnyTimes()
 
-	// case 1: normal case
+	// case 1:  normal case
 	res := app.ExecuteFailAckPackage(s.ctx, &sdk.CrossChainAppContext{}, serializedSynPackage)
 	s.Require().NoError(res.Err)
 }

--- a/x/storage/keeper/cross_app_group.go
+++ b/x/storage/keeper/cross_app_group.go
@@ -217,7 +217,7 @@ func (app *GroupApp) handleCreateGroupFailAckPackage(ctx sdk.Context, appCtx *sd
 }
 
 func (app *GroupApp) handleCreateGroupSynPackage(ctx sdk.Context, appCtx *sdk.CrossChainAppContext, createGroupPackage *types.CreateGroupSynPackage) sdk.ExecuteResult {
-	err := createGroupPackage.ValidateBasic(ctx)
+	err := createGroupPackage.ValidateBasic()
 	if err != nil {
 		return sdk.ExecuteResult{
 			Payload: types.CreateGroupAckPackage{

--- a/x/storage/keeper/payment_test.go
+++ b/x/storage/keeper/payment_test.go
@@ -45,12 +45,11 @@ type TestSuite struct {
 func (s *TestSuite) SetupTest() {
 	encCfg := moduletestutil.MakeTestEncodingConfig(challenge.AppModuleBasic{})
 	key := storetypes.NewKVStoreKey(types.StoreKey)
-	upgradeChecker := func(sdk.Context, string) bool { return true }
 	testCtx := testutil.DefaultContextWithDB(s.T(), key, storetypes.NewTransientStoreKey("transient_test"))
 	header := testCtx.Ctx.BlockHeader()
 	header.Time = time.Now()
 	testCtx = testutil.TestContext{
-		Ctx: sdk.NewContext(testCtx.CMS, header, false, upgradeChecker, testCtx.Ctx.Logger()),
+		Ctx: sdk.NewContext(testCtx.CMS, header, false, nil, testCtx.Ctx.Logger()),
 		DB:  testCtx.DB,
 		CMS: testCtx.CMS,
 	}

--- a/x/storage/types/crosschain.go
+++ b/x/storage/types/crosschain.go
@@ -548,7 +548,7 @@ func (p CreateBucketSynPackage) MustSerialize() []byte {
 	return encodedBytes
 }
 
-func (p CreateBucketSynPackage) ValidateBasic(ctx sdk.Context) error {
+func (p CreateBucketSynPackage) ValidateBasic() error {
 	msg := MsgCreateBucket{
 		Creator:          p.Creator.String(),
 		BucketName:       p.BucketName,
@@ -562,11 +562,7 @@ func (p CreateBucketSynPackage) ValidateBasic(ctx sdk.Context) error {
 		ChargedReadQuota: p.ChargedReadQuota,
 	}
 
-	if err := msg.ValidateBasic(); err != nil {
-		return err
-	}
-
-	return msg.ValidateRuntime(ctx)
+	return msg.ValidateBasic()
 }
 
 func (p CreateBucketSynPackage) GetApprovalBytes() []byte {
@@ -612,7 +608,7 @@ func DeserializeCreateBucketSynPackage(serializedPackage []byte) (interface{}, e
 }
 
 func (p CreateBucketSynPackageV2) MustSerialize() []byte {
-	encodedBytes, err := createBucketSynPackageV2StructArgs.Pack(&CreateBucketSynPackageV2Struct{
+	encodedBytes, err := createBucketSynPackageStructArgs.Pack(&CreateBucketSynPackageV2Struct{
 		Creator:                        common.BytesToAddress(p.Creator),
 		BucketName:                     p.BucketName,
 		Visibility:                     p.Visibility,
@@ -630,7 +626,7 @@ func (p CreateBucketSynPackageV2) MustSerialize() []byte {
 	return encodedBytes
 }
 
-func (p CreateBucketSynPackageV2) ValidateBasic(ctx sdk.Context) error {
+func (p CreateBucketSynPackageV2) ValidateBasic() error {
 	msg := MsgCreateBucket{
 		Creator:          p.Creator.String(),
 		BucketName:       p.BucketName,
@@ -645,11 +641,7 @@ func (p CreateBucketSynPackageV2) ValidateBasic(ctx sdk.Context) error {
 		ChargedReadQuota: p.ChargedReadQuota,
 	}
 
-	if err := msg.ValidateBasic(); err != nil {
-		return err
-	}
-
-	return msg.ValidateRuntime(ctx)
+	return msg.ValidateBasic()
 }
 
 func (p CreateBucketSynPackageV2) GetApprovalBytes() []byte {
@@ -891,17 +883,12 @@ var (
 	}
 )
 
-func (p CreateGroupSynPackage) ValidateBasic(ctx sdk.Context) error {
+func (p CreateGroupSynPackage) ValidateBasic() error {
 	msg := MsgCreateGroup{
 		Creator:   p.Creator.String(),
 		GroupName: p.GroupName,
 	}
-
-	if err := msg.ValidateBasic(); err != nil {
-		return err
-	}
-
-	return msg.ValidateRuntime(ctx)
+	return msg.ValidateBasic()
 }
 
 func (p CreateGroupSynPackage) MustSerialize() []byte {

--- a/x/storage/types/message.go
+++ b/x/storage/types/message.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	"cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -181,20 +180,10 @@ func (msg *MsgCreateBucket) ValidateBasic() error {
 		return errors.Wrapf(ErrInvalidVisibility, "Unspecified visibility is not allowed.")
 	}
 
-	return nil
-}
-
-func (msg *MsgCreateBucket) ValidateRuntime(ctx sdk.Context) error {
-	var err error
-	if ctx.IsUpgraded(upgradetypes.Ural) {
-		err = s3util.CheckValidBucketNameByCharacterLength(msg.BucketName)
-	} else {
-		err = s3util.CheckValidBucketName(msg.BucketName)
-	}
+	err = s3util.CheckValidBucketName(msg.BucketName)
 	if err != nil {
 		return err
 	}
-
 	return nil
 }
 
@@ -238,16 +227,7 @@ func (msg *MsgDeleteBucket) ValidateBasic() error {
 		return errors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
 	}
 
-	return nil
-}
-
-func (msg *MsgDeleteBucket) ValidateRuntime(ctx sdk.Context) error {
-	var err error
-	if ctx.IsUpgraded(upgradetypes.Ural) {
-		err = s3util.CheckValidBucketNameByCharacterLength(msg.BucketName)
-	} else {
-		err = s3util.CheckValidBucketName(msg.BucketName)
-	}
+	err = s3util.CheckValidBucketName(msg.BucketName)
 	if err != nil {
 		return err
 	}
@@ -299,26 +279,15 @@ func (msg *MsgUpdateBucketInfo) ValidateBasic() error {
 		return errors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
 	}
 
+	if err = s3util.CheckValidBucketName(msg.BucketName); err != nil {
+		return err
+	}
+
 	if msg.PaymentAddress != "" {
 		_, err = sdk.AccAddressFromHexUnsafe(msg.PaymentAddress)
 		if err != nil {
 			return errors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid payment address (%s)", err)
 		}
-	}
-
-	return nil
-}
-
-func (msg *MsgUpdateBucketInfo) ValidateRuntime(ctx sdk.Context) error {
-	var err error
-
-	if ctx.IsUpgraded(upgradetypes.Ural) {
-		err = s3util.CheckValidBucketNameByCharacterLength(msg.BucketName)
-	} else {
-		err = s3util.CheckValidBucketName(msg.BucketName)
-	}
-	if err != nil {
-		return err
 	}
 
 	return nil
@@ -378,6 +347,16 @@ func (msg *MsgCreateObject) ValidateBasic() error {
 		return errors.Wrapf(ErrInvalidApproval, "Empty approvals are not allowed.")
 	}
 
+	err = s3util.CheckValidBucketName(msg.BucketName)
+	if err != nil {
+		return err
+	}
+
+	err = s3util.CheckValidObjectName(msg.ObjectName)
+	if err != nil {
+		return err
+	}
+
 	err = s3util.CheckValidExpectChecksums(msg.ExpectChecksums)
 	if err != nil {
 		return err
@@ -391,28 +370,6 @@ func (msg *MsgCreateObject) ValidateBasic() error {
 	if msg.Visibility == VISIBILITY_TYPE_UNSPECIFIED {
 		return errors.Wrapf(ErrInvalidVisibility, "Unspecified visibility is not allowed.")
 	}
-	return nil
-}
-
-func (msg *MsgCreateObject) ValidateRuntime(ctx sdk.Context) error {
-	var err error
-
-	if ctx.IsUpgraded(upgradetypes.Ural) {
-		if err = s3util.CheckValidBucketNameByCharacterLength(msg.BucketName); err != nil {
-			return err
-		}
-		if err = s3util.CheckValidObjectNameByCharacterLength(msg.ObjectName); err != nil {
-			return err
-		}
-	} else {
-		if err = s3util.CheckValidBucketName(msg.BucketName); err != nil {
-			return err
-		}
-		if err = s3util.CheckValidObjectName(msg.ObjectName); err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 
@@ -457,27 +414,14 @@ func (msg *MsgCancelCreateObject) ValidateBasic() error {
 	if err != nil {
 		return errors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
 	}
+	err = s3util.CheckValidBucketName(msg.BucketName)
+	if err != nil {
+		return err
+	}
 
-	return nil
-}
-
-func (msg *MsgCancelCreateObject) ValidateRuntime(ctx sdk.Context) error {
-	var err error
-
-	if ctx.IsUpgraded(upgradetypes.Ural) {
-		if err = s3util.CheckValidBucketNameByCharacterLength(msg.BucketName); err != nil {
-			return err
-		}
-		if err = s3util.CheckValidObjectNameByCharacterLength(msg.ObjectName); err != nil {
-			return err
-		}
-	} else {
-		if err = s3util.CheckValidBucketName(msg.BucketName); err != nil {
-			return err
-		}
-		if err = s3util.CheckValidObjectName(msg.ObjectName); err != nil {
-			return err
-		}
+	err = s3util.CheckValidObjectName(msg.ObjectName)
+	if err != nil {
+		return err
 	}
 
 	return nil
@@ -523,28 +467,15 @@ func (msg *MsgDeleteObject) ValidateBasic() error {
 		return errors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
 	}
 
-	return nil
-}
-
-func (msg *MsgDeleteObject) ValidateRuntime(ctx sdk.Context) error {
-	var err error
-
-	if ctx.IsUpgraded(upgradetypes.Ural) {
-		if err = s3util.CheckValidBucketNameByCharacterLength(msg.BucketName); err != nil {
-			return err
-		}
-		if err = s3util.CheckValidObjectNameByCharacterLength(msg.ObjectName); err != nil {
-			return err
-		}
-	} else {
-		if err = s3util.CheckValidBucketName(msg.BucketName); err != nil {
-			return err
-		}
-		if err = s3util.CheckValidObjectName(msg.ObjectName); err != nil {
-			return err
-		}
+	err = s3util.CheckValidBucketName(msg.BucketName)
+	if err != nil {
+		return err
 	}
 
+	err = s3util.CheckValidObjectName(msg.ObjectName)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -593,32 +524,20 @@ func (msg *MsgSealObject) ValidateBasic() error {
 		return errors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
 	}
 
+	err = s3util.CheckValidBucketName(msg.BucketName)
+	if err != nil {
+		return err
+	}
+
+	err = s3util.CheckValidObjectName(msg.ObjectName)
+	if err != nil {
+		return err
+	}
+
 	if len(msg.GetSecondarySpBlsAggSignatures()) != sdk.BLSSignatureLength {
 		return errors.Wrap(gnfderrors.ErrInvalidBlsSignature,
 			fmt.Sprintf("length of signature should be %d", sdk.BLSSignatureLength),
 		)
-	}
-
-	return nil
-}
-
-func (msg *MsgSealObject) ValidateRuntime(ctx sdk.Context) error {
-	var err error
-
-	if ctx.IsUpgraded(upgradetypes.Ural) {
-		if err = s3util.CheckValidBucketNameByCharacterLength(msg.BucketName); err != nil {
-			return err
-		}
-		if err = s3util.CheckValidObjectNameByCharacterLength(msg.ObjectName); err != nil {
-			return err
-		}
-	} else {
-		if err = s3util.CheckValidBucketName(msg.BucketName); err != nil {
-			return err
-		}
-		if err = s3util.CheckValidObjectName(msg.ObjectName); err != nil {
-			return err
-		}
 	}
 
 	return nil
@@ -680,42 +599,25 @@ func (msg *MsgCopyObject) ValidateBasic() error {
 		return errors.Wrapf(ErrInvalidApproval, "Empty approvals are not allowed.")
 	}
 
-	return nil
-}
-
-func (msg *MsgCopyObject) ValidateRuntime(ctx sdk.Context) error {
-	var err error
-
-	if ctx.IsUpgraded(upgradetypes.Ural) {
-		if err = s3util.CheckValidBucketNameByCharacterLength(msg.SrcBucketName); err != nil {
-			return err
-		}
-		if err = s3util.CheckValidObjectNameByCharacterLength(msg.SrcObjectName); err != nil {
-			return err
-		}
-
-		if err = s3util.CheckValidBucketNameByCharacterLength(msg.DstBucketName); err != nil {
-			return err
-		}
-		if err = s3util.CheckValidObjectNameByCharacterLength(msg.DstObjectName); err != nil {
-			return err
-		}
-	} else {
-		if err = s3util.CheckValidBucketName(msg.SrcBucketName); err != nil {
-			return err
-		}
-		if err = s3util.CheckValidObjectName(msg.SrcObjectName); err != nil {
-			return err
-		}
-
-		if err = s3util.CheckValidBucketNameByCharacterLength(msg.DstBucketName); err != nil {
-			return err
-		}
-		if err = s3util.CheckValidObjectNameByCharacterLength(msg.DstObjectName); err != nil {
-			return err
-		}
+	err = s3util.CheckValidBucketName(msg.SrcBucketName)
+	if err != nil {
+		return err
 	}
 
+	err = s3util.CheckValidObjectName(msg.SrcObjectName)
+	if err != nil {
+		return err
+	}
+
+	err = s3util.CheckValidBucketName(msg.DstBucketName)
+	if err != nil {
+		return err
+	}
+
+	err = s3util.CheckValidObjectName(msg.DstObjectName)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -758,27 +660,14 @@ func (msg *MsgRejectSealObject) ValidateBasic() error {
 	if err != nil {
 		return errors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
 	}
+	err = s3util.CheckValidBucketName(msg.BucketName)
+	if err != nil {
+		return err
+	}
 
-	return nil
-}
-
-func (msg *MsgRejectSealObject) ValidateRuntime(ctx sdk.Context) error {
-	var err error
-
-	if ctx.IsUpgraded(upgradetypes.Ural) {
-		if err = s3util.CheckValidBucketNameByCharacterLength(msg.BucketName); err != nil {
-			return err
-		}
-		if err = s3util.CheckValidObjectNameByCharacterLength(msg.ObjectName); err != nil {
-			return err
-		}
-	} else {
-		if err = s3util.CheckValidBucketName(msg.BucketName); err != nil {
-			return err
-		}
-		if err = s3util.CheckValidObjectName(msg.ObjectName); err != nil {
-			return err
-		}
+	err = s3util.CheckValidObjectName(msg.ObjectName)
+	if err != nil {
+		return err
 	}
 
 	return nil
@@ -825,27 +714,17 @@ func (msg *MsgDiscontinueObject) ValidateBasic() error {
 		return errors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid operator address (%s)", err)
 	}
 
+	err = s3util.CheckValidBucketName(msg.BucketName)
+	if err != nil {
+		return err
+	}
+
 	if len(msg.ObjectIds) == 0 || len(msg.ObjectIds) > MaxDiscontinueObjects {
 		return errors.Wrapf(ErrInvalidObjectIds, "length of ids is %d", len(msg.ObjectIds))
 	}
 
 	if len(msg.Reason) > MaxDiscontinueReasonLen {
 		return errors.Wrapf(ErrInvalidReason, "reason is too long with length %d", len(msg.Reason))
-	}
-
-	return nil
-}
-
-func (msg *MsgDiscontinueObject) ValidateRuntime(ctx sdk.Context) error {
-	var err error
-
-	if ctx.IsUpgraded(upgradetypes.Ural) {
-		err = s3util.CheckValidBucketNameByCharacterLength(msg.BucketName)
-	} else {
-		err = s3util.CheckValidBucketName(msg.BucketName)
-	}
-	if err != nil {
-		return err
 	}
 
 	return nil
@@ -891,23 +770,13 @@ func (msg *MsgDiscontinueBucket) ValidateBasic() error {
 		return errors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid operator address (%s)", err)
 	}
 
-	if len(msg.Reason) > MaxDiscontinueReasonLen {
-		return errors.Wrapf(ErrInvalidReason, "reason is too long with length %d", len(msg.Reason))
-	}
-
-	return nil
-}
-
-func (msg *MsgDiscontinueBucket) ValidateRuntime(ctx sdk.Context) error {
-	var err error
-
-	if ctx.IsUpgraded(upgradetypes.Ural) {
-		err = s3util.CheckValidBucketNameByCharacterLength(msg.BucketName)
-	} else {
-		err = s3util.CheckValidBucketName(msg.BucketName)
-	}
+	err = s3util.CheckValidBucketName(msg.BucketName)
 	if err != nil {
 		return err
+	}
+
+	if len(msg.Reason) > MaxDiscontinueReasonLen {
+		return errors.Wrapf(ErrInvalidReason, "reason is too long with length %d", len(msg.Reason))
 	}
 
 	return nil
@@ -956,30 +825,18 @@ func (msg *MsgUpdateObjectInfo) ValidateBasic() error {
 		return errors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
 	}
 
-	if msg.Visibility == VISIBILITY_TYPE_UNSPECIFIED {
-		return errors.Wrapf(ErrInvalidVisibility, "Unspecified visibility is not allowed.")
+	err = s3util.CheckValidBucketName(msg.BucketName)
+	if err != nil {
+		return err
 	}
 
-	return nil
-}
+	err = s3util.CheckValidObjectName(msg.ObjectName)
+	if err != nil {
+		return err
+	}
 
-func (msg *MsgUpdateObjectInfo) ValidateRuntime(ctx sdk.Context) error {
-	var err error
-
-	if ctx.IsUpgraded(upgradetypes.Ural) {
-		if err = s3util.CheckValidBucketNameByCharacterLength(msg.BucketName); err != nil {
-			return err
-		}
-		if err = s3util.CheckValidObjectNameByCharacterLength(msg.ObjectName); err != nil {
-			return err
-		}
-	} else {
-		if err = s3util.CheckValidBucketName(msg.BucketName); err != nil {
-			return err
-		}
-		if err = s3util.CheckValidObjectName(msg.ObjectName); err != nil {
-			return err
-		}
+	if msg.Visibility == VISIBILITY_TYPE_UNSPECIFIED {
+		return errors.Wrapf(ErrInvalidVisibility, "Unspecified visibility is not allowed.")
 	}
 
 	return nil
@@ -1025,24 +882,14 @@ func (msg *MsgCreateGroup) ValidateBasic() error {
 		return errors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
 	}
 
+	err = s3util.CheckValidGroupName(msg.GroupName)
+	if err != nil {
+		return gnfderrors.ErrInvalidGroupName.Wrapf("invalid groupName (%s)", err)
+	}
+
 	if len(msg.Extra) > MaxGroupExtraInfoLimit {
 		return errors.Wrapf(gnfderrors.ErrInvalidParameter, "extra is too long with length %d, limit to %d", len(msg.Extra), MaxGroupExtraInfoLimit)
 	}
-	return nil
-}
-
-func (msg *MsgCreateGroup) ValidateRuntime(ctx sdk.Context) error {
-	var err error
-
-	if ctx.IsUpgraded(upgradetypes.Ural) {
-		err = s3util.CheckValidGroupNameByCharacterLength(msg.GroupName)
-	} else {
-		err = s3util.CheckValidGroupName(msg.GroupName)
-	}
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -1085,21 +932,10 @@ func (msg *MsgDeleteGroup) ValidateBasic() error {
 		return errors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
 	}
 
-	return nil
-}
-
-func (msg *MsgDeleteGroup) ValidateRuntime(ctx sdk.Context) error {
-	var err error
-
-	if ctx.IsUpgraded(upgradetypes.Ural) {
-		err = s3util.CheckValidGroupNameByCharacterLength(msg.GroupName)
-	} else {
-		err = s3util.CheckValidGroupName(msg.GroupName)
-	}
+	err = s3util.CheckValidGroupName(msg.GroupName)
 	if err != nil {
-		return err
+		return errors.Wrapf(gnfderrors.ErrInvalidGroupName, "invalid groupName (%s)", err)
 	}
-
 	return nil
 }
 
@@ -1148,21 +984,10 @@ func (msg *MsgLeaveGroup) ValidateBasic() error {
 		return errors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid group owner (%s)", err)
 	}
 
-	return nil
-}
-
-func (msg *MsgLeaveGroup) ValidateRuntime(ctx sdk.Context) error {
-	var err error
-
-	if ctx.IsUpgraded(upgradetypes.Ural) {
-		err = s3util.CheckValidGroupNameByCharacterLength(msg.GroupName)
-	} else {
-		err = s3util.CheckValidGroupName(msg.GroupName)
-	}
+	err = s3util.CheckValidGroupName(msg.GroupName)
 	if err != nil {
 		return err
 	}
-
 	return nil
 }
 
@@ -1220,6 +1045,11 @@ func (msg *MsgUpdateGroupMember) ValidateBasic() error {
 		return errors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid group owner address (%s)", err)
 	}
 
+	err = s3util.CheckValidGroupName(msg.GroupName)
+	if err != nil {
+		return err
+	}
+
 	if len(msg.MembersToAdd)+len(msg.MembersToDelete) > MaxGroupMemberLimitOnce {
 		return gnfderrors.ErrInvalidParameter.Wrapf("Once update group member limit exceeded")
 	}
@@ -1239,22 +1069,6 @@ func (msg *MsgUpdateGroupMember) ValidateBasic() error {
 			return errors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid member address (%s)", err)
 		}
 	}
-
-	return nil
-}
-
-func (msg *MsgUpdateGroupMember) ValidateRuntime(ctx sdk.Context) error {
-	var err error
-
-	if ctx.IsUpgraded(upgradetypes.Ural) {
-		err = s3util.CheckValidGroupNameByCharacterLength(msg.GroupName)
-	} else {
-		err = s3util.CheckValidGroupName(msg.GroupName)
-	}
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -1304,23 +1118,12 @@ func (msg *MsgUpdateGroupExtra) ValidateBasic() error {
 		return errors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid group owner address (%s)", err)
 	}
 
-	if len(msg.Extra) > MaxGroupExtraInfoLimit {
-		return errors.Wrapf(gnfderrors.ErrInvalidParameter, "extra is too long with length %d, limit to %d", len(msg.Extra), MaxGroupExtraInfoLimit)
-	}
-
-	return nil
-}
-
-func (msg *MsgUpdateGroupExtra) ValidateRuntime(ctx sdk.Context) error {
-	var err error
-
-	if ctx.IsUpgraded(upgradetypes.Ural) {
-		err = s3util.CheckValidGroupNameByCharacterLength(msg.GroupName)
-	} else {
-		err = s3util.CheckValidGroupName(msg.GroupName)
-	}
+	err = s3util.CheckValidGroupName(msg.GroupName)
 	if err != nil {
 		return err
+	}
+	if len(msg.Extra) > MaxGroupExtraInfoLimit {
+		return errors.Wrapf(gnfderrors.ErrInvalidParameter, "extra is too long with length %d, limit to %d", len(msg.Extra), MaxGroupExtraInfoLimit)
 	}
 
 	return nil
@@ -1509,12 +1312,6 @@ func (msg *MsgMirrorBucket) ValidateBasic() error {
 		return errors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
 	}
 
-	return nil
-}
-
-func (msg *MsgMirrorBucket) ValidateRuntime(ctx sdk.Context) error {
-	var err error
-
 	if !msg.Id.IsNil() && msg.Id.GT(sdk.NewUint(0)) {
 		if msg.BucketName != "" {
 			return errors.Wrap(gnfderrors.ErrInvalidBucketName, "Bucket name should be empty")
@@ -1522,11 +1319,7 @@ func (msg *MsgMirrorBucket) ValidateRuntime(ctx sdk.Context) error {
 		return nil
 	}
 
-	if ctx.IsUpgraded(upgradetypes.Ural) {
-		err = s3util.CheckValidBucketNameByCharacterLength(msg.BucketName)
-	} else {
-		err = s3util.CheckValidBucketName(msg.BucketName)
-	}
+	err = s3util.CheckValidBucketName(msg.BucketName)
 	if err != nil {
 		return err
 	}
@@ -1577,12 +1370,6 @@ func (msg *MsgMirrorObject) ValidateBasic() error {
 		return errors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
 	}
 
-	return nil
-}
-
-func (msg *MsgMirrorObject) ValidateRuntime(ctx sdk.Context) error {
-	var err error
-
 	if !msg.Id.IsNil() && msg.Id.GT(sdk.NewUint(0)) {
 		if msg.BucketName != "" {
 			return errors.Wrap(gnfderrors.ErrInvalidBucketName, "Bucket name should be empty")
@@ -1593,20 +1380,14 @@ func (msg *MsgMirrorObject) ValidateRuntime(ctx sdk.Context) error {
 		return nil
 	}
 
-	if ctx.IsUpgraded(upgradetypes.Ural) {
-		if err = s3util.CheckValidBucketNameByCharacterLength(msg.BucketName); err != nil {
-			return err
-		}
-		if err = s3util.CheckValidObjectNameByCharacterLength(msg.ObjectName); err != nil {
-			return err
-		}
-	} else {
-		if err = s3util.CheckValidBucketName(msg.BucketName); err != nil {
-			return err
-		}
-		if err = s3util.CheckValidObjectName(msg.ObjectName); err != nil {
-			return err
-		}
+	err = s3util.CheckValidBucketName(msg.BucketName)
+	if err != nil {
+		return err
+	}
+
+	err = s3util.CheckValidObjectName(msg.ObjectName)
+	if err != nil {
+		return err
 	}
 
 	return nil
@@ -1654,12 +1435,6 @@ func (msg *MsgMirrorGroup) ValidateBasic() error {
 		return errors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
 	}
 
-	return nil
-}
-
-func (msg *MsgMirrorGroup) ValidateRuntime(ctx sdk.Context) error {
-	var err error
-
 	if !msg.Id.IsNil() && msg.Id.GT(sdk.NewUint(0)) {
 		if msg.GroupName != "" {
 			return errors.Wrap(gnfderrors.ErrInvalidGroupName, "Group name should be empty")
@@ -1667,13 +1442,9 @@ func (msg *MsgMirrorGroup) ValidateRuntime(ctx sdk.Context) error {
 		return nil
 	}
 
-	if ctx.IsUpgraded(upgradetypes.Ural) {
-		err = s3util.CheckValidGroupNameByCharacterLength(msg.GroupName)
-	} else {
-		err = s3util.CheckValidGroupName(msg.GroupName)
-	}
+	err = s3util.CheckValidGroupName(msg.GroupName)
 	if err != nil {
-		return err
+		return gnfderrors.ErrInvalidGroupName.Wrapf("invalid groupName (%s)", err)
 	}
 
 	return nil
@@ -1751,6 +1522,11 @@ func (msg *MsgRenewGroupMember) ValidateBasic() error {
 		return errors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid group owner address (%s)", err)
 	}
 
+	err = s3util.CheckValidGroupName(msg.GroupName)
+	if err != nil {
+		return err
+	}
+
 	if len(msg.Members) > MaxGroupMemberLimitOnce {
 		return gnfderrors.ErrInvalidParameter.Wrapf("Once renew group member limit exceeded")
 	}
@@ -1762,21 +1538,6 @@ func (msg *MsgRenewGroupMember) ValidateBasic() error {
 		if member.ExpirationTime != nil && member.ExpirationTime.UTC().After(MaxTimeStamp) {
 			return gnfderrors.ErrInvalidParameter.Wrapf("Expiration time is bigger than max timestamp [%s]", MaxTimeStamp)
 		}
-	}
-
-	return nil
-}
-
-func (msg *MsgRenewGroupMember) ValidateRuntime(ctx sdk.Context) error {
-	var err error
-
-	if ctx.IsUpgraded(upgradetypes.Ural) {
-		err = s3util.CheckValidGroupNameByCharacterLength(msg.GroupName)
-	} else {
-		err = s3util.CheckValidGroupName(msg.GroupName)
-	}
-	if err != nil {
-		return err
 	}
 
 	return nil
@@ -1829,29 +1590,15 @@ func (msg *MsgSetTag) ValidateBasic() error {
 	}
 
 	if len(msg.Tags.GetTags()) > MaxTagCount {
-		return gnfderrors.ErrInvalidParameter.Wrapf("Tags count limit exceeded")
+		return gnfderrors.ErrInvalidParameter.Wrapf("Tags count cannot exceed %d", MaxTagCount)
 	}
-
-	return nil
-}
-
-func (msg *MsgSetTag) ValidateRuntime(ctx sdk.Context) error {
 	if len(msg.Tags.GetTags()) > 0 {
 		for _, tag := range msg.Tags.GetTags() {
-			if ctx.IsUpgraded(upgradetypes.Ural) {
-				if utf8.RuneCountInString(tag.GetKey()) > MaxTagKeyLength {
-					return gnfderrors.ErrInvalidParameter.Wrapf("Tag key length exceeded")
-				}
-				if utf8.RuneCountInString(tag.GetValue()) > MaxTagValueLength {
-					return gnfderrors.ErrInvalidParameter.Wrapf("Tag value length exceeded")
-				}
-			} else {
-				if len(tag.GetKey()) > MaxTagKeyLength {
-					return gnfderrors.ErrInvalidParameter.Wrapf("Tag key length exceeded")
-				}
-				if len(tag.GetValue()) > MaxTagValueLength {
-					return gnfderrors.ErrInvalidParameter.Wrapf("Tag value length exceeded")
-				}
+			if len(tag.GetKey()) > MaxTagKeyLength {
+				return gnfderrors.ErrInvalidParameter.Wrapf("Tag key length cannot exceed %d", MaxTagKeyLength)
+			}
+			if len(tag.GetValue()) > MaxTagValueLength {
+				return gnfderrors.ErrInvalidParameter.Wrapf("Tag value length cannot exceed %d", MaxTagValueLength)
 			}
 		}
 	}

--- a/x/storage/types/message_cancel_migrate_bucket.go
+++ b/x/storage/types/message_cancel_migrate_bucket.go
@@ -3,7 +3,6 @@ package types
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
 	"github.com/bnb-chain/greenfield/types/s3util"
 )
@@ -46,19 +45,9 @@ func (msg *MsgCancelMigrateBucket) ValidateBasic() error {
 		return sdkerrors.ErrInvalidAddress.Wrapf("invalid creator address (%s)", err)
 	}
 
-	return nil
-}
-
-func (msg *MsgCancelMigrateBucket) ValidateRuntime(ctx sdk.Context) error {
-	var err error
-	if ctx.IsUpgraded(upgradetypes.Ural) {
-		err = s3util.CheckValidBucketNameByCharacterLength(msg.BucketName)
-	} else {
-		err = s3util.CheckValidBucketName(msg.BucketName)
-	}
+	err = s3util.CheckValidBucketName(msg.BucketName)
 	if err != nil {
 		return err
 	}
-
 	return nil
 }

--- a/x/storage/types/message_complete_migrate_bucket.go
+++ b/x/storage/types/message_complete_migrate_bucket.go
@@ -4,7 +4,6 @@ import (
 	"cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
 	gnfderrors "github.com/bnb-chain/greenfield/types/errors"
 	"github.com/bnb-chain/greenfield/types/s3util"
@@ -50,7 +49,10 @@ func (msg *MsgCompleteMigrateBucket) ValidateBasic() error {
 	if err != nil {
 		return errors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
 	}
-
+	err = s3util.CheckValidBucketName(msg.BucketName)
+	if err != nil {
+		return err
+	}
 	if msg.GlobalVirtualGroupFamilyId == types.NoSpecifiedFamilyId {
 		return gnfderrors.ErrInvalidMessage.Wrap("the global virtual group family id not specify.")
 	}
@@ -70,20 +72,5 @@ func (msg *MsgCompleteMigrateBucket) ValidateBasic() error {
 		}
 		mappingMap[gvgMapping.SrcGlobalVirtualGroupId] = gvgMapping.DstGlobalVirtualGroupId
 	}
-
-	return nil
-}
-
-func (msg *MsgCompleteMigrateBucket) ValidateRuntime(ctx sdk.Context) error {
-	var err error
-	if ctx.IsUpgraded(upgradetypes.Ural) {
-		err = s3util.CheckValidBucketNameByCharacterLength(msg.BucketName)
-	} else {
-		err = s3util.CheckValidBucketName(msg.BucketName)
-	}
-	if err != nil {
-		return err
-	}
-
 	return nil
 }

--- a/x/storage/types/message_migrate_bucket.go
+++ b/x/storage/types/message_migrate_bucket.go
@@ -3,7 +3,6 @@ package types
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	"github.com/cosmos/gogoproto/proto"
 
 	"github.com/bnb-chain/greenfield/types/common"
@@ -57,6 +56,11 @@ func (msg *MsgMigrateBucket) ValidateBasic() error {
 		return sdkerrors.ErrInvalidAddress.Wrapf("invalid creator address (%s)", err)
 	}
 
+	err = s3util.CheckValidBucketName(msg.BucketName)
+	if err != nil {
+		return err
+	}
+
 	if msg.DstPrimarySpId == 0 {
 		return errors.ErrInvalidMessage.Wrapf("Invalid dst primary sp id: %d", msg.DstPrimarySpId)
 	}
@@ -64,19 +68,5 @@ func (msg *MsgMigrateBucket) ValidateBasic() error {
 	if msg.DstPrimarySpApproval == nil {
 		return ErrInvalidApproval.Wrap("Empty approvals are not allowed.")
 	}
-	return nil
-}
-
-func (msg *MsgMigrateBucket) ValidateRuntime(ctx sdk.Context) error {
-	var err error
-	if ctx.IsUpgraded(upgradetypes.Ural) {
-		err = s3util.CheckValidBucketNameByCharacterLength(msg.BucketName)
-	} else {
-		err = s3util.CheckValidBucketName(msg.BucketName)
-	}
-	if err != nil {
-		return err
-	}
-
 	return nil
 }

--- a/x/storage/types/message_object_test.go
+++ b/x/storage/types/message_object_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 
 	"cosmossdk.io/math"
-	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/prysmaticlabs/prysm/crypto/bls"
 	"github.com/stretchr/testify/require"
@@ -79,14 +77,7 @@ func TestMsgCreateObject_ValidateBasic(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.msg.ValidateBasic()
 			if tt.err != nil {
-				if err != nil {
-					require.ErrorIs(t, err, tt.err)
-				} else {
-					upgradeChecker := func(sdk.Context, string) bool { return true }
-					ctx := sdk.NewContext(nil, tmproto.Header{}, false, upgradeChecker, nil)
-					err = tt.msg.ValidateRuntime(ctx)
-					require.ErrorIs(t, err, tt.err)
-				}
+				require.ErrorIs(t, err, tt.err)
 				return
 			}
 			require.NoError(t, err)
@@ -260,14 +251,7 @@ func TestMsgCopyObject_ValidateBasic(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.msg.ValidateBasic()
 			if tt.err != nil {
-				if err != nil {
-					require.ErrorIs(t, err, tt.err)
-				} else {
-					upgradeChecker := func(sdk.Context, string) bool { return true }
-					ctx := sdk.NewContext(nil, tmproto.Header{}, false, upgradeChecker, nil)
-					err = tt.msg.ValidateRuntime(ctx)
-					require.ErrorIs(t, err, tt.err)
-				}
+				require.ErrorIs(t, err, tt.err)
 				return
 			}
 			require.NoError(t, err)
@@ -339,14 +323,7 @@ func TestMsgSealObject_ValidateBasic(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.msg.ValidateBasic()
 			if tt.err != nil {
-				if err != nil {
-					require.ErrorIs(t, err, tt.err)
-				} else {
-					upgradeChecker := func(sdk.Context, string) bool { return true }
-					ctx := sdk.NewContext(nil, tmproto.Header{}, false, upgradeChecker, nil)
-					err = tt.msg.ValidateRuntime(ctx)
-					require.ErrorIs(t, err, tt.err)
-				}
+				require.ErrorIs(t, err, tt.err)
 				return
 			}
 			require.NoError(t, err)
@@ -400,14 +377,7 @@ func TestMsgRejectSealObject_ValidateBasic(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.msg.ValidateBasic()
 			if tt.err != nil {
-				if err != nil {
-					require.ErrorIs(t, err, tt.err)
-				} else {
-					upgradeChecker := func(sdk.Context, string) bool { return true }
-					ctx := sdk.NewContext(nil, tmproto.Header{}, false, upgradeChecker, nil)
-					err = tt.msg.ValidateRuntime(ctx)
-					require.ErrorIs(t, err, tt.err)
-				}
+				require.ErrorIs(t, err, tt.err)
 				return
 			}
 			require.NoError(t, err)
@@ -475,14 +445,7 @@ func TestMsgUpdateObjectInfo_ValidateBasic(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.msg.ValidateBasic()
 			if tt.err != nil {
-				if err != nil {
-					require.ErrorIs(t, err, tt.err)
-				} else {
-					upgradeChecker := func(sdk.Context, string) bool { return true }
-					ctx := sdk.NewContext(nil, tmproto.Header{}, false, upgradeChecker, nil)
-					err = tt.msg.ValidateRuntime(ctx)
-					require.ErrorIs(t, err, tt.err)
-				}
+				require.ErrorIs(t, err, tt.err)
 				return
 			}
 			require.NoError(t, err)
@@ -595,14 +558,7 @@ func TestMsgDiscontinueObject_ValidateBasic(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.msg.ValidateBasic()
 			if tt.err != nil {
-				if err != nil {
-					require.ErrorIs(t, err, tt.err)
-				} else {
-					upgradeChecker := func(sdk.Context, string) bool { return true }
-					ctx := sdk.NewContext(nil, tmproto.Header{}, false, upgradeChecker, nil)
-					err = tt.msg.ValidateRuntime(ctx)
-					require.ErrorIs(t, err, tt.err)
-				}
+				require.ErrorIs(t, err, tt.err)
 				return
 			}
 			require.NoError(t, err)

--- a/x/storage/types/message_reject_migrate_bucket.go
+++ b/x/storage/types/message_reject_migrate_bucket.go
@@ -3,7 +3,6 @@ package types
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
 	"github.com/bnb-chain/greenfield/types/s3util"
 )
@@ -46,19 +45,9 @@ func (msg *MsgRejectMigrateBucket) ValidateBasic() error {
 		return sdkerrors.ErrInvalidAddress.Wrapf("invalid operator address (%s)", err)
 	}
 
-	return nil
-}
-
-func (msg *MsgRejectMigrateBucket) ValidateRuntime(ctx sdk.Context) error {
-	var err error
-	if ctx.IsUpgraded(upgradetypes.Ural) {
-		err = s3util.CheckValidBucketNameByCharacterLength(msg.BucketName)
-	} else {
-		err = s3util.CheckValidBucketName(msg.BucketName)
-	}
+	err = s3util.CheckValidBucketName(msg.BucketName)
 	if err != nil {
 		return err
 	}
-
 	return nil
 }

--- a/x/storage/types/message_test.go
+++ b/x/storage/types/message_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"cosmossdk.io/math"
-	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/require"
@@ -88,9 +87,7 @@ func TestMsgCreateBucket_ValidateBasic(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			upgradeChecker := func(sdk.Context, string) bool { return true }
-			ctx := sdk.NewContext(nil, tmproto.Header{}, false, upgradeChecker, nil)
-			err := tt.msg.ValidateRuntime(ctx)
+			err := tt.msg.ValidateBasic()
 			if tt.err != nil {
 				require.ErrorIs(t, err, tt.err)
 				return
@@ -123,9 +120,7 @@ func TestMsgDeleteBucket_ValidateBasic(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			upgradeChecker := func(sdk.Context, string) bool { return true }
-			ctx := sdk.NewContext(nil, tmproto.Header{}, false, upgradeChecker, nil)
-			err := tt.msg.ValidateRuntime(ctx)
+			err := tt.msg.ValidateBasic()
 			if tt.err != nil {
 				require.ErrorIs(t, err, tt.err)
 				return


### PR DESCRIPTION
* Revert "feat: change logic of resource name length check (#560)"

This reverts commit eb942972

* chore: update go.mod and some error msgs

### Description

revert * Revert "feat: change logic of resource name length check (#560)"

As it is no longer support, we just align with S3
### Rationale

Revert unnecessary PR
### Example

None
### Changes

None
