### PR TITLE
fix: disallow update payment address when there are created/updating objects

### DIFF
--- a/e2e/core/basesuite.go
+++ b/e2e/core/basesuite.go
@@ -128,7 +128,7 @@ func (s *BaseSuite) InitChain() {
 func (s *BaseSuite) SetupSuite() {
 	s.Config = InitConfig()
 	initValidatorOnce.Do(func() {
-		//s.InitChain()
+		s.InitChain()
 	})
 
 	s.Client, _ = client.NewGreenfieldClient(s.Config.TendermintAddr, s.Config.ChainId)

--- a/e2e/core/basesuite.go
+++ b/e2e/core/basesuite.go
@@ -128,7 +128,7 @@ func (s *BaseSuite) InitChain() {
 func (s *BaseSuite) SetupSuite() {
 	s.Config = InitConfig()
 	initValidatorOnce.Do(func() {
-		s.InitChain()
+		//s.InitChain()
 	})
 
 	s.Client, _ = client.NewGreenfieldClient(s.Config.TendermintAddr, s.Config.ChainId)

--- a/e2e/tests/storage_test.go
+++ b/e2e/tests/storage_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	paymenttypes "github.com/bnb-chain/greenfield/x/payment/types"
+
 	sdkmath "cosmossdk.io/math"
 	ctypes "github.com/cometbft/cometbft/rpc/core/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -2406,4 +2408,130 @@ func (s *StorageTestSuite) TestDeleteCreateObject_InCreatedStatus() {
 
 	_, err = s.Client.HeadObject(ctx, &queryHeadObjectRequest)
 	s.Require().EqualError(err, "rpc error: code = Unknown desc = No such object: unknown request")
+}
+
+func (s *StorageTestSuite) TestDisallowChangePaymentAccount() {
+	var err error
+	sp := s.BaseSuite.PickStorageProvider()
+	gvg, found := sp.GetFirstGlobalVirtualGroup()
+	s.Require().True(found)
+	user := s.User
+	// CreateBucket
+	bucketName := storageutils.GenRandomBucketName()
+	msgCreateBucket := storagetypes.NewMsgCreateBucket(
+		user.GetAddr(), bucketName, storagetypes.VISIBILITY_TYPE_PUBLIC_READ, sp.OperatorKey.GetAddr(),
+		nil, math.MaxUint, nil, 0)
+	msgCreateBucket.PrimarySpApproval.GlobalVirtualGroupFamilyId = gvg.FamilyId
+	msgCreateBucket.PrimarySpApproval.Sig, err = sp.ApprovalKey.Sign(msgCreateBucket.GetApprovalBytes())
+	s.Require().NoError(err)
+	s.SendTxBlock(user, msgCreateBucket)
+
+	// HeadBucket
+	ctx := context.Background()
+	queryHeadBucketRequest := storagetypes.QueryHeadBucketRequest{
+		BucketName: bucketName,
+	}
+	_, err = s.Client.HeadBucket(ctx, &queryHeadBucketRequest)
+	s.Require().NoError(err)
+
+	// create a new payment account
+	msgCreatePaymentAccount := &paymenttypes.MsgCreatePaymentAccount{
+		Creator: user.GetAddr().String(),
+	}
+	_ = s.SendTxBlock(user, msgCreatePaymentAccount)
+	// query user's payment accounts
+	queryGetPaymentAccountsByOwnerRequest := paymenttypes.QueryPaymentAccountsByOwnerRequest{
+		Owner: user.GetAddr().String(),
+	}
+	paymentAccounts, err := s.Client.PaymentAccountsByOwner(ctx, &queryGetPaymentAccountsByOwnerRequest)
+	s.Require().NoError(err)
+	s.T().Log(paymentAccounts)
+	s.Require().Equal(1, len(paymentAccounts.PaymentAccounts))
+	paymentAccountAddr := sdk.MustAccAddressFromHex(paymentAccounts.PaymentAccounts[0])
+
+	msgDeposit := &paymenttypes.MsgDeposit{
+		Creator: user.GetAddr().String(),
+		To:      paymentAccountAddr.String(),
+		Amount:  types.NewIntFromInt64WithDecimal(2, types.DecimalBNB),
+	}
+	_ = s.SendTxBlock(user, msgDeposit)
+
+	// UpdateBucketInfo is fine for no created object
+	msgUpdateBucketInfo := storagetypes.NewMsgUpdateBucketInfo(
+		user.GetAddr(), bucketName, nil, paymentAccountAddr, storagetypes.VISIBILITY_TYPE_PRIVATE)
+	s.Require().NoError(err)
+	s.SendTxBlock(user, msgUpdateBucketInfo)
+	s.Require().NoError(err)
+
+	// CreateObject
+	objectName := storageutils.GenRandomObjectName()
+	// create test buffer
+	var buffer bytes.Buffer
+	line := `1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,
+	1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,
+	1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,
+	1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,
+	1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,
+	1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,
+	1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,
+	1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,
+	1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,
+	1234567890,1234567890,1234567890,123`
+	// Create 1MiB content where each line contains 1024 characters.
+	for i := 0; i < 1024; i++ {
+		buffer.WriteString(fmt.Sprintf("[%05d] %s\n", i, line))
+	}
+	payloadSize := buffer.Len()
+	checksum := sdk.Keccak256(buffer.Bytes())
+	expectChecksum := [][]byte{checksum, checksum, checksum, checksum, checksum, checksum, checksum}
+	contextType := "text/event-stream"
+	msgCreateObject := storagetypes.NewMsgCreateObject(user.GetAddr(), bucketName, objectName, uint64(payloadSize),
+		storagetypes.VISIBILITY_TYPE_PRIVATE, expectChecksum, contextType, storagetypes.REDUNDANCY_EC_TYPE, math.MaxUint, nil)
+	msgCreateObject.PrimarySpApproval.Sig, err = sp.ApprovalKey.Sign(msgCreateObject.GetApprovalBytes())
+	s.Require().NoError(err)
+	s.SendTxBlock(user, msgCreateObject)
+
+	// HeadObject
+	queryHeadObjectRequest := storagetypes.QueryHeadObjectRequest{
+		BucketName: bucketName,
+		ObjectName: objectName,
+	}
+	queryHeadObjectResponse, err := s.Client.HeadObject(ctx, &queryHeadObjectRequest)
+	s.Require().NoError(err)
+
+	// UpdateBucketInfo is not fine for there is a created object
+	msgUpdateBucketInfo = storagetypes.NewMsgUpdateBucketInfo(
+		user.GetAddr(), bucketName, nil, user.GetAddr(), storagetypes.VISIBILITY_TYPE_PRIVATE)
+	s.Require().NoError(err)
+	s.SendTxBlockWithExpectErrorString(msgUpdateBucketInfo, user, "has unseald objects")
+
+	// SealObject
+	gvgId := gvg.Id
+	msgSealObject := storagetypes.NewMsgSealObject(sp.SealKey.GetAddr(), bucketName, objectName, gvgId, nil)
+
+	secondarySigs := make([][]byte, 0)
+	secondarySPBlsPubKeys := make([]bls.PublicKey, 0)
+	blsSignHash := storagetypes.NewSecondarySpSealObjectSignDoc(s.GetChainID(), gvgId, queryHeadObjectResponse.ObjectInfo.Id, storagetypes.GenerateHash(queryHeadObjectResponse.ObjectInfo.Checksums[:])).GetBlsSignHash()
+	// every secondary sp signs the checksums
+	for _, spID := range gvg.SecondarySpIds {
+		sig, err := core.BlsSignAndVerify(s.StorageProviders[spID], blsSignHash)
+		s.Require().NoError(err)
+		secondarySigs = append(secondarySigs, sig)
+		pk, err := bls.PublicKeyFromBytes(s.StorageProviders[spID].BlsKey.PubKey().Bytes())
+		s.Require().NoError(err)
+		secondarySPBlsPubKeys = append(secondarySPBlsPubKeys, pk)
+	}
+	aggBlsSig, err := core.BlsAggregateAndVerify(secondarySPBlsPubKeys, blsSignHash, secondarySigs)
+	s.Require().NoError(err)
+	msgSealObject.SecondarySpBlsAggSignatures = aggBlsSig
+
+	s.T().Logf("msg %s", msgSealObject.String())
+	s.SendTxBlock(sp.SealKey, msgSealObject)
+
+	// UpdateBucketInfo is fine for there is no created object
+	msgUpdateBucketInfo = storagetypes.NewMsgUpdateBucketInfo(
+		user.GetAddr(), bucketName, nil, user.GetAddr(), storagetypes.VISIBILITY_TYPE_PRIVATE)
+	s.Require().NoError(err)
+	s.SendTxBlock(user, msgUpdateBucketInfo)
+	s.Require().NoError(err)
 }

--- a/e2e/tests/storage_test.go
+++ b/e2e/tests/storage_test.go
@@ -11,8 +11,6 @@ import (
 	"testing"
 	"time"
 
-	paymenttypes "github.com/bnb-chain/greenfield/x/payment/types"
-
 	sdkmath "cosmossdk.io/math"
 	ctypes "github.com/cometbft/cometbft/rpc/core/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -30,6 +28,7 @@ import (
 	"github.com/bnb-chain/greenfield/sdk/types"
 	storageutils "github.com/bnb-chain/greenfield/testutil/storage"
 	types2 "github.com/bnb-chain/greenfield/types"
+	paymenttypes "github.com/bnb-chain/greenfield/x/payment/types"
 	sptypes "github.com/bnb-chain/greenfield/x/sp/types"
 	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
 )

--- a/x/payment/keeper/grpc_query_params_by_timestamp.go
+++ b/x/payment/keeper/grpc_query_params_by_timestamp.go
@@ -18,7 +18,7 @@ func (k Keeper) ParamsByTimestamp(c context.Context, req *types.QueryParamsByTim
 
 	ts := req.GetTimestamp()
 	if ts == 0 {
-		ts = ctx.BlockTime().Unix()
+		ts = ctx.BlockTime().Unix() + 1
 	}
 
 	params := k.GetParams(ctx)

--- a/x/payment/keeper/grpc_query_test.go
+++ b/x/payment/keeper/grpc_query_test.go
@@ -41,13 +41,13 @@ func TestParamsByTimestampQuery(t *testing.T) {
 	require.NoError(t, err)
 
 	response, err := keeper.ParamsByTimestamp(ctx, &types.QueryParamsByTimestampRequest{
-		Timestamp: before.Unix(),
+		Timestamp: before.Unix() + 1,
 	})
 	require.NoError(t, err)
 	require.True(t, newReserveTime != response.Params.VersionedParams.ReserveTime)
 
 	response, err = keeper.ParamsByTimestamp(ctx, &types.QueryParamsByTimestampRequest{
-		Timestamp: after.Unix(),
+		Timestamp: after.Unix() + 1,
 	})
 	require.NoError(t, err)
 	require.True(t, newReserveTime == response.Params.VersionedParams.ReserveTime)

--- a/x/payment/keeper/params.go
+++ b/x/payment/keeper/params.go
@@ -53,8 +53,11 @@ func (k Keeper) SetVersionedParamsWithTs(ctx sdk.Context, verParams types.Versio
 func (k Keeper) GetVersionedParamsWithTs(ctx sdk.Context, ts int64) (verParams types.VersionedParams, err error) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.VersionedParamsKeyPrefix)
 
-	// ReverseIterator will exclusive end, so we increment ts by 1
-	startKey := types.VersionedParamsKey(ts + 1)
+	// params are updated in the endblock, so we do not need to make the ts to be included
+	// for example, if the params is updated in 100 timestamp: the txs that are executed in 100 timestamp
+	// will use the old parameter, after 100 timestamp, when we passing 100 to query, we should still get
+	// the old parameter.
+	startKey := types.VersionedParamsKey(ts)
 	iterator := store.ReverseIterator(nil, startKey)
 	defer iterator.Close()
 	if !iterator.Valid() {

--- a/x/payment/types/expected_keepers_mocks.go
+++ b/x/payment/types/expected_keepers_mocks.go
@@ -182,20 +182,6 @@ func (mr *MockBankKeeperMockRecorder) SendCoinsFromModuleToAccount(ctx, senderMo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendCoinsFromModuleToAccount", reflect.TypeOf((*MockBankKeeper)(nil).SendCoinsFromModuleToAccount), ctx, senderModule, recipientAddr, amt)
 }
 
-// SendCoinsFromModuleToModule mocks base method.
-func (m *MockBankKeeper) SendCoinsFromModuleToModule(ctx types.Context, senderModule string, recipientModule string, amt types.Coins) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SendCoinsFromModuleToModule", ctx, senderModule, recipientModule, amt)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SendCoinsFromModuleToModule indicates an expected call of SendCoinsFromModuleToAccount.
-func (mr *MockBankKeeperMockRecorder) SendCoinsFromModuleToModule(ctx, senderModule, recipientModule, amt interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendCoinsFromModuleToAccount", reflect.TypeOf((*MockBankKeeper)(nil).SendCoinsFromModuleToModule), ctx, senderModule, recipientModule, amt)
-}
-
 // SpendableCoins mocks base method.
 func (m *MockBankKeeper) SpendableCoins(ctx types.Context, addr types.AccAddress) types.Coins {
 	m.ctrl.T.Helper()

--- a/x/storage/keeper/abci.go
+++ b/x/storage/keeper/abci.go
@@ -40,7 +40,8 @@ func EndBlocker(ctx sdk.Context, keeper Keeper) {
 
 	// delete buckets
 	doDeleteBucket := true
-	if ctx.BlockHeight() > 5946511 && ctx.ChainID() == "greenfield_5600-1" {
+	// on testnet, we had a hot fix to disable deleting buckets after discontinue since 5946512 height
+	if ctx.BlockHeight() > 5946511 && ctx.ChainID() == upgradetypes.TestnetChainID {
 		doDeleteBucket = false
 	}
 	if ctx.IsUpgraded(upgradetypes.Pawnee) {

--- a/x/storage/keeper/grpc_query.go
+++ b/x/storage/keeper/grpc_query.go
@@ -40,7 +40,7 @@ func (k Keeper) QueryParamsByTimestamp(c context.Context, req *types.QueryParams
 
 	ts := req.GetTimestamp()
 	if ts == 0 {
-		ts = ctx.BlockTime().Unix()
+		ts = ctx.BlockTime().Unix() + 1
 	}
 
 	params := k.GetParams(ctx)

--- a/x/storage/keeper/grpc_query_test.go
+++ b/x/storage/keeper/grpc_query_test.go
@@ -67,13 +67,13 @@ func (s *TestSuite) TestQueryVersionedParams() {
 	err = s.storageKeeper.SetParams(s.ctx, params)
 	s.Require().NoError(err)
 
-	responseT1, err := s.storageKeeper.QueryParamsByTimestamp(s.ctx, &types.QueryParamsByTimestampRequest{Timestamp: blockTimeT1})
+	responseT1, err := s.storageKeeper.QueryParamsByTimestamp(s.ctx, &types.QueryParamsByTimestampRequest{Timestamp: blockTimeT1 + 1})
 	s.Require().NoError(err)
 	s.Require().Equal(&types.QueryParamsByTimestampResponse{Params: paramsT1}, responseT1)
 	getParams := responseT1.GetParams()
 	s.Require().Equal(getParams.GetMaxSegmentSize(), uint64(1))
 
-	responseT2, err := s.storageKeeper.QueryParamsByTimestamp(s.ctx, &types.QueryParamsByTimestampRequest{Timestamp: blockTimeT2})
+	responseT2, err := s.storageKeeper.QueryParamsByTimestamp(s.ctx, &types.QueryParamsByTimestampRequest{Timestamp: blockTimeT2 + 1})
 	s.Require().NoError(err)
 	s.Require().Equal(&types.QueryParamsByTimestampResponse{Params: paramsT2}, responseT2)
 	p := responseT2.GetParams()

--- a/x/storage/keeper/keeper.go
+++ b/x/storage/keeper/keeper.go
@@ -987,6 +987,11 @@ func (k Keeper) DeleteObject(
 		return types.ErrNoSuchObject
 	}
 
+	if objectInfo.ObjectStatus == types.OBJECT_STATUS_DISCONTINUED {
+		return types.ErrInvalidObjectStatus.Wrapf("The object %s is discontined, will be deleted automatically",
+			objectInfo.ObjectName)
+	}
+
 	if objectInfo.SourceType != opts.SourceType {
 		return types.ErrSourceTypeMismatch
 	}

--- a/x/storage/keeper/keeper_object_test.go
+++ b/x/storage/keeper/keeper_object_test.go
@@ -1,6 +1,8 @@
 package keeper_test
 
 import (
+	"time"
+
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/golang/mock/gomock"
@@ -202,6 +204,7 @@ func (s *TestSuite) TestCreateObject() {
 		OutFlowCount:      0,
 		FrozenNetflowRate: math.Int{},
 	}, nil).AnyTimes()
+	s.ctx = s.ctx.WithBlockTime(s.ctx.BlockTime().Add(1 * time.Second))
 	_, err = s.storageKeeper.CreateObject(s.ctx, operatorAddress, bucketInfo.BucketName,
 		objectName, 100, types.CreateObjectOptions{
 			Visibility:     0,

--- a/x/storage/keeper/params.go
+++ b/x/storage/keeper/params.go
@@ -249,8 +249,11 @@ func (k Keeper) SetVersionedParamsWithTs(ctx sdk.Context, verParams types.Versio
 func (k Keeper) GetVersionedParamsWithTs(ctx sdk.Context, ts int64) (verParams types.VersionedParams, err error) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.VersionedParamsKeyPrefix)
 
-	// ReverseIterator will exclusive end, so we increment ts by 1
-	startKey := types.GetParamsKeyWithTimestamp(ts + 1)
+	// params are updated in the endblock, so we do not need to make the ts to be included
+	// for example, if the params is updated in 100 timestamp: the txs that are executed in 100 timestamp
+	// will use the old parameter, after 100 timestamp, when we passing 100 to query, we should still get
+	// the old parameter.
+	startKey := types.GetParamsKeyWithTimestamp(ts)
 	iterator := store.ReverseIterator(nil, startKey)
 	defer iterator.Close()
 	if !iterator.Valid() {

--- a/x/storage/keeper/params_test.go
+++ b/x/storage/keeper/params_test.go
@@ -30,7 +30,7 @@ func GetVersionedParamsWithTimestamp(k *keeper.Keeper, ctx sdk.Context, ts int64
 	return params
 }
 
-func TestMultiVersiontParams(t *testing.T) {
+func TestMultiVersionParams(t *testing.T) {
 	k, ctx := makeKeeper(t)
 	params := types.DefaultParams()
 
@@ -53,8 +53,8 @@ func TestMultiVersiontParams(t *testing.T) {
 
 	require.EqualValues(t, params, k.GetParams(ctx))
 	// default params
-	require.EqualValues(t, GetVersionedParamsWithTimestamp(k, ctx, blockTimeT1).MaxSegmentSize, 1)
-	require.EqualValues(t, GetVersionedParamsWithTimestamp(k, ctx, blockTimeT2).MaxSegmentSize, 2)
-	require.EqualValues(t, GetVersionedParamsWithTimestamp(k, ctx, blockTimeT3).MaxSegmentSize, 3)
+	require.EqualValues(t, GetVersionedParamsWithTimestamp(k, ctx, blockTimeT1+1).MaxSegmentSize, 1)
+	require.EqualValues(t, GetVersionedParamsWithTimestamp(k, ctx, blockTimeT2+1).MaxSegmentSize, 2)
+	require.EqualValues(t, GetVersionedParamsWithTimestamp(k, ctx, blockTimeT3+1).MaxSegmentSize, 3)
 
 }

--- a/x/storage/keeper/payment_test.go
+++ b/x/storage/keeper/payment_test.go
@@ -116,10 +116,11 @@ func (s *TestSuite) TestGetObjectLockFee() {
 		Return(params.VersionedParams, nil).AnyTimes()
 
 	// verify lock fee calculation
+	timeNow := time.Now().Unix() + 1
 	payloadSize := int64(10 * 1024 * 1024)
-	amount, err := s.storageKeeper.GetObjectLockFee(s.ctx, time.Now().Unix(), uint64(payloadSize))
+	amount, err := s.storageKeeper.GetObjectLockFee(s.ctx, timeNow, uint64(payloadSize))
 	s.Require().NoError(err)
-	secondarySPNum := int64(s.storageKeeper.GetExpectSecondarySPNumForECObject(s.ctx, time.Now().Unix()))
+	secondarySPNum := int64(s.storageKeeper.GetExpectSecondarySPNumForECObject(s.ctx, timeNow))
 	spRate := price.PrimaryStorePrice.Add(price.SecondaryStorePrice.MulInt64(secondarySPNum)).MulInt64(payloadSize)
 	validatorTaxRate := params.VersionedParams.ValidatorTaxRate.MulInt(spRate.TruncateInt())
 	expectedAmount := spRate.Add(validatorTaxRate).MulInt64(int64(params.VersionedParams.ReserveTime)).TruncateInt()

--- a/x/storage/types/errors.go
+++ b/x/storage/types/errors.go
@@ -34,6 +34,7 @@ var (
 	ErrUpdateObjectNotAllowed       = errors.Register(ModuleName, 1126, "Object is not allowed to update")
 	ErrObjectIsUpdating             = errors.Register(ModuleName, 1127, "Object is being updated")
 	ErrObjectIsNotUpdating          = errors.Register(ModuleName, 1128, "Object is not being updated")
+	ErrUpdatePaymentAccountFailed   = errors.Register(ModuleName, 1129, "Update payment account failed")
 
 	ErrInvalidCrossChainPackage = errors.Register(ModuleName, 3000, "invalid cross chain package")
 	ErrAlreadyMirrored          = errors.Register(ModuleName, 3001, "resource is already mirrored")

--- a/x/storage/types/expected_keepers_mocks.go
+++ b/x/storage/types/expected_keepers_mocks.go
@@ -834,6 +834,21 @@ func (mr *MockVirtualGroupKeeperMockRecorder) GetGlobalVirtualGroupIfAvailable(c
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGlobalVirtualGroupIfAvailable", reflect.TypeOf((*MockVirtualGroupKeeper)(nil).GetGlobalVirtualGroupIfAvailable), ctx, gvgID, expectedStoreSize)
 }
 
+// GetSwapInInfo mocks base method.
+func (m *MockVirtualGroupKeeper) GetSwapInInfo(ctx types3.Context, familyID, gvgID uint32) (*types2.SwapInInfo, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSwapInInfo", ctx, familyID, gvgID)
+	ret0, _ := ret[0].(*types2.SwapInInfo)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// GetSwapInInfo indicates an expected call of GetSwapInInfo.
+func (mr *MockVirtualGroupKeeperMockRecorder) GetSwapInInfo(ctx, familyID, gvgID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSwapInInfo", reflect.TypeOf((*MockVirtualGroupKeeper)(nil).GetSwapInInfo), ctx, familyID, gvgID)
+}
+
 // SetGVGAndEmitUpdateEvent mocks base method.
 func (m *MockVirtualGroupKeeper) SetGVGAndEmitUpdateEvent(ctx types3.Context, gvg *types2.GlobalVirtualGroup) error {
 	m.ctrl.T.Helper()
@@ -876,49 +891,10 @@ func (mr *MockVirtualGroupKeeperMockRecorder) SettleAndDistributeGVGFamily(ctx, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SettleAndDistributeGVGFamily", reflect.TypeOf((*MockVirtualGroupKeeper)(nil).SettleAndDistributeGVGFamily), ctx, sp, family)
 }
 
-// GetSwapInInfo mocks base method.
-func (m *MockVirtualGroupKeeper) GetSwapInInfo(ctx types3.Context, familyID, gvgID uint32) (*types2.SwapInInfo, bool) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSwapInInfo", ctx, familyID, gvgID)
-	ret0, _ := ret[0].(*types2.SwapInInfo)
-	ret1, _ := ret[1].(bool)
-	return ret0, ret1
-}
-
-// GetSwapInInfo indicates an expected call of GetSwapInInfo.
-func (mr *MockVirtualGroupKeeperMockRecorder) GetSwapInInfo(ctx, familyID, gvgID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSwapInInfo", reflect.TypeOf((*MockVirtualGroupKeeper)(nil).GetSwapInInfo), ctx, familyID, gvgID)
-}
-
 // MockStorageKeeper is a mock of StorageKeeper interface.
 type MockStorageKeeper struct {
 	ctrl     *gomock.Controller
 	recorder *MockStorageKeeperMockRecorder
-}
-
-func (m *MockStorageKeeper) NormalizePrincipal(ctx types3.Context, principal *types0.Principal) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "NormalizePrincipal", ctx, principal)
-}
-
-// NormalizePrincipal indicates an expected call of NormalizePrincipal.
-func (mr *MockStorageKeeperMockRecorder) NormalizePrincipal(ctx types3.Context, principal *types0.Principal) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NormalizePrincipal", reflect.TypeOf((*MockStorageKeeper)(nil).NormalizePrincipal), ctx, principal)
-}
-
-func (m *MockStorageKeeper) ValidatePrincipal(ctx types3.Context, resOwner types3.AccAddress, principal *types0.Principal) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidatePrincipal", ctx, resOwner, principal)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// NormalizePrincipal indicates an expected call of NormalizePrincipal.
-func (mr *MockStorageKeeperMockRecorder) ValidatePrincipal(ctx types3.Context, resOwner types3.AccAddress, principal *types0.Principal) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidatePrincipal", reflect.TypeOf((*MockStorageKeeper)(nil).ValidatePrincipal), ctx, resOwner, principal)
 }
 
 // MockStorageKeeperMockRecorder is the mock recorder for MockStorageKeeper.
@@ -1025,18 +1001,25 @@ func (mr *MockStorageKeeperMockRecorder) GetBucketInfoById(ctx, bucketId interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBucketInfoById", reflect.TypeOf((*MockStorageKeeper)(nil).GetBucketInfoById), ctx, bucketId)
 }
 
-// GetGroupInfoById mocks base method.
-func (m *MockStorageKeeper) GetGroupInfoById(ctx types3.Context, groupId math.Uint) (*GroupInfo, bool) {
+// GetGroupInfo mocks base method.
+func (m *MockStorageKeeper) GetGroupInfo(ctx types3.Context, ownerAddr types3.AccAddress, groupName string) (*GroupInfo, bool) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetGroupInfoById", ctx, groupId)
+	ret := m.ctrl.Call(m, "GetGroupInfo", ctx, ownerAddr, groupName)
 	ret0, _ := ret[0].(*GroupInfo)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
 
-func (m *MockStorageKeeper) GetGroupInfo(ctx types3.Context, ownerAddr types3.AccAddress, groupName string) (*GroupInfo, bool) {
+// GetGroupInfo indicates an expected call of GetGroupInfo.
+func (mr *MockStorageKeeperMockRecorder) GetGroupInfo(ctx, ownerAddr, groupName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroupInfo", reflect.TypeOf((*MockStorageKeeper)(nil).GetGroupInfo), ctx, ownerAddr, groupName)
+}
+
+// GetGroupInfoById mocks base method.
+func (m *MockStorageKeeper) GetGroupInfoById(ctx types3.Context, groupId math.Uint) (*GroupInfo, bool) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetGroupInfo", ctx, ownerAddr, groupName)
+	ret := m.ctrl.Call(m, "GetGroupInfoById", ctx, groupId)
 	ret0, _ := ret[0].(*GroupInfo)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
@@ -1090,6 +1073,18 @@ func (m *MockStorageKeeper) Logger(ctx types3.Context) log.Logger {
 func (mr *MockStorageKeeperMockRecorder) Logger(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Logger", reflect.TypeOf((*MockStorageKeeper)(nil).Logger), ctx)
+}
+
+// NormalizePrincipal mocks base method.
+func (m *MockStorageKeeper) NormalizePrincipal(ctx types3.Context, principal *types0.Principal) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "NormalizePrincipal", ctx, principal)
+}
+
+// NormalizePrincipal indicates an expected call of NormalizePrincipal.
+func (mr *MockStorageKeeperMockRecorder) NormalizePrincipal(ctx, principal interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NormalizePrincipal", reflect.TypeOf((*MockStorageKeeper)(nil).NormalizePrincipal), ctx, principal)
 }
 
 // RenewGroupMember mocks base method.
@@ -1154,4 +1149,18 @@ func (m *MockStorageKeeper) UpdateGroupMember(ctx types3.Context, operator types
 func (mr *MockStorageKeeperMockRecorder) UpdateGroupMember(ctx, operator, groupInfo, opts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateGroupMember", reflect.TypeOf((*MockStorageKeeper)(nil).UpdateGroupMember), ctx, operator, groupInfo, opts)
+}
+
+// ValidatePrincipal mocks base method.
+func (m *MockStorageKeeper) ValidatePrincipal(ctx types3.Context, resOwner types3.AccAddress, principal *types0.Principal) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidatePrincipal", ctx, resOwner, principal)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ValidatePrincipal indicates an expected call of ValidatePrincipal.
+func (mr *MockStorageKeeperMockRecorder) ValidatePrincipal(ctx, resOwner, principal interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidatePrincipal", reflect.TypeOf((*MockStorageKeeper)(nil).ValidatePrincipal), ctx, resOwner, principal)
 }

--- a/x/storage/types/keys.go
+++ b/x/storage/types/keys.go
@@ -40,7 +40,7 @@ var (
 
 	ShadowObjectInfoPrefix = []byte{0x16}
 
-	CreatedObjectCountPrefix = []byte{0x17}
+	LockedObjectCountPrefix = []byte{0x17} // key to track count of created/updating objects, which will involve lock fee
 
 	BucketByIDPrefix = []byte{0x21}
 	ObjectByIDPrefix = []byte{0x22}
@@ -168,7 +168,7 @@ func GetInternalBucketInfoKey(bucketID math.Uint) []byte {
 	return append(InternalBucketInfoPrefix, seq.EncodeSequence(bucketID)...)
 }
 
-func GetCreatedObjectCountKey(bucketId math.Uint) []byte {
+func GetLockedObjectCountKey(bucketId math.Uint) []byte {
 	var seq sequence.Sequence[math.Uint]
-	return append(CreatedObjectCountPrefix, seq.EncodeSequence(bucketId)...)
+	return append(LockedObjectCountPrefix, seq.EncodeSequence(bucketId)...)
 }

--- a/x/storage/types/keys.go
+++ b/x/storage/types/keys.go
@@ -40,6 +40,8 @@ var (
 
 	ShadowObjectInfoPrefix = []byte{0x16}
 
+	CreatedObjectCountPrefix = []byte{0x17}
+
 	BucketByIDPrefix = []byte{0x21}
 	ObjectByIDPrefix = []byte{0x22}
 	GroupByIDPrefix  = []byte{0x23}
@@ -164,4 +166,9 @@ func GetQuotaKey(bucketID math.Uint) []byte {
 func GetInternalBucketInfoKey(bucketID math.Uint) []byte {
 	var seq sequence.Sequence[math.Uint]
 	return append(InternalBucketInfoPrefix, seq.EncodeSequence(bucketID)...)
+}
+
+func GetCreatedObjectCountKey(bucketId math.Uint) []byte {
+	var seq sequence.Sequence[math.Uint]
+	return append(CreatedObjectCountPrefix, seq.EncodeSequence(bucketId)...)
 }

--- a/x/virtualgroup/types/expected_keepers_mocks.go
+++ b/x/virtualgroup/types/expected_keepers_mocks.go
@@ -46,7 +46,7 @@ func (m *MockSpKeeper) DepositDenomForSP(ctx types0.Context) string {
 }
 
 // DepositDenomForSP indicates an expected call of DepositDenomForSP.
-func (mr *MockSpKeeperMockRecorder) DepositDenomForSP(ctx any) *gomock.Call {
+func (mr *MockSpKeeperMockRecorder) DepositDenomForSP(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DepositDenomForSP", reflect.TypeOf((*MockSpKeeper)(nil).DepositDenomForSP), ctx)
 }
@@ -60,9 +60,23 @@ func (m *MockSpKeeper) Exit(ctx types0.Context, sp *types.StorageProvider) error
 }
 
 // Exit indicates an expected call of Exit.
-func (mr *MockSpKeeperMockRecorder) Exit(ctx, sp any) *gomock.Call {
+func (mr *MockSpKeeperMockRecorder) Exit(ctx, sp interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exit", reflect.TypeOf((*MockSpKeeper)(nil).Exit), ctx, sp)
+}
+
+// GetAllStorageProviders mocks base method.
+func (m *MockSpKeeper) GetAllStorageProviders(ctx types0.Context) []types.StorageProvider {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAllStorageProviders", ctx)
+	ret0, _ := ret[0].([]types.StorageProvider)
+	return ret0
+}
+
+// GetAllStorageProviders indicates an expected call of GetAllStorageProviders.
+func (mr *MockSpKeeperMockRecorder) GetAllStorageProviders(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllStorageProviders", reflect.TypeOf((*MockSpKeeper)(nil).GetAllStorageProviders), ctx)
 }
 
 // GetStorageProvider mocks base method.
@@ -75,7 +89,7 @@ func (m *MockSpKeeper) GetStorageProvider(ctx types0.Context, id uint32) (*types
 }
 
 // GetStorageProvider indicates an expected call of GetStorageProvider.
-func (mr *MockSpKeeperMockRecorder) GetStorageProvider(ctx, id any) *gomock.Call {
+func (mr *MockSpKeeperMockRecorder) GetStorageProvider(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorageProvider", reflect.TypeOf((*MockSpKeeper)(nil).GetStorageProvider), ctx, id)
 }
@@ -90,7 +104,7 @@ func (m *MockSpKeeper) GetStorageProviderByFundingAddr(ctx types0.Context, sealA
 }
 
 // GetStorageProviderByFundingAddr indicates an expected call of GetStorageProviderByFundingAddr.
-func (mr *MockSpKeeperMockRecorder) GetStorageProviderByFundingAddr(ctx, sealAddr any) *gomock.Call {
+func (mr *MockSpKeeperMockRecorder) GetStorageProviderByFundingAddr(ctx, sealAddr interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorageProviderByFundingAddr", reflect.TypeOf((*MockSpKeeper)(nil).GetStorageProviderByFundingAddr), ctx, sealAddr)
 }
@@ -105,7 +119,7 @@ func (m *MockSpKeeper) GetStorageProviderByOperatorAddr(ctx types0.Context, addr
 }
 
 // GetStorageProviderByOperatorAddr indicates an expected call of GetStorageProviderByOperatorAddr.
-func (mr *MockSpKeeperMockRecorder) GetStorageProviderByOperatorAddr(ctx, addr any) *gomock.Call {
+func (mr *MockSpKeeperMockRecorder) GetStorageProviderByOperatorAddr(ctx, addr interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorageProviderByOperatorAddr", reflect.TypeOf((*MockSpKeeper)(nil).GetStorageProviderByOperatorAddr), ctx, addr)
 }
@@ -117,23 +131,9 @@ func (m *MockSpKeeper) SetStorageProvider(ctx types0.Context, sp *types.StorageP
 }
 
 // SetStorageProvider indicates an expected call of SetStorageProvider.
-func (mr *MockSpKeeperMockRecorder) SetStorageProvider(ctx, sp any) *gomock.Call {
+func (mr *MockSpKeeperMockRecorder) SetStorageProvider(ctx, sp interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStorageProvider", reflect.TypeOf((*MockSpKeeper)(nil).SetStorageProvider), ctx, sp)
-}
-
-// GetAllStorageProviders mocks base method.
-func (m *MockSpKeeper) GetAllStorageProviders(ctx types0.Context) (sps []types.StorageProvider) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllStorageProviders", ctx)
-	ret0, _ := ret[0].([]types.StorageProvider)
-	return ret0
-}
-
-// GetAllStorageProviders indicates an expected call of GetAllStorageProviders.
-func (mr *MockSpKeeperMockRecorder) GetAllStorageProviders(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllStorageProviders", reflect.TypeOf((*MockSpKeeper)(nil).GetAllStorageProviders), ctx)
 }
 
 // MockAccountKeeper is a mock of AccountKeeper interface.
@@ -168,7 +168,7 @@ func (m *MockAccountKeeper) GetAccount(ctx types0.Context, addr types0.AccAddres
 }
 
 // GetAccount indicates an expected call of GetAccount.
-func (mr *MockAccountKeeperMockRecorder) GetAccount(ctx, addr any) *gomock.Call {
+func (mr *MockAccountKeeperMockRecorder) GetAccount(ctx, addr interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccount", reflect.TypeOf((*MockAccountKeeper)(nil).GetAccount), ctx, addr)
 }
@@ -182,7 +182,7 @@ func (m *MockAccountKeeper) GetModuleAccount(ctx types0.Context, moduleName stri
 }
 
 // GetModuleAccount indicates an expected call of GetModuleAccount.
-func (mr *MockAccountKeeperMockRecorder) GetModuleAccount(ctx, moduleName any) *gomock.Call {
+func (mr *MockAccountKeeperMockRecorder) GetModuleAccount(ctx, moduleName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleAccount", reflect.TypeOf((*MockAccountKeeper)(nil).GetModuleAccount), ctx, moduleName)
 }
@@ -196,7 +196,7 @@ func (m *MockAccountKeeper) GetModuleAddress(name string) types0.AccAddress {
 }
 
 // GetModuleAddress indicates an expected call of GetModuleAddress.
-func (mr *MockAccountKeeperMockRecorder) GetModuleAddress(name any) *gomock.Call {
+func (mr *MockAccountKeeperMockRecorder) GetModuleAddress(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleAddress", reflect.TypeOf((*MockAccountKeeper)(nil).GetModuleAddress), name)
 }
@@ -208,7 +208,7 @@ func (m *MockAccountKeeper) IterateAccounts(ctx types0.Context, process func(typ
 }
 
 // IterateAccounts indicates an expected call of IterateAccounts.
-func (mr *MockAccountKeeperMockRecorder) IterateAccounts(ctx, process any) *gomock.Call {
+func (mr *MockAccountKeeperMockRecorder) IterateAccounts(ctx, process interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IterateAccounts", reflect.TypeOf((*MockAccountKeeper)(nil).IterateAccounts), ctx, process)
 }
@@ -220,7 +220,7 @@ func (m *MockAccountKeeper) SetModuleAccount(arg0 types0.Context, arg1 types1.Mo
 }
 
 // SetModuleAccount indicates an expected call of SetModuleAccount.
-func (mr *MockAccountKeeperMockRecorder) SetModuleAccount(arg0, arg1 any) *gomock.Call {
+func (mr *MockAccountKeeperMockRecorder) SetModuleAccount(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetModuleAccount", reflect.TypeOf((*MockAccountKeeper)(nil).SetModuleAccount), arg0, arg1)
 }
@@ -257,7 +257,7 @@ func (m *MockBankKeeper) GetAllBalances(ctx types0.Context, addr types0.AccAddre
 }
 
 // GetAllBalances indicates an expected call of GetAllBalances.
-func (mr *MockBankKeeperMockRecorder) GetAllBalances(ctx, addr any) *gomock.Call {
+func (mr *MockBankKeeperMockRecorder) GetAllBalances(ctx, addr interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllBalances", reflect.TypeOf((*MockBankKeeper)(nil).GetAllBalances), ctx, addr)
 }
@@ -271,7 +271,7 @@ func (m *MockBankKeeper) GetBalance(ctx types0.Context, addr types0.AccAddress, 
 }
 
 // GetBalance indicates an expected call of GetBalance.
-func (mr *MockBankKeeperMockRecorder) GetBalance(ctx, addr, denom any) *gomock.Call {
+func (mr *MockBankKeeperMockRecorder) GetBalance(ctx, addr, denom interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBalance", reflect.TypeOf((*MockBankKeeper)(nil).GetBalance), ctx, addr, denom)
 }
@@ -285,7 +285,7 @@ func (m *MockBankKeeper) LockedCoins(ctx types0.Context, addr types0.AccAddress)
 }
 
 // LockedCoins indicates an expected call of LockedCoins.
-func (mr *MockBankKeeperMockRecorder) LockedCoins(ctx, addr any) *gomock.Call {
+func (mr *MockBankKeeperMockRecorder) LockedCoins(ctx, addr interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LockedCoins", reflect.TypeOf((*MockBankKeeper)(nil).LockedCoins), ctx, addr)
 }
@@ -299,7 +299,7 @@ func (m *MockBankKeeper) SendCoins(ctx types0.Context, fromAddr, toAddr types0.A
 }
 
 // SendCoins indicates an expected call of SendCoins.
-func (mr *MockBankKeeperMockRecorder) SendCoins(ctx, fromAddr, toAddr, amt any) *gomock.Call {
+func (mr *MockBankKeeperMockRecorder) SendCoins(ctx, fromAddr, toAddr, amt interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendCoins", reflect.TypeOf((*MockBankKeeper)(nil).SendCoins), ctx, fromAddr, toAddr, amt)
 }
@@ -313,7 +313,7 @@ func (m *MockBankKeeper) SendCoinsFromAccountToModule(ctx types0.Context, sender
 }
 
 // SendCoinsFromAccountToModule indicates an expected call of SendCoinsFromAccountToModule.
-func (mr *MockBankKeeperMockRecorder) SendCoinsFromAccountToModule(ctx, senderAddr, recipientModule, amt any) *gomock.Call {
+func (mr *MockBankKeeperMockRecorder) SendCoinsFromAccountToModule(ctx, senderAddr, recipientModule, amt interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendCoinsFromAccountToModule", reflect.TypeOf((*MockBankKeeper)(nil).SendCoinsFromAccountToModule), ctx, senderAddr, recipientModule, amt)
 }
@@ -327,7 +327,7 @@ func (m *MockBankKeeper) SendCoinsFromModuleToAccount(ctx types0.Context, sender
 }
 
 // SendCoinsFromModuleToAccount indicates an expected call of SendCoinsFromModuleToAccount.
-func (mr *MockBankKeeperMockRecorder) SendCoinsFromModuleToAccount(ctx, senderModule, recipientAddr, amt any) *gomock.Call {
+func (mr *MockBankKeeperMockRecorder) SendCoinsFromModuleToAccount(ctx, senderModule, recipientAddr, amt interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendCoinsFromModuleToAccount", reflect.TypeOf((*MockBankKeeper)(nil).SendCoinsFromModuleToAccount), ctx, senderModule, recipientAddr, amt)
 }
@@ -341,7 +341,7 @@ func (m *MockBankKeeper) SpendableCoins(ctx types0.Context, addr types0.AccAddre
 }
 
 // SpendableCoins indicates an expected call of SpendableCoins.
-func (mr *MockBankKeeperMockRecorder) SpendableCoins(ctx, addr any) *gomock.Call {
+func (mr *MockBankKeeperMockRecorder) SpendableCoins(ctx, addr interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SpendableCoins", reflect.TypeOf((*MockBankKeeper)(nil).SpendableCoins), ctx, addr)
 }
@@ -378,7 +378,7 @@ func (m *MockPaymentKeeper) IsEmptyNetFlow(ctx types0.Context, account types0.Ac
 }
 
 // IsEmptyNetFlow indicates an expected call of IsEmptyNetFlow.
-func (mr *MockPaymentKeeperMockRecorder) IsEmptyNetFlow(ctx, account any) *gomock.Call {
+func (mr *MockPaymentKeeperMockRecorder) IsEmptyNetFlow(ctx, account interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsEmptyNetFlow", reflect.TypeOf((*MockPaymentKeeper)(nil).IsEmptyNetFlow), ctx, account)
 }
@@ -393,7 +393,7 @@ func (m *MockPaymentKeeper) QueryDynamicBalance(ctx types0.Context, addr types0.
 }
 
 // QueryDynamicBalance indicates an expected call of QueryDynamicBalance.
-func (mr *MockPaymentKeeperMockRecorder) QueryDynamicBalance(ctx, addr any) *gomock.Call {
+func (mr *MockPaymentKeeperMockRecorder) QueryDynamicBalance(ctx, addr interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryDynamicBalance", reflect.TypeOf((*MockPaymentKeeper)(nil).QueryDynamicBalance), ctx, addr)
 }
@@ -407,7 +407,7 @@ func (m *MockPaymentKeeper) Withdraw(ctx types0.Context, fromAddr, toAddr types0
 }
 
 // Withdraw indicates an expected call of Withdraw.
-func (mr *MockPaymentKeeperMockRecorder) Withdraw(ctx, fromAddr, toAddr, amount any) *gomock.Call {
+func (mr *MockPaymentKeeperMockRecorder) Withdraw(ctx, fromAddr, toAddr, amount interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Withdraw", reflect.TypeOf((*MockPaymentKeeper)(nil).Withdraw), ctx, fromAddr, toAddr, amount)
 }
@@ -444,7 +444,7 @@ func (m *MockStorageKeeper) GetExpectSecondarySPNumForECObject(ctx types0.Contex
 }
 
 // GetExpectSecondarySPNumForECObject indicates an expected call of GetExpectSecondarySPNumForECObject.
-func (mr *MockStorageKeeperMockRecorder) GetExpectSecondarySPNumForECObject(ctx, time any) *gomock.Call {
+func (mr *MockStorageKeeperMockRecorder) GetExpectSecondarySPNumForECObject(ctx, time interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExpectSecondarySPNumForECObject", reflect.TypeOf((*MockStorageKeeper)(nil).GetExpectSecondarySPNumForECObject), ctx, time)
 }


### PR DESCRIPTION
### Description

* When updating the payment address of a bucket, it is required there is no object in created or updating status.
* Fix GetVersionedParameters is not correct issue.
* Do not allow delete discontinued objects for DeleteObject message. (no DiscontinueObject message on testnet/mainnet. This does not happen on testnet/qa, just to make the logic easier, especially after the feature of updating object content).

### Rationale

Bug fix

### Example

NA

### Changes

Notable changes: 
* do not allow update payment account when there are objects in created or updating status


### Potential Impacts
* add potential impacts for other components here
* ...
