### PR TITLE
fix: disallow copy an object is being updated

### DIFF
--- a/x/storage/keeper/keeper.go
+++ b/x/storage/keeper/keeper.go
@@ -795,7 +795,9 @@ func (k Keeper) SealObject(
 	prevCheckSums := objectInfo.Checksums
 
 	isUpdate := objectInfo.IsUpdating
-	if isUpdate {
+
+	// an object might be set to OBJECT_STATUS_DISCONTINUED
+	if isUpdate && objectInfo.ObjectStatus == types.OBJECT_STATUS_SEALED {
 		internalBucketInfo := k.MustGetInternalBucketInfo(ctx, bucketInfo.Id)
 		err := k.UnChargeObjectStoreFee(ctx, bucketInfo, internalBucketInfo, objectInfo)
 		if err != nil {

--- a/x/storage/keeper/keeper.go
+++ b/x/storage/keeper/keeper.go
@@ -1117,6 +1117,10 @@ func (k Keeper) CopyObject(
 		return sdkmath.ZeroUint(), types.ErrSourceTypeMismatch
 	}
 
+	if srcObjectInfo.IsUpdating {
+		return sdkmath.ZeroUint(), types.ErrAccessDenied.Wrapf("the object is being updated, can not be copied")
+	}
+
 	// check permission
 	effect := k.VerifyObjectPermission(ctx, srcBucketInfo, srcObjectInfo, operator, permtypes.ACTION_COPY_OBJECT)
 	if effect != permtypes.EFFECT_ALLOW {


### PR DESCRIPTION
### Description

1. disallow copy an object is being updated
2. an object might be set to OBJECT_STATUS_DISCONTINUED, should not allow sealing on it.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...
