### PR TITLE
release: prepare for v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v1.5.0
+This release introduces the Pawnee upgrade to Testnet and Mainnet
+
+Features:
+* [#564](https://github.com/bnb-chain/greenfield/pull/564) feat: add settlement events
+* [#570](https://github.com/bnb-chain/greenfield/pull/570) feat: atomic object update
+* [#571](https://github.com/bnb-chain/greenfield/pull/571) feat: modify dependency for supporting custom blocks to rollback
+* [#573](https://github.com/bnb-chain/greenfield/pull/573) feat: support delete object in created status
+
+Fix:
+* [#579](https://github.com/bnb-chain/greenfield/pull/579) fix: delete created object by authorized account
+* [#583](https://github.com/bnb-chain/greenfield/pull/583) fix: disable discontinue on testnet
+* [#584](https://github.com/bnb-chain/greenfield/pull/584) fix: disallow update payment address when there are created/updating objects
+* [#586](https://github.com/bnb-chain/greenfield/pull/586) fix: unlock shadow-object balance when a bucket is force deleted
+* [#587](https://github.com/bnb-chain/greenfield/pull/587) fix: disallow copy an object is being updated
+
 ## v1.4.0
 This release introduces the Ural upgrade to the testnet.
 

--- a/go.mod
+++ b/go.mod
@@ -179,7 +179,7 @@ replace (
 	github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v1.2.0
 	github.com/cometbft/cometbft-db => github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v1.4.1-0.20240221065455-ef1f7f0d2659
+	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v1.5.0
 	github.com/cosmos/iavl => github.com/bnb-chain/greenfield-iavl v0.20.1
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	github.com/wercker/journalhook => github.com/wercker/journalhook v0.0.0-20230927020745-64542ffa4117

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,8 @@ github.com/bnb-chain/greenfield-cometbft v1.2.0 h1:LTStppZS9WkVj0TfEYKkk5OAQDGfY
 github.com/bnb-chain/greenfield-cometbft v1.2.0/go.mod h1:WVOEZ59UYM2XePQH47/IQfcInspDn8wbRXhFSJrbU1c=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1 h1:XcWulGacHVRiSCx90Q8Y//ajOrLNBQWR/KDB89dy3cU=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1/go.mod h1:ey1CiK4bYo1RBNJLRiVbYr5CMdSxci9S/AZRINLtppI=
-github.com/bnb-chain/greenfield-cosmos-sdk v1.4.1-0.20240221065455-ef1f7f0d2659 h1:ytOD5CuSsmV9pe9HXXJEsxiDKxHzOYShSG8s21Yw5Xw=
-github.com/bnb-chain/greenfield-cosmos-sdk v1.4.1-0.20240221065455-ef1f7f0d2659/go.mod h1:XF8U3VN1euzLkIR5xiSNyQSnBabvnD86oz6fgdrpteQ=
+github.com/bnb-chain/greenfield-cosmos-sdk v1.5.0 h1:6HjAJpGEIqKmJ24pgkNPhbMKDtRYZQDeOjf0DZhOiA0=
+github.com/bnb-chain/greenfield-cosmos-sdk v1.5.0/go.mod h1:XF8U3VN1euzLkIR5xiSNyQSnBabvnD86oz6fgdrpteQ=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230816082903-b48770f5e210 h1:GHPbV2bC+gmuO6/sG0Tm8oGal3KKSRlyE+zPscDjlA8=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230816082903-b48770f5e210/go.mod h1:vhsZxXE9tYJeYB5JR4hPhd6Pc/uPf7j1T8IJ7p9FdeM=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230816082903-b48770f5e210 h1:FLVOn4+OVbsKi2+YJX5kmD27/4dRu4FW7xCXFhzDO5s=


### PR DESCRIPTION
### Description

The Greenfield Testnet is expected to have a scheduled hardfork upgrade named Pawnee at block height `6623127`. The current block generation speed forecasts this to occur around 2024/03/27 07:00:00 am +UTC

The Greenfield Mainnet is expected to have a scheduled hardfork upgrade named Pawnee at block height `6239520`. The current block generation speed forecasts this to occur around 2024/04/10  07:00:00 am UTC

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...
