### PR TITLE
fix: delete after harkfork

### DIFF
--- a/x/storage/keeper/keeper.go
+++ b/x/storage/keeper/keeper.go
@@ -235,8 +235,9 @@ func (k Keeper) doDeleteBucket(ctx sdk.Context, operator sdk.AccAddress, bucketI
 	store.Delete(types.GetQuotaKey(bucketInfo.Id))
 	store.Delete(types.GetInternalBucketInfoKey(bucketInfo.Id))
 	store.Delete(types.GetMigrationBucketKey(bucketInfo.Id))
-	store.Delete(types.GetLockedObjectCountKey(bucketInfo.Id))
-
+	if ctx.IsUpgraded(upgradetypes.Pawnee) {
+		store.Delete(types.GetLockedObjectCountKey(bucketInfo.Id))
+	}
 	err := k.appendResourceIdForGarbageCollection(ctx, resource.RESOURCE_TYPE_BUCKET, bucketInfo.Id)
 	if err != nil {
 		return err


### PR DESCRIPTION
### Description

the `GetLockedObjectCountKey` will not be enabled until Pawnee upgrade. 

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...
