### PR TITLE
fix: add upgrade check when deleting rate limit status

### DIFF
--- a/x/storage/keeper/keeper.go
+++ b/x/storage/keeper/keeper.go
@@ -6,6 +6,14 @@ import (
 
 	"cosmossdk.io/errors"
 	sdkmath "cosmossdk.io/math"
+	"github.com/cometbft/cometbft/libs/log"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/store/prefix"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	"github.com/cosmos/gogoproto/proto"
+
 	"github.com/bnb-chain/greenfield/internal/sequence"
 	gnfdtypes "github.com/bnb-chain/greenfield/types"
 	types2 "github.com/bnb-chain/greenfield/types"
@@ -18,13 +26,6 @@ import (
 	sptypes "github.com/bnb-chain/greenfield/x/sp/types"
 	"github.com/bnb-chain/greenfield/x/storage/types"
 	virtualgroupmoduletypes "github.com/bnb-chain/greenfield/x/virtualgroup/types"
-	"github.com/cometbft/cometbft/libs/log"
-	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/cosmos/cosmos-sdk/store/prefix"
-	storetypes "github.com/cosmos/cosmos-sdk/store/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
-	"github.com/cosmos/gogoproto/proto"
 )
 
 type (
@@ -269,8 +270,10 @@ func (k Keeper) doDeleteBucket(ctx sdk.Context, operator sdk.AccAddress, bucketI
 		}
 	}
 
-	// delete bucket flow rate limit status
-	k.deleteBucketFlowRateLimitStatus(ctx, bucketInfo.BucketName)
+	if ctx.IsUpgraded(upgradetypes.Serengeti) {
+		// delete bucket flow rate limit status
+		k.deleteBucketFlowRateLimitStatus(ctx, bucketInfo.BucketName)
+	}
 	return nil
 }
 


### PR DESCRIPTION
### Description

This pr will add upgrade check when deleting rate limit status for the bucket.

### Rationale

Add upgrade check when deleting rate limit status.

### Example

NA

### Changes

Notable changes: 
* dd upgrade check when deleting rate limit status

### Potential Impacts

N/A
