### PR TITLE
feat: add `ExecutorApp`

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -733,12 +733,6 @@ func (app *App) initModules(ctx sdk.Context) {
 	app.initBridge()
 	app.initStorage()
 	app.initGov()
-
-	executorApp := storagemodulekeeper.NewExecutorApp(app.StorageKeeper, storagemodulekeeper.NewMsgServerImpl(app.StorageKeeper), paymentmodulekeeper.NewMsgServerImpl(app.PaymentKeeper))
-	err := app.CrossChainKeeper.RegisterChannel(storagemoduletypes.ExecutorChannel, storagemoduletypes.ExecutorChannelId, executorApp)
-	if err != nil {
-		panic(err)
-	}
 }
 
 func (app *App) initCrossChain() {

--- a/app/app.go
+++ b/app/app.go
@@ -733,6 +733,12 @@ func (app *App) initModules(ctx sdk.Context) {
 	app.initBridge()
 	app.initStorage()
 	app.initGov()
+
+	executorApp := storagemodulekeeper.NewExecutorApp(app.StorageKeeper, storagemodulekeeper.NewMsgServerImpl(app.StorageKeeper), paymentmodulekeeper.NewMsgServerImpl(app.PaymentKeeper))
+	err := app.CrossChainKeeper.RegisterChannel(storagemoduletypes.ExecutorChannel, storagemoduletypes.ExecutorChannelId, executorApp)
+	if err != nil {
+		panic(err)
+	}
 }
 
 func (app *App) initCrossChain() {

--- a/app/app.go
+++ b/app/app.go
@@ -704,7 +704,7 @@ func New(
 	}
 
 	if app.IsIavlStore() {
-		//enable diff for reconciliation
+		// enable diff for reconciliation
 		bankIavl, ok := ms.GetCommitStore(keys[banktypes.StoreKey]).(*iavl.Store)
 		if !ok {
 			tmos.Exit("cannot convert bank store to ival store")

--- a/app/upgrade.go
+++ b/app/upgrade.go
@@ -247,11 +247,6 @@ func (app *App) registerErdosUpgradeHandler() {
 	app.UpgradeKeeper.SetUpgradeHandler(upgradetypes.Erdos,
 		func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 			app.Logger().Info("upgrade to ", plan.Name)
-			executorApp := storagemodulekeeper.NewExecutorApp(app.StorageKeeper, storagemodulekeeper.NewMsgServerImpl(app.StorageKeeper), paymentmodulekeeper.NewMsgServerImpl(app.PaymentKeeper))
-			err := app.CrossChainKeeper.RegisterChannel(storagemoduletypes.ExecutorChannel, storagemoduletypes.ExecutorChannelId, executorApp)
-			if err != nil {
-				panic(err)
-			}
 			return app.mm.RunMigrations(ctx, app.configurator, fromVM)
 		})
 

--- a/app/upgrade.go
+++ b/app/upgrade.go
@@ -9,7 +9,9 @@ import (
 
 	bridgemoduletypes "github.com/bnb-chain/greenfield/x/bridge/types"
 	paymentmodule "github.com/bnb-chain/greenfield/x/payment"
+	paymentmodulekeeper "github.com/bnb-chain/greenfield/x/payment/keeper"
 	paymenttypes "github.com/bnb-chain/greenfield/x/payment/types"
+	storagemodulekeeper "github.com/bnb-chain/greenfield/x/storage/keeper"
 	storagemoduletypes "github.com/bnb-chain/greenfield/x/storage/types"
 	virtualgroupmodule "github.com/bnb-chain/greenfield/x/virtualgroup"
 	virtualgrouptypes "github.com/bnb-chain/greenfield/x/virtualgroup/types"
@@ -31,6 +33,7 @@ func (app *App) RegisterUpgradeHandlers(chainID string, serverCfg *serverconfig.
 	app.registerUralUpgradeHandler()
 	app.registerPawneeUpgradeHandler()
 	app.registerSerengetiUpgradeHandler()
+	app.registerErdosUpgradeHandler()
 	// app.register...()
 	// ...
 	return nil
@@ -235,6 +238,32 @@ func (app *App) registerSerengetiUpgradeHandler() {
 	app.UpgradeKeeper.SetUpgradeInitializer(upgradetypes.Serengeti,
 		func() error {
 			app.Logger().Info("Init Serengeti upgrade")
+			return nil
+		})
+}
+
+func (app *App) registerErdosUpgradeHandler() {
+	// Register the upgrade handler
+	app.UpgradeKeeper.SetUpgradeHandler(upgradetypes.Erdos,
+		func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+			app.Logger().Info("upgrade to ", plan.Name)
+			executorApp := storagemodulekeeper.NewExecutorApp(app.StorageKeeper, storagemodulekeeper.NewMsgServerImpl(app.StorageKeeper), paymentmodulekeeper.NewMsgServerImpl(app.PaymentKeeper))
+			err := app.CrossChainKeeper.RegisterChannel(storagemoduletypes.ExecutorChannel, storagemoduletypes.ExecutorChannelId, executorApp)
+			if err != nil {
+				panic(err)
+			}
+			return app.mm.RunMigrations(ctx, app.configurator, fromVM)
+		})
+
+	// Register the upgrade initializer
+	app.UpgradeKeeper.SetUpgradeInitializer(upgradetypes.Erdos,
+		func() error {
+			app.Logger().Info("Init Erdos upgrade")
+			executorApp := storagemodulekeeper.NewExecutorApp(app.StorageKeeper, storagemodulekeeper.NewMsgServerImpl(app.StorageKeeper), paymentmodulekeeper.NewMsgServerImpl(app.PaymentKeeper))
+			err := app.CrossChainKeeper.RegisterChannel(storagemoduletypes.ExecutorChannel, storagemoduletypes.ExecutorChannelId, executorApp)
+			if err != nil {
+				panic(err)
+			}
 			return nil
 		})
 }

--- a/x/storage/keeper/cross_app_executor.go
+++ b/x/storage/keeper/cross_app_executor.go
@@ -1,0 +1,343 @@
+package keeper
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	paymentmoduletypes "github.com/bnb-chain/greenfield/x/payment/types"
+	"github.com/bnb-chain/greenfield/x/storage/types"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var _ sdk.CrossChainApplication = &ExecutorApp{}
+
+type ExecutorApp struct {
+	sKeeper    types.StorageKeeper
+	sMsgServer types.StorageMsgServer
+	pMsgServer types.PaymentMsgServer
+}
+
+func NewExecutorApp(storageKeeper types.StorageKeeper, storageMsgServer types.StorageMsgServer, paymentMsgServer types.PaymentMsgServer) *ExecutorApp {
+	return &ExecutorApp{
+		sKeeper:    storageKeeper,
+		sMsgServer: storageMsgServer,
+		pMsgServer: paymentMsgServer,
+	}
+}
+
+func (app *ExecutorApp) ExecuteSynPackage(ctx sdk.Context, appCtx *sdk.CrossChainAppContext, payload []byte) sdk.ExecuteResult {
+	pack, err := deserializeSynPackage(payload)
+	if err != nil {
+		app.sKeeper.Logger(ctx).Error("deserialize executor syn package error", "payload", hex.EncodeToString(payload), "error", err.Error())
+		panic("deserialize executor syn package error")
+	}
+
+	for i, msgBz := range pack.Msgs {
+		msg, err := deserializeExecutorMsg(msgBz)
+		if err != nil {
+			app.sKeeper.Logger(ctx).Error("deserialize executor msg error", "msg bytes", hex.EncodeToString(msgBz), "error", err.Error())
+			panic("deserialize executor msg error")
+		}
+
+		err = app.msgHandler(ctx, msg)
+		if err != nil {
+			app.sKeeper.Logger(ctx).Debug("executor msg error", "index", i, "data", msgBz, "error", err.Error())
+		}
+	}
+
+	return sdk.ExecuteResult{}
+}
+
+func (app *ExecutorApp) ExecuteAckPackage(ctx sdk.Context, appCtx *sdk.CrossChainAppContext, payload []byte) sdk.ExecuteResult {
+	app.sKeeper.Logger(ctx).Error("received execute ack package ")
+	return sdk.ExecuteResult{}
+}
+
+func (app *ExecutorApp) ExecuteFailAckPackage(ctx sdk.Context, appCtx *sdk.CrossChainAppContext, payload []byte) sdk.ExecuteResult {
+	app.sKeeper.Logger(ctx).Error("received execute fail ack package ")
+	return sdk.ExecuteResult{}
+}
+
+type MsgType uint8
+
+const (
+	MsgTypeCreatePaymentAccount  MsgType = 1
+	MsgTypeDeposit               MsgType = 2
+	MsgTypeDisableRefund         MsgType = 3
+	MsgWithdraw                  MsgType = 4
+	MsgMigrateBucket             MsgType = 5
+	MsgCancelMigrateBucket       MsgType = 6
+	MsgCompleteMigrateBucket     MsgType = 7
+	MsgRejectMigrateBucket       MsgType = 8
+	MsgUpdateBucketInfo          MsgType = 9
+	MsgToggleSPAsDelegatedAgent  MsgType = 10
+	MsgDiscontinueBucket         MsgType = 11
+	MsgSetBucketFlowRateLimit    MsgType = 12
+	MsgCopyObject                MsgType = 13
+	MsgDiscontinueObject         MsgType = 14
+	MsgUpdateObjectInfo          MsgType = 15
+	MsgLeaveGroup                MsgType = 16
+	MsgUpdateGroupExtra          MsgType = 17
+	MsgSetTag                    MsgType = 18
+	MsgCancelUpdateObjectContent MsgType = 19
+)
+
+func (app *ExecutorApp) msgHandler(ctx sdk.Context, msg ExecutorMsgStruct) error {
+	msgSender, err := sdk.AccAddressFromHexUnsafe(msg.Sender.String())
+	if err != nil {
+		return err
+	}
+
+	switch MsgType(msg.Type) {
+	case MsgTypeCreatePaymentAccount:
+		var gnfdMsg paymentmoduletypes.MsgCreatePaymentAccount
+		err = gnfdMsg.Unmarshal(msg.Data)
+		if err != nil {
+			return err
+		}
+		if !gnfdMsg.GetSigners()[0].Equals(msgSender) {
+			return fmt.Errorf("invalid msg sender")
+		}
+		_, err = app.pMsgServer.CreatePaymentAccount(sdk.WrapSDKContext(ctx), &gnfdMsg)
+	case MsgTypeDeposit:
+		var gnfdMsg paymentmoduletypes.MsgDeposit
+		err = gnfdMsg.Unmarshal(msg.Data)
+		if err != nil {
+			return err
+		}
+		if !gnfdMsg.GetSigners()[0].Equals(msgSender) {
+			return fmt.Errorf("invalid msg sender")
+		}
+		_, err = app.pMsgServer.Deposit(sdk.WrapSDKContext(ctx), &gnfdMsg)
+	case MsgTypeDisableRefund:
+		var gnfdMsg paymentmoduletypes.MsgDisableRefund
+		err = gnfdMsg.Unmarshal(msg.Data)
+		if err != nil {
+			return err
+		}
+		if !gnfdMsg.GetSigners()[0].Equals(msgSender) {
+			return fmt.Errorf("invalid msg sender")
+		}
+		_, err = app.pMsgServer.DisableRefund(sdk.WrapSDKContext(ctx), &gnfdMsg)
+	case MsgWithdraw:
+		var gnfdMsg paymentmoduletypes.MsgWithdraw
+		err = gnfdMsg.Unmarshal(msg.Data)
+		if err != nil {
+			return err
+		}
+		if !gnfdMsg.GetSigners()[0].Equals(msgSender) {
+			return fmt.Errorf("invalid msg sender")
+		}
+		_, err = app.pMsgServer.Withdraw(sdk.WrapSDKContext(ctx), &gnfdMsg)
+	case MsgMigrateBucket:
+		var gnfdMsg types.MsgMigrateBucket
+		err = gnfdMsg.Unmarshal(msg.Data)
+		if err != nil {
+			return err
+		}
+		if !gnfdMsg.GetSigners()[0].Equals(msgSender) {
+			return fmt.Errorf("invalid msg sender")
+		}
+		_, err = app.sMsgServer.MigrateBucket(sdk.WrapSDKContext(ctx), &gnfdMsg)
+	case MsgCancelMigrateBucket:
+		var gnfdMsg types.MsgCancelMigrateBucket
+		err = gnfdMsg.Unmarshal(msg.Data)
+		if err != nil {
+			return err
+		}
+		if !gnfdMsg.GetSigners()[0].Equals(msgSender) {
+			return fmt.Errorf("invalid msg sender")
+		}
+		_, err = app.sMsgServer.CancelMigrateBucket(sdk.WrapSDKContext(ctx), &gnfdMsg)
+	case MsgCompleteMigrateBucket:
+		var gnfdMsg types.MsgCompleteMigrateBucket
+		err = gnfdMsg.Unmarshal(msg.Data)
+		if err != nil {
+			return err
+		}
+		if !gnfdMsg.GetSigners()[0].Equals(msgSender) {
+			return fmt.Errorf("invalid msg sender")
+		}
+		_, err = app.sMsgServer.CompleteMigrateBucket(sdk.WrapSDKContext(ctx), &gnfdMsg)
+	case MsgRejectMigrateBucket:
+		var gnfdMsg types.MsgRejectMigrateBucket
+		err = gnfdMsg.Unmarshal(msg.Data)
+		if err != nil {
+			return err
+		}
+		if !gnfdMsg.GetSigners()[0].Equals(msgSender) {
+			return fmt.Errorf("invalid msg sender")
+		}
+		_, err = app.sMsgServer.RejectMigrateBucket(sdk.WrapSDKContext(ctx), &gnfdMsg)
+	case MsgUpdateBucketInfo:
+		var gnfdMsg types.MsgUpdateBucketInfo
+		err = gnfdMsg.Unmarshal(msg.Data)
+		if err != nil {
+			return err
+		}
+		if !gnfdMsg.GetSigners()[0].Equals(msgSender) {
+			return fmt.Errorf("invalid msg sender")
+		}
+		_, err = app.sMsgServer.UpdateBucketInfo(sdk.WrapSDKContext(ctx), &gnfdMsg)
+	case MsgToggleSPAsDelegatedAgent:
+		var gnfdMsg types.MsgToggleSPAsDelegatedAgent
+		err = gnfdMsg.Unmarshal(msg.Data)
+		if err != nil {
+			return err
+		}
+		if !gnfdMsg.GetSigners()[0].Equals(msgSender) {
+			return fmt.Errorf("invalid msg sender")
+		}
+		_, err = app.sMsgServer.ToggleSPAsDelegatedAgent(sdk.WrapSDKContext(ctx), &gnfdMsg)
+	case MsgDiscontinueBucket:
+		var gnfdMsg types.MsgDiscontinueBucket
+		err = gnfdMsg.Unmarshal(msg.Data)
+		if err != nil {
+			return err
+		}
+		if !gnfdMsg.GetSigners()[0].Equals(msgSender) {
+			return fmt.Errorf("invalid msg sender")
+		}
+		_, err = app.sMsgServer.DiscontinueBucket(sdk.WrapSDKContext(ctx), &gnfdMsg)
+	case MsgSetBucketFlowRateLimit:
+		var gnfdMsg types.MsgSetBucketFlowRateLimit
+		err = gnfdMsg.Unmarshal(msg.Data)
+		if err != nil {
+			return err
+		}
+		if !gnfdMsg.GetSigners()[0].Equals(msgSender) {
+			return fmt.Errorf("invalid msg sender")
+		}
+		_, err = app.sMsgServer.SetBucketFlowRateLimit(sdk.WrapSDKContext(ctx), &gnfdMsg)
+	case MsgCopyObject:
+		var gnfdMsg types.MsgCopyObject
+		err = gnfdMsg.Unmarshal(msg.Data)
+		if err != nil {
+			return err
+		}
+		if !gnfdMsg.GetSigners()[0].Equals(msgSender) {
+			return fmt.Errorf("invalid msg sender")
+		}
+		_, err = app.sMsgServer.CopyObject(sdk.WrapSDKContext(ctx), &gnfdMsg)
+	case MsgDiscontinueObject:
+		var gnfdMsg types.MsgDiscontinueObject
+		err = gnfdMsg.Unmarshal(msg.Data)
+		if err != nil {
+			return err
+		}
+		if !gnfdMsg.GetSigners()[0].Equals(msgSender) {
+			return fmt.Errorf("invalid msg sender")
+		}
+		_, err = app.sMsgServer.DiscontinueObject(sdk.WrapSDKContext(ctx), &gnfdMsg)
+	case MsgUpdateObjectInfo:
+		var gnfdMsg types.MsgUpdateObjectInfo
+		err = gnfdMsg.Unmarshal(msg.Data)
+		if err != nil {
+			return err
+		}
+		if !gnfdMsg.GetSigners()[0].Equals(msgSender) {
+			return fmt.Errorf("invalid msg sender")
+		}
+		_, err = app.sMsgServer.UpdateObjectInfo(sdk.WrapSDKContext(ctx), &gnfdMsg)
+	case MsgLeaveGroup:
+		var gnfdMsg types.MsgLeaveGroup
+		err = gnfdMsg.Unmarshal(msg.Data)
+		if err != nil {
+			return err
+		}
+		if !gnfdMsg.GetSigners()[0].Equals(msgSender) {
+			return fmt.Errorf("invalid msg sender")
+		}
+		_, err = app.sMsgServer.LeaveGroup(sdk.WrapSDKContext(ctx), &gnfdMsg)
+	case MsgUpdateGroupExtra:
+		var gnfdMsg types.MsgUpdateGroupExtra
+		err = gnfdMsg.Unmarshal(msg.Data)
+		if err != nil {
+			return err
+		}
+		if !gnfdMsg.GetSigners()[0].Equals(msgSender) {
+			return fmt.Errorf("invalid msg sender")
+		}
+		_, err = app.sMsgServer.UpdateGroupExtra(sdk.WrapSDKContext(ctx), &gnfdMsg)
+	case MsgSetTag:
+		var gnfdMsg types.MsgSetTag
+		err = gnfdMsg.Unmarshal(msg.Data)
+		if err != nil {
+			return err
+		}
+		if !gnfdMsg.GetSigners()[0].Equals(msgSender) {
+			return fmt.Errorf("invalid msg sender")
+		}
+		_, err = app.sMsgServer.SetTag(sdk.WrapSDKContext(ctx), &gnfdMsg)
+	case MsgCancelUpdateObjectContent:
+		var gnfdMsg types.MsgCancelUpdateObjectContent
+		err = gnfdMsg.Unmarshal(msg.Data)
+		if err != nil {
+			return err
+		}
+		if !gnfdMsg.GetSigners()[0].Equals(msgSender) {
+			return fmt.Errorf("invalid msg sender")
+		}
+		_, err = app.sMsgServer.CancelUpdateObjectContent(sdk.WrapSDKContext(ctx), &gnfdMsg)
+	default:
+		err = fmt.Errorf("invalid msg type")
+	}
+	return err
+}
+
+type ExecutorSynPackageStruct struct {
+	Msgs [][]byte
+}
+
+type ExecutorMsgStruct struct {
+	Sender common.Address
+	Type   uint8
+	Data   []byte
+}
+
+var (
+	executorSynPackageStructType, _ = abi.NewType("bytes[]", "", nil)
+
+	executorSynPackageArgs = abi.Arguments{
+		{Type: executorSynPackageStructType},
+	}
+
+	executorMsgStructType, _ = abi.NewType("tuple", "", []abi.ArgumentMarshaling{
+		{Name: "Sender", Type: "address"},
+		{Name: "Type", Type: "uint8"},
+		{Name: "Data", Type: "bytes"},
+	})
+
+	executorMsgArgs = abi.Arguments{
+		{Type: executorMsgStructType},
+	}
+)
+
+func deserializeSynPackage(payload []byte) (ExecutorSynPackageStruct, error) {
+	unpacked, err := executorSynPackageArgs.Unpack(payload)
+	if err != nil {
+		return ExecutorSynPackageStruct{}, err
+	}
+	unpackedStruct := abi.ConvertType(unpacked[0], ExecutorSynPackageStruct{})
+	pkgStruct, ok := unpackedStruct.(ExecutorSynPackageStruct)
+	if !ok {
+		return ExecutorSynPackageStruct{}, err
+	}
+	return pkgStruct, nil
+}
+
+func deserializeExecutorMsg(msgBz []byte) (ExecutorMsgStruct, error) {
+	unpacked, err := executorMsgArgs.Unpack(msgBz)
+	if err != nil {
+		return ExecutorMsgStruct{}, err
+	}
+	unpackedStruct := abi.ConvertType(unpacked[0], ExecutorMsgStruct{})
+	pkgStruct, ok := unpackedStruct.(ExecutorMsgStruct)
+	if !ok {
+		return ExecutorMsgStruct{}, err
+	}
+	return pkgStruct, nil
+}

--- a/x/storage/keeper/cross_app_executor.go
+++ b/x/storage/keeper/cross_app_executor.go
@@ -64,25 +64,19 @@ func (app *ExecutorApp) ExecuteFailAckPackage(ctx sdk.Context, appCtx *sdk.Cross
 type MsgType uint8
 
 const (
-	MsgTypeCreatePaymentAccount  MsgType = 1
-	MsgTypeDeposit               MsgType = 2
-	MsgTypeDisableRefund         MsgType = 3
-	MsgWithdraw                  MsgType = 4
-	MsgMigrateBucket             MsgType = 5
-	MsgCancelMigrateBucket       MsgType = 6
-	MsgCompleteMigrateBucket     MsgType = 7
-	MsgRejectMigrateBucket       MsgType = 8
-	MsgUpdateBucketInfo          MsgType = 9
-	MsgToggleSPAsDelegatedAgent  MsgType = 10
-	MsgDiscontinueBucket         MsgType = 11
-	MsgSetBucketFlowRateLimit    MsgType = 12
-	MsgCopyObject                MsgType = 13
-	MsgDiscontinueObject         MsgType = 14
-	MsgUpdateObjectInfo          MsgType = 15
-	MsgLeaveGroup                MsgType = 16
-	MsgUpdateGroupExtra          MsgType = 17
-	MsgSetTag                    MsgType = 18
-	MsgCancelUpdateObjectContent MsgType = 19
+	MsgTypeCreatePaymentAccount MsgType = 1
+	MsgTypeDeposit              MsgType = 2
+	MsgTypeDisableRefund        MsgType = 3
+	MsgWithdraw                 MsgType = 4
+	MsgMigrateBucket            MsgType = 5
+	MsgCancelMigrateBucket      MsgType = 6
+	MsgUpdateBucketInfo         MsgType = 7
+	MsgToggleSPAsDelegatedAgent MsgType = 8
+	MsgSetBucketFlowRateLimit   MsgType = 9
+	MsgCopyObject               MsgType = 10
+	MsgUpdateObjectInfo         MsgType = 11
+	MsgUpdateGroupExtra         MsgType = 12
+	MsgSetTag                   MsgType = 13
 )
 
 func (app *ExecutorApp) msgHandler(ctx sdk.Context, msg ExecutorMsgStruct) error {
@@ -152,26 +146,6 @@ func (app *ExecutorApp) msgHandler(ctx sdk.Context, msg ExecutorMsgStruct) error
 			return fmt.Errorf("invalid msg sender")
 		}
 		_, err = app.sMsgServer.CancelMigrateBucket(sdk.WrapSDKContext(ctx), &gnfdMsg)
-	case MsgCompleteMigrateBucket:
-		var gnfdMsg types.MsgCompleteMigrateBucket
-		err = gnfdMsg.Unmarshal(msg.Data)
-		if err != nil {
-			return err
-		}
-		if !gnfdMsg.GetSigners()[0].Equals(msgSender) {
-			return fmt.Errorf("invalid msg sender")
-		}
-		_, err = app.sMsgServer.CompleteMigrateBucket(sdk.WrapSDKContext(ctx), &gnfdMsg)
-	case MsgRejectMigrateBucket:
-		var gnfdMsg types.MsgRejectMigrateBucket
-		err = gnfdMsg.Unmarshal(msg.Data)
-		if err != nil {
-			return err
-		}
-		if !gnfdMsg.GetSigners()[0].Equals(msgSender) {
-			return fmt.Errorf("invalid msg sender")
-		}
-		_, err = app.sMsgServer.RejectMigrateBucket(sdk.WrapSDKContext(ctx), &gnfdMsg)
 	case MsgUpdateBucketInfo:
 		var gnfdMsg types.MsgUpdateBucketInfo
 		err = gnfdMsg.Unmarshal(msg.Data)
@@ -192,16 +166,6 @@ func (app *ExecutorApp) msgHandler(ctx sdk.Context, msg ExecutorMsgStruct) error
 			return fmt.Errorf("invalid msg sender")
 		}
 		_, err = app.sMsgServer.ToggleSPAsDelegatedAgent(sdk.WrapSDKContext(ctx), &gnfdMsg)
-	case MsgDiscontinueBucket:
-		var gnfdMsg types.MsgDiscontinueBucket
-		err = gnfdMsg.Unmarshal(msg.Data)
-		if err != nil {
-			return err
-		}
-		if !gnfdMsg.GetSigners()[0].Equals(msgSender) {
-			return fmt.Errorf("invalid msg sender")
-		}
-		_, err = app.sMsgServer.DiscontinueBucket(sdk.WrapSDKContext(ctx), &gnfdMsg)
 	case MsgSetBucketFlowRateLimit:
 		var gnfdMsg types.MsgSetBucketFlowRateLimit
 		err = gnfdMsg.Unmarshal(msg.Data)
@@ -222,16 +186,6 @@ func (app *ExecutorApp) msgHandler(ctx sdk.Context, msg ExecutorMsgStruct) error
 			return fmt.Errorf("invalid msg sender")
 		}
 		_, err = app.sMsgServer.CopyObject(sdk.WrapSDKContext(ctx), &gnfdMsg)
-	case MsgDiscontinueObject:
-		var gnfdMsg types.MsgDiscontinueObject
-		err = gnfdMsg.Unmarshal(msg.Data)
-		if err != nil {
-			return err
-		}
-		if !gnfdMsg.GetSigners()[0].Equals(msgSender) {
-			return fmt.Errorf("invalid msg sender")
-		}
-		_, err = app.sMsgServer.DiscontinueObject(sdk.WrapSDKContext(ctx), &gnfdMsg)
 	case MsgUpdateObjectInfo:
 		var gnfdMsg types.MsgUpdateObjectInfo
 		err = gnfdMsg.Unmarshal(msg.Data)
@@ -242,16 +196,6 @@ func (app *ExecutorApp) msgHandler(ctx sdk.Context, msg ExecutorMsgStruct) error
 			return fmt.Errorf("invalid msg sender")
 		}
 		_, err = app.sMsgServer.UpdateObjectInfo(sdk.WrapSDKContext(ctx), &gnfdMsg)
-	case MsgLeaveGroup:
-		var gnfdMsg types.MsgLeaveGroup
-		err = gnfdMsg.Unmarshal(msg.Data)
-		if err != nil {
-			return err
-		}
-		if !gnfdMsg.GetSigners()[0].Equals(msgSender) {
-			return fmt.Errorf("invalid msg sender")
-		}
-		_, err = app.sMsgServer.LeaveGroup(sdk.WrapSDKContext(ctx), &gnfdMsg)
 	case MsgUpdateGroupExtra:
 		var gnfdMsg types.MsgUpdateGroupExtra
 		err = gnfdMsg.Unmarshal(msg.Data)
@@ -272,16 +216,6 @@ func (app *ExecutorApp) msgHandler(ctx sdk.Context, msg ExecutorMsgStruct) error
 			return fmt.Errorf("invalid msg sender")
 		}
 		_, err = app.sMsgServer.SetTag(sdk.WrapSDKContext(ctx), &gnfdMsg)
-	case MsgCancelUpdateObjectContent:
-		var gnfdMsg types.MsgCancelUpdateObjectContent
-		err = gnfdMsg.Unmarshal(msg.Data)
-		if err != nil {
-			return err
-		}
-		if !gnfdMsg.GetSigners()[0].Equals(msgSender) {
-			return fmt.Errorf("invalid msg sender")
-		}
-		_, err = app.sMsgServer.CancelUpdateObjectContent(sdk.WrapSDKContext(ctx), &gnfdMsg)
 	default:
 		err = fmt.Errorf("invalid msg type")
 	}

--- a/x/storage/keeper/cross_app_executor.go
+++ b/x/storage/keeper/cross_app_executor.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
 
 	paymentmoduletypes "github.com/bnb-chain/greenfield/x/payment/types"
 	"github.com/bnb-chain/greenfield/x/storage/types"
-	"github.com/ethereum/go-ethereum/accounts/abi"
-	"github.com/ethereum/go-ethereum/common"
 )
 
 var _ sdk.CrossChainApplication = &ExecutorApp{}

--- a/x/storage/keeper/cross_app_executor.go
+++ b/x/storage/keeper/cross_app_executor.go
@@ -110,7 +110,7 @@ func (app *ExecutorApp) msgHandler(ctx sdk.Context, msg ExecutorMsg) error {
 		if err != nil {
 			return err
 		}
-		if err = checkSigner(msgSender, &gnfdMsg); err != nil {
+		if err = checkMsg(msgSender, &gnfdMsg); err != nil {
 			return err
 		}
 		_, err = app.pMsgServer.CreatePaymentAccount(sdk.WrapSDKContext(ctx), &gnfdMsg)
@@ -120,7 +120,7 @@ func (app *ExecutorApp) msgHandler(ctx sdk.Context, msg ExecutorMsg) error {
 		if err != nil {
 			return err
 		}
-		if err = checkSigner(msgSender, &gnfdMsg); err != nil {
+		if err = checkMsg(msgSender, &gnfdMsg); err != nil {
 			return err
 		}
 		_, err = app.pMsgServer.Deposit(sdk.WrapSDKContext(ctx), &gnfdMsg)
@@ -130,7 +130,7 @@ func (app *ExecutorApp) msgHandler(ctx sdk.Context, msg ExecutorMsg) error {
 		if err != nil {
 			return err
 		}
-		if err = checkSigner(msgSender, &gnfdMsg); err != nil {
+		if err = checkMsg(msgSender, &gnfdMsg); err != nil {
 			return err
 		}
 		_, err = app.pMsgServer.DisableRefund(sdk.WrapSDKContext(ctx), &gnfdMsg)
@@ -140,7 +140,7 @@ func (app *ExecutorApp) msgHandler(ctx sdk.Context, msg ExecutorMsg) error {
 		if err != nil {
 			return err
 		}
-		if err = checkSigner(msgSender, &gnfdMsg); err != nil {
+		if err = checkMsg(msgSender, &gnfdMsg); err != nil {
 			return err
 		}
 		_, err = app.pMsgServer.Withdraw(sdk.WrapSDKContext(ctx), &gnfdMsg)
@@ -150,7 +150,7 @@ func (app *ExecutorApp) msgHandler(ctx sdk.Context, msg ExecutorMsg) error {
 		if err != nil {
 			return err
 		}
-		if err = checkSigner(msgSender, &gnfdMsg); err != nil {
+		if err = checkMsg(msgSender, &gnfdMsg); err != nil {
 			return err
 		}
 		_, err = app.sMsgServer.MigrateBucket(sdk.WrapSDKContext(ctx), &gnfdMsg)
@@ -160,7 +160,7 @@ func (app *ExecutorApp) msgHandler(ctx sdk.Context, msg ExecutorMsg) error {
 		if err != nil {
 			return err
 		}
-		if err = checkSigner(msgSender, &gnfdMsg); err != nil {
+		if err = checkMsg(msgSender, &gnfdMsg); err != nil {
 			return err
 		}
 		_, err = app.sMsgServer.CancelMigrateBucket(sdk.WrapSDKContext(ctx), &gnfdMsg)
@@ -170,7 +170,7 @@ func (app *ExecutorApp) msgHandler(ctx sdk.Context, msg ExecutorMsg) error {
 		if err != nil {
 			return err
 		}
-		if err = checkSigner(msgSender, &gnfdMsg); err != nil {
+		if err = checkMsg(msgSender, &gnfdMsg); err != nil {
 			return err
 		}
 		_, err = app.sMsgServer.UpdateBucketInfo(sdk.WrapSDKContext(ctx), &gnfdMsg)
@@ -180,7 +180,7 @@ func (app *ExecutorApp) msgHandler(ctx sdk.Context, msg ExecutorMsg) error {
 		if err != nil {
 			return err
 		}
-		if err = checkSigner(msgSender, &gnfdMsg); err != nil {
+		if err = checkMsg(msgSender, &gnfdMsg); err != nil {
 			return err
 		}
 		_, err = app.sMsgServer.ToggleSPAsDelegatedAgent(sdk.WrapSDKContext(ctx), &gnfdMsg)
@@ -190,7 +190,7 @@ func (app *ExecutorApp) msgHandler(ctx sdk.Context, msg ExecutorMsg) error {
 		if err != nil {
 			return err
 		}
-		if err = checkSigner(msgSender, &gnfdMsg); err != nil {
+		if err = checkMsg(msgSender, &gnfdMsg); err != nil {
 			return err
 		}
 		_, err = app.sMsgServer.SetBucketFlowRateLimit(sdk.WrapSDKContext(ctx), &gnfdMsg)
@@ -200,7 +200,7 @@ func (app *ExecutorApp) msgHandler(ctx sdk.Context, msg ExecutorMsg) error {
 		if err != nil {
 			return err
 		}
-		if err = checkSigner(msgSender, &gnfdMsg); err != nil {
+		if err = checkMsg(msgSender, &gnfdMsg); err != nil {
 			return err
 		}
 		_, err = app.sMsgServer.CopyObject(sdk.WrapSDKContext(ctx), &gnfdMsg)
@@ -210,7 +210,7 @@ func (app *ExecutorApp) msgHandler(ctx sdk.Context, msg ExecutorMsg) error {
 		if err != nil {
 			return err
 		}
-		if err = checkSigner(msgSender, &gnfdMsg); err != nil {
+		if err = checkMsg(msgSender, &gnfdMsg); err != nil {
 			return err
 		}
 		_, err = app.sMsgServer.UpdateObjectInfo(sdk.WrapSDKContext(ctx), &gnfdMsg)
@@ -220,7 +220,7 @@ func (app *ExecutorApp) msgHandler(ctx sdk.Context, msg ExecutorMsg) error {
 		if err != nil {
 			return err
 		}
-		if err = checkSigner(msgSender, &gnfdMsg); err != nil {
+		if err = checkMsg(msgSender, &gnfdMsg); err != nil {
 			return err
 		}
 		_, err = app.sMsgServer.UpdateGroupExtra(sdk.WrapSDKContext(ctx), &gnfdMsg)
@@ -230,7 +230,7 @@ func (app *ExecutorApp) msgHandler(ctx sdk.Context, msg ExecutorMsg) error {
 		if err != nil {
 			return err
 		}
-		if err = checkSigner(msgSender, &gnfdMsg); err != nil {
+		if err = checkMsg(msgSender, &gnfdMsg); err != nil {
 			return err
 		}
 		_, err = app.sMsgServer.SetTag(sdk.WrapSDKContext(ctx), &gnfdMsg)
@@ -290,7 +290,10 @@ func abiDecode(typeDef string, encodedBz []byte) ([]interface{}, error) {
 	return outAbi.Unpack("method", encodedBz)
 }
 
-func checkSigner(msgSender sdk.AccAddress, msg sdk.Msg) error {
+func checkMsg(msgSender sdk.AccAddress, msg sdk.Msg) error {
+	if err := msg.ValidateBasic(); err != nil {
+		return err
+	}
 	if len(msg.GetSigners()) != 1 {
 		return fmt.Errorf("invalid signers number")
 	}

--- a/x/storage/keeper/cross_app_executor_test.go
+++ b/x/storage/keeper/cross_app_executor_test.go
@@ -1,0 +1,50 @@
+package keeper_test
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/cosmos/gogoproto/proto"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/bnb-chain/greenfield/testutil/sample"
+	"github.com/bnb-chain/greenfield/x/storage/keeper"
+	"github.com/bnb-chain/greenfield/x/storage/types"
+)
+
+func TestDecodeMsg(t *testing.T) {
+	operator := sample.RandAccAddress()
+	bucketName := string(sample.RandStr(10))
+	msg := types.NewMsgMigrateBucket(operator, bucketName, rand.Uint32())
+	msgBz, err := proto.Marshal(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var gnfdMsg types.MsgMigrateBucket
+	err = gnfdMsg.Unmarshal(msgBz)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, msg.Operator, gnfdMsg.Operator)
+	assert.Equal(t, msg.BucketName, gnfdMsg.BucketName)
+	assert.Equal(t, msg.DstPrimarySpId, gnfdMsg.DstPrimarySpId)
+}
+
+func TestDecodeSynPackage(t *testing.T) {
+	payloadStr := "00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000bfd66d9636253f11ae43f3428e8df73b5ad6950f00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000002c0a2a3078663339466436653531616164383846364634636536614238383237323739636666466239323236360000000000000000000000000000000000000000"
+	payloadBz, _ := hex.DecodeString(payloadStr)
+	pack, err := keeper.DeserializeSynPackage(payloadBz)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msg, err := keeper.DeserializeExecutorMsg(pack[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Println(msg)
+}

--- a/x/storage/types/crosschain.go
+++ b/x/storage/types/crosschain.go
@@ -18,11 +18,13 @@ const (
 	ObjectChannel     = "object"
 	GroupChannel      = "group"
 	PermissionChannel = "permission"
+	ExecutorChannel   = "executor"
 
 	BucketChannelId     sdk.ChannelID = 4
 	ObjectChannelId     sdk.ChannelID = 5
 	GroupChannelId      sdk.ChannelID = 6
 	PermissionChannelId sdk.ChannelID = 7
+	ExecutorChannelId   sdk.ChannelID = 9
 
 	// bucket operation types
 
@@ -1278,13 +1280,13 @@ func (p UpdateGroupMemberSynPackage) ValidateBasic() error {
 func DeserializeUpdateGroupMemberSynPackage(serializedPackage []byte) (interface{}, error) {
 	unpacked, err := updateGroupMemberSynPackageArgs.Unpack(serializedPackage)
 	if err != nil {
-		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "deserialize update group member sun package failed")
+		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "deserialize update group member syn package failed")
 	}
 
 	unpackedStruct := abi.ConvertType(unpacked[0], UpdateGroupMemberSynPackageStruct{})
 	pkgStruct, ok := unpackedStruct.(UpdateGroupMemberSynPackageStruct)
 	if !ok {
-		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "reflect update group member sun package failed")
+		return nil, errors.Wrapf(ErrInvalidCrossChainPackage, "reflect update group member syn package failed")
 	}
 
 	totalMember := len(pkgStruct.Members)

--- a/x/storage/types/expected_keepers.go
+++ b/x/storage/types/expected_keepers.go
@@ -135,46 +135,13 @@ type PaymentMsgServer interface {
 }
 
 type StorageMsgServer interface {
-	// basic operation of bucket
-	CreateBucket(context.Context, *MsgCreateBucket) (*MsgCreateBucketResponse, error)
-	DeleteBucket(context.Context, *MsgDeleteBucket) (*MsgDeleteBucketResponse, error)
 	UpdateBucketInfo(context.Context, *MsgUpdateBucketInfo) (*MsgUpdateBucketInfoResponse, error)
-	MirrorBucket(context.Context, *MsgMirrorBucket) (*MsgMirrorBucketResponse, error)
-	DiscontinueBucket(context.Context, *MsgDiscontinueBucket) (*MsgDiscontinueBucketResponse, error)
 	ToggleSPAsDelegatedAgent(context.Context, *MsgToggleSPAsDelegatedAgent) (*MsgToggleSPAsDelegatedAgentResponse, error)
-	// basic operation of object
-	CreateObject(context.Context, *MsgCreateObject) (*MsgCreateObjectResponse, error)
-	SealObject(context.Context, *MsgSealObject) (*MsgSealObjectResponse, error)
-	SealObjectV2(context.Context, *MsgSealObjectV2) (*MsgSealObjectV2Response, error)
-	RejectSealObject(context.Context, *MsgRejectSealObject) (*MsgRejectSealObjectResponse, error)
 	CopyObject(context.Context, *MsgCopyObject) (*MsgCopyObjectResponse, error)
-	DeleteObject(context.Context, *MsgDeleteObject) (*MsgDeleteObjectResponse, error)
-	CancelCreateObject(context.Context, *MsgCancelCreateObject) (*MsgCancelCreateObjectResponse, error)
-	MirrorObject(context.Context, *MsgMirrorObject) (*MsgMirrorObjectResponse, error)
-	DiscontinueObject(context.Context, *MsgDiscontinueObject) (*MsgDiscontinueObjectResponse, error)
 	UpdateObjectInfo(context.Context, *MsgUpdateObjectInfo) (*MsgUpdateObjectInfoResponse, error)
-	UpdateObjectContent(context.Context, *MsgUpdateObjectContent) (*MsgUpdateObjectContentResponse, error)
-	CancelUpdateObjectContent(context.Context, *MsgCancelUpdateObjectContent) (*MsgCancelUpdateObjectContentResponse, error)
-	DelegateCreateObject(context.Context, *MsgDelegateCreateObject) (*MsgDelegateCreateObjectResponse, error)
-	DelegateUpdateObjectContent(context.Context, *MsgDelegateUpdateObjectContent) (*MsgDelegateUpdateObjectContentResponse, error)
-	// basic operation of group
-	CreateGroup(context.Context, *MsgCreateGroup) (*MsgCreateGroupResponse, error)
-	DeleteGroup(context.Context, *MsgDeleteGroup) (*MsgDeleteGroupResponse, error)
-	UpdateGroupMember(context.Context, *MsgUpdateGroupMember) (*MsgUpdateGroupMemberResponse, error)
 	UpdateGroupExtra(context.Context, *MsgUpdateGroupExtra) (*MsgUpdateGroupExtraResponse, error)
-	LeaveGroup(context.Context, *MsgLeaveGroup) (*MsgLeaveGroupResponse, error)
-	MirrorGroup(context.Context, *MsgMirrorGroup) (*MsgMirrorGroupResponse, error)
-	RenewGroupMember(context.Context, *MsgRenewGroupMember) (*MsgRenewGroupMemberResponse, error)
-	// basic operation of policy
-	PutPolicy(context.Context, *MsgPutPolicy) (*MsgPutPolicyResponse, error)
-	DeletePolicy(context.Context, *MsgDeletePolicy) (*MsgDeletePolicyResponse, error)
-	// Since: cosmos-sdk 0.47
-	UpdateParams(context.Context, *MsgUpdateParams) (*MsgUpdateParamsResponse, error)
 	MigrateBucket(context.Context, *MsgMigrateBucket) (*MsgMigrateBucketResponse, error)
-	CompleteMigrateBucket(context.Context, *MsgCompleteMigrateBucket) (*MsgCompleteMigrateBucketResponse, error)
 	CancelMigrateBucket(context.Context, *MsgCancelMigrateBucket) (*MsgCancelMigrateBucketResponse, error)
-	RejectMigrateBucket(context.Context, *MsgRejectMigrateBucket) (*MsgRejectMigrateBucketResponse, error)
-	// Since: Manchurian upgrade
 	SetTag(context.Context, *MsgSetTag) (*MsgSetTagResponse, error)
 	SetBucketFlowRateLimit(context.Context, *MsgSetBucketFlowRateLimit) (*MsgSetBucketFlowRateLimitResponse, error)
 }

--- a/x/storage/types/expected_keepers.go
+++ b/x/storage/types/expected_keepers.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"context"
 	"math/big"
 	time "time"
 
@@ -15,7 +16,6 @@ import (
 	permtypes "github.com/bnb-chain/greenfield/x/permission/types"
 	sptypes "github.com/bnb-chain/greenfield/x/sp/types"
 	"github.com/bnb-chain/greenfield/x/virtualgroup/types"
-	"context"
 )
 
 // AccountKeeper defines the expected account keeper used for simulations (noalias)

--- a/x/storage/types/expected_keepers.go
+++ b/x/storage/types/expected_keepers.go
@@ -15,6 +15,7 @@ import (
 	permtypes "github.com/bnb-chain/greenfield/x/permission/types"
 	sptypes "github.com/bnb-chain/greenfield/x/sp/types"
 	"github.com/bnb-chain/greenfield/x/virtualgroup/types"
+	"context"
 )
 
 // AccountKeeper defines the expected account keeper used for simulations (noalias)
@@ -124,4 +125,56 @@ type StorageKeeper interface {
 
 	NormalizePrincipal(ctx sdk.Context, principal *permtypes.Principal)
 	ValidatePrincipal(ctx sdk.Context, resOwner sdk.AccAddress, principal *permtypes.Principal) error
+}
+
+type PaymentMsgServer interface {
+	CreatePaymentAccount(context.Context, *paymenttypes.MsgCreatePaymentAccount) (*paymenttypes.MsgCreatePaymentAccountResponse, error)
+	Deposit(context.Context, *paymenttypes.MsgDeposit) (*paymenttypes.MsgDepositResponse, error)
+	Withdraw(context.Context, *paymenttypes.MsgWithdraw) (*paymenttypes.MsgWithdrawResponse, error)
+	DisableRefund(context.Context, *paymenttypes.MsgDisableRefund) (*paymenttypes.MsgDisableRefundResponse, error)
+}
+
+type StorageMsgServer interface {
+	// basic operation of bucket
+	CreateBucket(context.Context, *MsgCreateBucket) (*MsgCreateBucketResponse, error)
+	DeleteBucket(context.Context, *MsgDeleteBucket) (*MsgDeleteBucketResponse, error)
+	UpdateBucketInfo(context.Context, *MsgUpdateBucketInfo) (*MsgUpdateBucketInfoResponse, error)
+	MirrorBucket(context.Context, *MsgMirrorBucket) (*MsgMirrorBucketResponse, error)
+	DiscontinueBucket(context.Context, *MsgDiscontinueBucket) (*MsgDiscontinueBucketResponse, error)
+	ToggleSPAsDelegatedAgent(context.Context, *MsgToggleSPAsDelegatedAgent) (*MsgToggleSPAsDelegatedAgentResponse, error)
+	// basic operation of object
+	CreateObject(context.Context, *MsgCreateObject) (*MsgCreateObjectResponse, error)
+	SealObject(context.Context, *MsgSealObject) (*MsgSealObjectResponse, error)
+	SealObjectV2(context.Context, *MsgSealObjectV2) (*MsgSealObjectV2Response, error)
+	RejectSealObject(context.Context, *MsgRejectSealObject) (*MsgRejectSealObjectResponse, error)
+	CopyObject(context.Context, *MsgCopyObject) (*MsgCopyObjectResponse, error)
+	DeleteObject(context.Context, *MsgDeleteObject) (*MsgDeleteObjectResponse, error)
+	CancelCreateObject(context.Context, *MsgCancelCreateObject) (*MsgCancelCreateObjectResponse, error)
+	MirrorObject(context.Context, *MsgMirrorObject) (*MsgMirrorObjectResponse, error)
+	DiscontinueObject(context.Context, *MsgDiscontinueObject) (*MsgDiscontinueObjectResponse, error)
+	UpdateObjectInfo(context.Context, *MsgUpdateObjectInfo) (*MsgUpdateObjectInfoResponse, error)
+	UpdateObjectContent(context.Context, *MsgUpdateObjectContent) (*MsgUpdateObjectContentResponse, error)
+	CancelUpdateObjectContent(context.Context, *MsgCancelUpdateObjectContent) (*MsgCancelUpdateObjectContentResponse, error)
+	DelegateCreateObject(context.Context, *MsgDelegateCreateObject) (*MsgDelegateCreateObjectResponse, error)
+	DelegateUpdateObjectContent(context.Context, *MsgDelegateUpdateObjectContent) (*MsgDelegateUpdateObjectContentResponse, error)
+	// basic operation of group
+	CreateGroup(context.Context, *MsgCreateGroup) (*MsgCreateGroupResponse, error)
+	DeleteGroup(context.Context, *MsgDeleteGroup) (*MsgDeleteGroupResponse, error)
+	UpdateGroupMember(context.Context, *MsgUpdateGroupMember) (*MsgUpdateGroupMemberResponse, error)
+	UpdateGroupExtra(context.Context, *MsgUpdateGroupExtra) (*MsgUpdateGroupExtraResponse, error)
+	LeaveGroup(context.Context, *MsgLeaveGroup) (*MsgLeaveGroupResponse, error)
+	MirrorGroup(context.Context, *MsgMirrorGroup) (*MsgMirrorGroupResponse, error)
+	RenewGroupMember(context.Context, *MsgRenewGroupMember) (*MsgRenewGroupMemberResponse, error)
+	// basic operation of policy
+	PutPolicy(context.Context, *MsgPutPolicy) (*MsgPutPolicyResponse, error)
+	DeletePolicy(context.Context, *MsgDeletePolicy) (*MsgDeletePolicyResponse, error)
+	// Since: cosmos-sdk 0.47
+	UpdateParams(context.Context, *MsgUpdateParams) (*MsgUpdateParamsResponse, error)
+	MigrateBucket(context.Context, *MsgMigrateBucket) (*MsgMigrateBucketResponse, error)
+	CompleteMigrateBucket(context.Context, *MsgCompleteMigrateBucket) (*MsgCompleteMigrateBucketResponse, error)
+	CancelMigrateBucket(context.Context, *MsgCancelMigrateBucket) (*MsgCancelMigrateBucketResponse, error)
+	RejectMigrateBucket(context.Context, *MsgRejectMigrateBucket) (*MsgRejectMigrateBucketResponse, error)
+	// Since: Manchurian upgrade
+	SetTag(context.Context, *MsgSetTag) (*MsgSetTagResponse, error)
+	SetBucketFlowRateLimit(context.Context, *MsgSetBucketFlowRateLimit) (*MsgSetBucketFlowRateLimitResponse, error)
 }


### PR DESCRIPTION
### Description

This pr is to add a new crossApp `ExecutorApp` which is used for executing msg from BSC. 

For more information, please refer to [BEP363](https://github.com/bnb-chain/BEPs/pull/363).

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add new cross chain channel `ExecutorChannel` and corresponding cross app `ExecutorApp`
