### PR TITLE
fix: fix uncharge issue when deleting objects

### DIFF
--- a/e2e/tests/storage_rate_limit_test.go
+++ b/e2e/tests/storage_rate_limit_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/prysmaticlabs/prysm/crypto/bls"
 
 	"github.com/bnb-chain/greenfield/e2e/core"
-
 	storageutils "github.com/bnb-chain/greenfield/testutil/storage"
 	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
 )

--- a/x/storage/keeper/payment.go
+++ b/x/storage/keeper/payment.go
@@ -278,6 +278,13 @@ func (k Keeper) ChargeObjectStoreFee(ctx sdk.Context, primarySpId uint32, bucket
 
 func (k Keeper) UnChargeObjectStoreFee(ctx sdk.Context, bucketInfo *storagetypes.BucketInfo,
 	internalBucketInfo *storagetypes.InternalBucketInfo, objectInfo *storagetypes.ObjectInfo) error {
+	if ctx.IsUpgraded(upgradetypes.Serengeti) {
+		// if the bucket's flow rate limit is set to zero, no need to uncharge, since the bucket is already uncharged
+		if k.IsBucketRateLimited(ctx, bucketInfo.BucketName) {
+			return nil
+		}
+	}
+
 	chargeSize, err := k.GetObjectChargeSize(ctx, objectInfo.PayloadSize, objectInfo.GetLatestUpdatedTime())
 	if err != nil {
 		return fmt.Errorf("get charge size failed: %s %s %w", bucketInfo.BucketName, objectInfo.ObjectName, err)


### PR DESCRIPTION
### Description

This pr will fix the issue when deleting objects.

When we set flow rate limit for a bucket, if the flow rate limit is less than the current flow rate of the bucket, the bucket will be uncharged. We should not uncharge object store fee if the bucket is rate limited since the bucket is already uncharged.

### Rationale

Fix the issue deleting objects.

### Example

n/a

### Changes

Notable changes: 
* don't uncharge object when the bucket is rate-limited.

### Potential Impacts

n/a

