### PR TITLE
release: prepare for v1.7.0 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## V1.7.0
+This release introduces the Erdos upgrade.
+
+Features:
+* [#595](https://github.com/bnb-chain/greenfield/pull/595) feat: add ExecutorApp
+* [#582](https://github.com/bnb-chain/greenfield/pull/595) feat: implement paymaster
+
+Fixes:
+* [#601](https://github.com/bnb-chain/greenfield/pull/601) fix: fix uncharge issue when force-deleting objects
+
+Chore:
+* [#597](https://github.com/bnb-chain/greenfield/pull/597) chore: upgrade deps for fixing vulnerabilities
+
 ## V1.6.0
 This release introduces the Serengeti upgrade.
 

--- a/go.mod
+++ b/go.mod
@@ -173,10 +173,10 @@ replace (
 	cosmossdk.io/api => github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230816082903-b48770f5e210
 	cosmossdk.io/math => github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230816082903-b48770f5e210
 	github.com/btcsuite/btcd => github.com/btcsuite/btcd v0.23.0
-	github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v1.2.1-0.20240423054022-904c57ecf3ff
+	github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v1.3.0
 	github.com/cometbft/cometbft-db => github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v1.6.1-0.20240424024349-50ec153bb41a
+	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v1.7.0
 	github.com/cosmos/iavl => github.com/bnb-chain/greenfield-iavl v0.20.1
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	github.com/wercker/journalhook => github.com/wercker/journalhook v0.0.0-20230927020745-64542ffa4117

--- a/go.sum
+++ b/go.sum
@@ -159,12 +159,12 @@ github.com/bgentry/speakeasy v0.1.1-0.20220910012023-760eaf8b6816/go.mod h1:+zsy
 github.com/bits-and-blooms/bitset v1.10.0 h1:ePXTeiPEazB5+opbv5fr8umg2R/1NlzgDsyepwsSr88=
 github.com/bits-and-blooms/bitset v1.10.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
-github.com/bnb-chain/greenfield-cometbft v1.2.1-0.20240423054022-904c57ecf3ff h1:ClDnN5TePzIrgpAAyZs6diPCXu1NqCeh93B8FtypQdg=
-github.com/bnb-chain/greenfield-cometbft v1.2.1-0.20240423054022-904c57ecf3ff/go.mod h1:0D+VPivZTeBldjtGGi9LKbBnKEO/RtMRJikie92LkYI=
+github.com/bnb-chain/greenfield-cometbft v1.3.0 h1:v3nZ16ledTZGF5Csys7fTQGZcEV78ZLUtptA9PLKMo4=
+github.com/bnb-chain/greenfield-cometbft v1.3.0/go.mod h1:0D+VPivZTeBldjtGGi9LKbBnKEO/RtMRJikie92LkYI=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1 h1:XcWulGacHVRiSCx90Q8Y//ajOrLNBQWR/KDB89dy3cU=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1/go.mod h1:ey1CiK4bYo1RBNJLRiVbYr5CMdSxci9S/AZRINLtppI=
-github.com/bnb-chain/greenfield-cosmos-sdk v1.6.1-0.20240424024349-50ec153bb41a h1:GQ23mAZlwZppluAmW6Y1yALs0u/80xwWevEqjJKT83c=
-github.com/bnb-chain/greenfield-cosmos-sdk v1.6.1-0.20240424024349-50ec153bb41a/go.mod h1:dufx01AXi/P7/0zDLllXA4uMNZ2bkTxBVDzuYDoz3zY=
+github.com/bnb-chain/greenfield-cosmos-sdk v1.7.0 h1:4wr+w9BMTU/S2LZd4J/Gc5v4H9Z1JTpJxno09g1nekY=
+github.com/bnb-chain/greenfield-cosmos-sdk v1.7.0/go.mod h1:2bwmwdXYBISnQoMwgAcZTVGt21lMsHZSeeeMByTvDlQ=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230816082903-b48770f5e210 h1:GHPbV2bC+gmuO6/sG0Tm8oGal3KKSRlyE+zPscDjlA8=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230816082903-b48770f5e210/go.mod h1:vhsZxXE9tYJeYB5JR4hPhd6Pc/uPf7j1T8IJ7p9FdeM=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230816082903-b48770f5e210 h1:FLVOn4+OVbsKi2+YJX5kmD27/4dRu4FW7xCXFhzDO5s=


### PR DESCRIPTION
### Description

The Greenfield Testnet is expected to have a scheduled hardfork upgrade named Erdos at block height 8086093. The current block generation speed forecasts this to occur around 2024/05/10 07:00:00 am +UTC

The Greenfield Mainnet is expected to have a scheduled hardfork upgrade named Erdos at block height 7627845. The current block generation speed forecasts this to occur around 2024/05/22  07:00:00 am UTC

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...
