### PR TITLE
fix: principal value supports group name

### DIFF
--- a/proto/greenfield/permission/common.proto
+++ b/proto/greenfield/permission/common.proto
@@ -79,6 +79,8 @@ enum PrincipalType {
 message Principal {
   PrincipalType type = 1;
   // When the type is an account, its value is sdk.AccAddress().String();
-  // when the type is a group, its value is math.Uint().String()
+  // When the type is a group, its value can be in one of two formats:
+  // 1. group id
+  // 2. grn:g:ownerAddress:groupName
   string value = 2;
 }

--- a/x/permission/types/common.pb.go
+++ b/x/permission/types/common.pb.go
@@ -246,7 +246,9 @@ func (m *Statement) GetLimitSize() *common.UInt64Value {
 type Principal struct {
 	Type PrincipalType `protobuf:"varint,1,opt,name=type,proto3,enum=greenfield.permission.PrincipalType" json:"type,omitempty"`
 	// When the type is an account, its value is sdk.AccAddress().String();
-	// when the type is a group, its value is math.Uint().String()
+	// When the type is a group, its value can be in one of two formats:
+	// 1. group id
+	// 2. grn:g:ownerAddress:groupName
 	Value string `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
 }
 


### PR DESCRIPTION
### Description

fix: principal value supports group name

### Rationale

The user discovered that the current cross-chain process does not support creating a group and binding it to a bucket/object through a multi-message in a single transaction. This is because they believed that the principal value only supports a group ID, not a group name.

However, this is actually supported, but it requires a specific naming convention to be followed. The format should be: `grn:g:ownerAddress:groupName`. We will update the corresponding principal value comment to support group names, to prevent any misunderstanding by developers in the future.

### Example

Go-SDK
<img width="858" alt="image" src="https://github.com/bnb-chain/greenfield/assets/122767193/18b86883-90fc-4d74-91a1-b7f6e33204b0">

BSC Testnet transaction
https://testnet.bscscan.com/tx/0xc983b0ef02796a9e0b6f3a7eb13fc2fbfe22895ba17fbd8a54f7becff8b2d183

Greenfield 
![image](https://github.com/bnb-chain/greenfield/assets/122767193/ba20593d-2d05-48fb-9c46-e68c6f844a02)
![image](https://github.com/bnb-chain/greenfield/assets/122767193/8ba23396-fd98-4e0e-80bc-60f89318cd94)


### Changes

Notable changes: 
* fix: principal value supports group name


### Potential Impacts
N/A