### PR TITLE
release: prepare for v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## V1.8.0
+This release introduces the Veld upgrade.
+
+Fixes:
+* [#621](https://github.com/bnb-chain/greenfield/pull/621) fix: add bucket status to bucket migration related events
+* [#625](https://github.com/bnb-chain/greenfield/pull/625) fix: discontinued bucket can't be migrated
+* [#626](https://github.com/bnb-chain/greenfield/pull/626) fix: principal value supports group name
+* [#632](https://github.com/bnb-chain/greenfield/pull/632) fix: ingore register channel error
+
+Chore:
+* [#619](https://github.com/bnb-chain/greenfield/pull/619) docs: move greenfield cmd/module/api docs from docs.bnbchain.org to greenfield repo
+
 ## V1.7.0
 This release introduces the Erdos upgrade.
 

--- a/go.mod
+++ b/go.mod
@@ -176,7 +176,7 @@ replace (
 	github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v1.3.0
 	github.com/cometbft/cometbft-db => github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v1.7.3-0.20240527082454-48d116d99ca4
+	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v1.8.0
 	github.com/cosmos/iavl => github.com/bnb-chain/greenfield-iavl v0.20.1
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	github.com/wercker/journalhook => github.com/wercker/journalhook v0.0.0-20230927020745-64542ffa4117

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,8 @@ github.com/bnb-chain/greenfield-cometbft v1.3.0 h1:v3nZ16ledTZGF5Csys7fTQGZcEV78
 github.com/bnb-chain/greenfield-cometbft v1.3.0/go.mod h1:0D+VPivZTeBldjtGGi9LKbBnKEO/RtMRJikie92LkYI=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1 h1:XcWulGacHVRiSCx90Q8Y//ajOrLNBQWR/KDB89dy3cU=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1/go.mod h1:ey1CiK4bYo1RBNJLRiVbYr5CMdSxci9S/AZRINLtppI=
-github.com/bnb-chain/greenfield-cosmos-sdk v1.7.3-0.20240527082454-48d116d99ca4 h1:0UFOOdVKbiIEfKkL15NJ/VtE6TSdlwM4HtJJuukJfio=
-github.com/bnb-chain/greenfield-cosmos-sdk v1.7.3-0.20240527082454-48d116d99ca4/go.mod h1:2bwmwdXYBISnQoMwgAcZTVGt21lMsHZSeeeMByTvDlQ=
+github.com/bnb-chain/greenfield-cosmos-sdk v1.8.0 h1:XaHBYnlAJNIEVTr9dXp3jzw12gCoIEL5jHiAMp+PX0s=
+github.com/bnb-chain/greenfield-cosmos-sdk v1.8.0/go.mod h1:2bwmwdXYBISnQoMwgAcZTVGt21lMsHZSeeeMByTvDlQ=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230816082903-b48770f5e210 h1:GHPbV2bC+gmuO6/sG0Tm8oGal3KKSRlyE+zPscDjlA8=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230816082903-b48770f5e210/go.mod h1:vhsZxXE9tYJeYB5JR4hPhd6Pc/uPf7j1T8IJ7p9FdeM=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230816082903-b48770f5e210 h1:FLVOn4+OVbsKi2+YJX5kmD27/4dRu4FW7xCXFhzDO5s=


### PR DESCRIPTION
### Description

The Greenfield Testnet is expected to have a scheduled hardfork upgrade named `Veld` at block height 9581218. The current block generation speed forecasts this to occur around 2024/06/25 07:00:00 am +UTC

The Greenfield Mainnet is expected to have a scheduled hardfork upgrade named `Veld` at block height 9269910. The current block generation speed forecasts this to occur around 2024/07/08  07:00:00 am UTC

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...
