### PR TITLE
fix: initial val for min value comparison should be large enough

### DIFF
--- a/x/virtualgroup/keeper/grpc_query.go
+++ b/x/virtualgroup/keeper/grpc_query.go
@@ -232,6 +232,7 @@ func (k Keeper) QuerySpOptimalGlobalVirtualGroupFamily(goCtx context.Context, re
 			}
 		}
 	case types.Strategy_Minimal_Free_Store_Size:
+		freeStoreSize = math.MaxFloat64
 		for _, gvgfID := range stats.GlobalVirtualGroupFamilyIds {
 			gvgFamily, found := k.GetGVGFamily(ctx, gvgfID)
 			if !found {


### PR DESCRIPTION
### Description

initial val for min value comparison should be large enough

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...
