### PR TITLE
release: prepare for v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## V1.9.0
+This release introduces the Mongolian upgrade.
+
+Features:
+* [#639] https://github.com/bnb-chain/greenfield/pull/639 feat: Support msg to create policy by cross chain
+
+Fixes:
+* [#638] https://github.com/bnb-chain/greenfield/pull/638 fix: initial val for min value comparison should be large enough
+* [#640] https://github.com/bnb-chain/greenfield/pull/640 fix: broken links reroute from local repo to bnbchain docs
+
+Docs:
+* [#633] https://github.com/bnb-chain/greenfield/pull/633 docs: replace docs link
+
 ## V1.8.0
 This release introduces the Veld upgrade.
 

--- a/app/upgrade.go
+++ b/app/upgrade.go
@@ -292,7 +292,7 @@ func (app *App) registerMongolianUpgradeHandler() {
 	// Register the upgrade initializer
 	app.UpgradeKeeper.SetUpgradeInitializer(upgradetypes.Mongolian,
 		func() error {
-			app.Logger().Info("Init Veld upgrade")
+			app.Logger().Info("Init Mongolian upgrade")
 			return nil
 		})
 }

--- a/go.mod
+++ b/go.mod
@@ -176,7 +176,7 @@ replace (
 	github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v1.3.0
 	github.com/cometbft/cometbft-db => github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v1.8.1-0.20240711041516-7fd2f478ff35
+	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v1.9.0
 	github.com/cosmos/iavl => github.com/bnb-chain/greenfield-iavl v0.20.1
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	github.com/wercker/journalhook => github.com/wercker/journalhook v0.0.0-20230927020745-64542ffa4117

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,8 @@ github.com/bnb-chain/greenfield-cometbft v1.3.0 h1:v3nZ16ledTZGF5Csys7fTQGZcEV78
 github.com/bnb-chain/greenfield-cometbft v1.3.0/go.mod h1:0D+VPivZTeBldjtGGi9LKbBnKEO/RtMRJikie92LkYI=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1 h1:XcWulGacHVRiSCx90Q8Y//ajOrLNBQWR/KDB89dy3cU=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1/go.mod h1:ey1CiK4bYo1RBNJLRiVbYr5CMdSxci9S/AZRINLtppI=
-github.com/bnb-chain/greenfield-cosmos-sdk v1.8.1-0.20240711041516-7fd2f478ff35 h1:9VZdnAqCBFCGzNxzV7jnxqSpUwIDwH7UcUMl1nfCEY4=
-github.com/bnb-chain/greenfield-cosmos-sdk v1.8.1-0.20240711041516-7fd2f478ff35/go.mod h1:2bwmwdXYBISnQoMwgAcZTVGt21lMsHZSeeeMByTvDlQ=
+github.com/bnb-chain/greenfield-cosmos-sdk v1.9.0 h1:gYelZIgkLe0TEQeBSjuVAyzBvKKz5uAe1A1zhvF33Ws=
+github.com/bnb-chain/greenfield-cosmos-sdk v1.9.0/go.mod h1:2bwmwdXYBISnQoMwgAcZTVGt21lMsHZSeeeMByTvDlQ=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230816082903-b48770f5e210 h1:GHPbV2bC+gmuO6/sG0Tm8oGal3KKSRlyE+zPscDjlA8=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230816082903-b48770f5e210/go.mod h1:vhsZxXE9tYJeYB5JR4hPhd6Pc/uPf7j1T8IJ7p9FdeM=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230816082903-b48770f5e210 h1:FLVOn4+OVbsKi2+YJX5kmD27/4dRu4FW7xCXFhzDO5s=


### PR DESCRIPTION
### Description

The Greenfield Testnet is expected to have a scheduled hardfork upgrade named Mongolian
 at block height 10780238. The current block generation speed forecasts this to occur around 31 July 2024 07:00:00  UTC

The Greenfield Mainnet is expected to have a scheduled hardfork upgrade named Mongolian
 at block height 10314605. The current block generation speed forecasts this to occur around 08 Aug 2024 07:00:00 UTC
