### PR TITLE
feat: allow change GvgStakingPerBytes for gvg updateParams

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,6 +46,6 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: latest
+          version: v1.54
           skip-pkg-cache: true
           args: --timeout=99m

--- a/x/virtualgroup/keeper/msg_server.go
+++ b/x/virtualgroup/keeper/msg_server.go
@@ -36,8 +36,8 @@ func (k msgServer) UpdateParams(goCtx context.Context, req *types.MsgUpdateParam
 
 	// Some parameters cannot be modified
 	originParams := k.GetParams(ctx)
-	if !req.Params.GvgStakingPerBytes.Equal(originParams.GvgStakingPerBytes) || req.Params.DepositDenom != originParams.DepositDenom {
-		return nil, errors.ErrInvalidParameter.Wrapf("GvgStakingPerBytes and depositDenom are not allow to update, current: %v, %v, got: %v, %v", originParams.GvgStakingPerBytes, originParams.DepositDenom, req.Params.GvgStakingPerBytes, req.Params.DepositDenom)
+	if req.Params.DepositDenom != originParams.DepositDenom {
+		return nil, errors.ErrInvalidParameter.Wrapf("DepositDenom is not allow to update, current: %v, got: %v", originParams.DepositDenom, req.Params.DepositDenom)
 	}
 
 	if err := k.SetParams(ctx, req.Params); err != nil {


### PR DESCRIPTION
### Description
Update the rule of gvg updateParams to allow GvgStakingPerBytes change.

### Rationale
We want to reduce the cost of SP staking when create and expand size of gvg.

### Example
N/A

### Changes

Notable changes: 
* gvg updateParams allowance check

### Potential Impacts
* gvg updateParams when send in proposal
