### PR TITLE
release: prepare for v1.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## V1.10.1
+This release contains 1 new feature
+
+Features:
+* [#655] https://github.com/bnb-chain/greenfield/pull/655 feat: allow change GvgStakingPerBytes for gvg updateParams
+
 ## V1.10.0
 This release introduces the Savanna upgrade.
 


### PR DESCRIPTION
This release contains 1 new feature.

Features:
https://github.com/bnb-chain/greenfield/pull/655 feat: allow change GvgStakingPerBytes for gvg updateParams