### PR TITLE
feat: update km

### DIFF
--- a/sdk/keys/key_manager.go
+++ b/sdk/keys/key_manager.go
@@ -24,8 +24,8 @@ type KeyManager interface {
 }
 
 type keyManager struct {
-	privKey  ctypes.PrivKey
-	addr     types.AccAddress
+	privKey ctypes.PrivKey
+	addr    types.AccAddress
 }
 
 // TODO: NewKeyStoreKeyManager to be implemented
@@ -155,5 +155,5 @@ func (km *keyManager) String() string {
 	}
 	return "KeyManager{uninitialized}"
 }
-func (km *keyManager) ProtoMessage()  {}
-func (km *keyManager) Reset()         { *km = keyManager{} }
+func (km *keyManager) ProtoMessage() {}
+func (km *keyManager) Reset()        { *km = keyManager{} }

--- a/sdk/keys/key_manager.go
+++ b/sdk/keys/key_manager.go
@@ -25,7 +25,6 @@ type KeyManager interface {
 
 type keyManager struct {
 	privKey  ctypes.PrivKey
-	mnemonic string
 	addr     types.AccAddress
 }
 
@@ -88,7 +87,6 @@ func (km *keyManager) recoveryFromMnemonic(mnemonic, keyPath string) error {
 	}
 	priKey := hd.EthSecp256k1.Generate()(derivedPriv[:]).(*ethsecp256k1.PrivKey)
 	km.privKey = priKey
-	km.mnemonic = mnemonic
 	km.addr = types.AccAddress(km.privKey.PubKey().Address())
 	return nil
 }
@@ -123,7 +121,6 @@ func (km *keyManager) recoveryBlsFromMnemonic(mnemonic, keyPath string) error {
 
 	priKey := hd.EthBLS.Generate()(derivedPriv)
 	km.privKey = priKey
-	km.mnemonic = mnemonic
 	km.addr = types.AccAddress(km.privKey.PubKey().Address())
 	return nil
 }
@@ -152,6 +149,11 @@ func (km *keyManager) GetAddr() types.AccAddress {
 	return km.addr
 }
 
-func (km *keyManager) String() string { return km.mnemonic }
+func (km *keyManager) String() string {
+	if km.addr != nil {
+		return fmt.Sprintf("KeyManager{addr:%s}", km.addr.String())
+	}
+	return "KeyManager{uninitialized}"
+}
 func (km *keyManager) ProtoMessage()  {}
 func (km *keyManager) Reset()         { *km = keyManager{} }

--- a/sdk/keys/key_manager_test.go
+++ b/sdk/keys/key_manager_test.go
@@ -2,6 +2,7 @@ package keys
 
 import (
 	"encoding/hex"
+	"fmt"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/v5/crypto/bls"
@@ -33,4 +34,16 @@ func TestCreateBlsKeyManagerFromPrivateKeyHex(t *testing.T) {
 	km, err := NewBlsPrivateKeyManager(hex.EncodeToString(blsPrivKey.Marshal()))
 	assert.NoError(t, err)
 	assert.Equal(t, blsPubKey, hex.EncodeToString(km.PubKey().Bytes()))
+}
+
+func TestStringDoesNotLeakMnemonic(t *testing.T) {
+	mnemonic := "dragon shy author wave swamp avoid lens hen please series heavy squeeze alley castle crazy action peasant green vague camp mirror amount person legal"
+	km, err := NewMnemonicKeyManager(mnemonic)
+	assert.NoError(t, err)
+	assert.NotContains(t, fmt.Sprintf("%v", km), mnemonic)
+
+	blsMnemonic := "dragon shy author wave swamp avoid lens hen please series heavy squeeze alley castle crazy action peasant green vague camp mirror amount person legal"
+	blsKm, err := NewBlsMnemonicKeyManager(blsMnemonic)
+	assert.NoError(t, err)
+	assert.NotContains(t, fmt.Sprintf("%v", blsKm), blsMnemonic)
 }


### PR DESCRIPTION
### Description

Remove sensitive info from keyManager and make String() return a non-sensitive representation.

### Rationale

keyManager.String() previously returned raw sensitive info, so routine formatting/logging (fmt, %v, logger fields) could leak them.
This was inconsistent with the existing security intent (Bytes() blocks key extraction) and created unnecessary exposure risk.
Since mnemonic data is not needed after key derivation, this PR removes mnemonic storage and updates String() to a safe output (address/uninitialized).
A regression test is added to ensure fmt.Sprintf("%v", km) does not contain mnemonic content.

### Changes

Notable changes: 
* key_manager.go
