### PR TITLE
fix 816

### DIFF
--- a/x/challenge/keeper/challenge.go
+++ b/x/challenge/keeper/challenge.go
@@ -56,6 +56,12 @@ func (k Keeper) RemoveChallengeUntil(ctx sdk.Context, height uint64) {
 	}
 }
 
+// RemoveChallenge removes a specific challenge from the store
+func (k Keeper) RemoveChallenge(ctx sdk.Context, challengeId uint64) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.ChallengeKeyPrefix)
+	store.Delete(getChallengeKeyBytes(challengeId))
+}
+
 // ExistsChallenge check whether there exists ongoing challenge for an id
 func (k Keeper) ExistsChallenge(ctx sdk.Context, challengeId uint64) bool {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.ChallengeKeyPrefix)

--- a/x/challenge/keeper/msg_server_attest.go
+++ b/x/challenge/keeper/msg_server_attest.go
@@ -136,6 +136,8 @@ func (k msgServer) Attest(goCtx context.Context, msg *types.MsgAttest) (*types.M
 		if err != nil {
 			return nil, err
 		}
+		// prevent heartbeat attestation replay (SRC-816)
+		k.RemoveChallenge(ctx, msg.ChallengeId)
 	}
 	k.AppendAttestedChallenge(ctx, &types.AttestedChallenge{
 		Id:     msg.ChallengeId,


### PR DESCRIPTION
#### Description
fix: prevent heartbeat attestation replay by consuming challenge after reward