### PR TITLE
fix: restrict DiscontinueObject authorization to current family prima…

### DIFF
--- a/app/upgrade.go
+++ b/app/upgrade.go
@@ -43,6 +43,7 @@ func (app *App) RegisterUpgradeHandlers(chainID string, serverCfg *serverconfig.
 	app.registerTaigaUpgradeHandler()
 	app.registerSteppeUpgradeHandler()
 	app.registerCerradoUpgradeHandler()
+	app.registerSahelUpgradeHandler()
 	return nil
 }
 
@@ -392,6 +393,20 @@ func (app *App) registerSteppeUpgradeHandler() {
 	app.UpgradeKeeper.SetUpgradeInitializer(upgradetypes.Steppe,
 		func() error {
 			app.Logger().Info("Init Steppe upgrade")
+			return nil
+		})
+}
+
+func (app *App) registerSahelUpgradeHandler() {
+	app.UpgradeKeeper.SetUpgradeHandler(upgradetypes.Sahel,
+		func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+			app.Logger().Info("upgrade to ", plan.Name)
+			return app.mm.RunMigrations(ctx, app.configurator, fromVM)
+		})
+
+	app.UpgradeKeeper.SetUpgradeInitializer(upgradetypes.Sahel,
+		func() error {
+			app.Logger().Info("Init Sahel upgrade")
 			return nil
 		})
 }

--- a/go.mod
+++ b/go.mod
@@ -183,7 +183,7 @@ replace (
 	github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v1.3.2-0.20250421115205-d0c58e3042cf
 	github.com/cometbft/cometbft-db => github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v1.10.6-dev
+	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v1.10.6-dev.0.20260715024147-65000c3f0290
 	github.com/cosmos/iavl => github.com/bnb-chain/greenfield-iavl v0.20.1
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	github.com/wercker/journalhook => github.com/wercker/journalhook v0.0.0-20230927020745-64542ffa4117

--- a/go.mod
+++ b/go.mod
@@ -183,7 +183,7 @@ replace (
 	github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v1.3.2-0.20250421115205-d0c58e3042cf
 	github.com/cometbft/cometbft-db => github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v1.10.6-dev.0.20260715024147-65000c3f0290
+	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v1.10.6-dev.0.20260715064536-e199ebeaec47
 	github.com/cosmos/iavl => github.com/bnb-chain/greenfield-iavl v0.20.1
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	github.com/wercker/journalhook => github.com/wercker/journalhook v0.0.0-20230927020745-64542ffa4117

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,8 @@ github.com/bnb-chain/greenfield-cometbft v1.3.2-0.20250421115205-d0c58e3042cf h1
 github.com/bnb-chain/greenfield-cometbft v1.3.2-0.20250421115205-d0c58e3042cf/go.mod h1:KHJjaV8GR/HLVUNpA8l+ro8clFSlwEbyNZIujf8c27w=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1 h1:XcWulGacHVRiSCx90Q8Y//ajOrLNBQWR/KDB89dy3cU=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1/go.mod h1:ey1CiK4bYo1RBNJLRiVbYr5CMdSxci9S/AZRINLtppI=
-github.com/bnb-chain/greenfield-cosmos-sdk v1.10.6-dev.0.20260715024147-65000c3f0290 h1:NAJER/ZRtW04GaIXCMIO1iwtPul4/fNuh+Ch/lSS/sQ=
-github.com/bnb-chain/greenfield-cosmos-sdk v1.10.6-dev.0.20260715024147-65000c3f0290/go.mod h1:3yqFQxEw05CP1uCyKZtUJjP5N5E+OYALrfJnSWLTE6c=
+github.com/bnb-chain/greenfield-cosmos-sdk v1.10.6-dev.0.20260715064536-e199ebeaec47 h1:+sIm87t8e1tM7fCiVZ+UH9HU826oAkqq92kukA06ErI=
+github.com/bnb-chain/greenfield-cosmos-sdk v1.10.6-dev.0.20260715064536-e199ebeaec47/go.mod h1:3yqFQxEw05CP1uCyKZtUJjP5N5E+OYALrfJnSWLTE6c=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20250424012533-3644b91a4a5c h1:+kWAQ4r5KXkReB7IE9Z91mtOUNeIKG0KRjC/v7kuxP0=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20250424012533-3644b91a4a5c/go.mod h1:YzvJKV9ZaLfB0Bt5NiTId53lhMUFDmeBJpFddWNoDeQ=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20250424012533-3644b91a4a5c h1:0LTfgCXv6gk3PubhFMQwRHgo510hxeyacOHuv9ADebA=

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,8 @@ github.com/bnb-chain/greenfield-cometbft v1.3.2-0.20250421115205-d0c58e3042cf h1
 github.com/bnb-chain/greenfield-cometbft v1.3.2-0.20250421115205-d0c58e3042cf/go.mod h1:KHJjaV8GR/HLVUNpA8l+ro8clFSlwEbyNZIujf8c27w=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1 h1:XcWulGacHVRiSCx90Q8Y//ajOrLNBQWR/KDB89dy3cU=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1/go.mod h1:ey1CiK4bYo1RBNJLRiVbYr5CMdSxci9S/AZRINLtppI=
-github.com/bnb-chain/greenfield-cosmos-sdk v1.10.6-dev h1:qlahVmlkiyDuveEPfDsStuxdpFmBX7YR5G4mk1BcNdM=
-github.com/bnb-chain/greenfield-cosmos-sdk v1.10.6-dev/go.mod h1:3yqFQxEw05CP1uCyKZtUJjP5N5E+OYALrfJnSWLTE6c=
+github.com/bnb-chain/greenfield-cosmos-sdk v1.10.6-dev.0.20260715024147-65000c3f0290 h1:NAJER/ZRtW04GaIXCMIO1iwtPul4/fNuh+Ch/lSS/sQ=
+github.com/bnb-chain/greenfield-cosmos-sdk v1.10.6-dev.0.20260715024147-65000c3f0290/go.mod h1:3yqFQxEw05CP1uCyKZtUJjP5N5E+OYALrfJnSWLTE6c=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20250424012533-3644b91a4a5c h1:+kWAQ4r5KXkReB7IE9Z91mtOUNeIKG0KRjC/v7kuxP0=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20250424012533-3644b91a4a5c/go.mod h1:YzvJKV9ZaLfB0Bt5NiTId53lhMUFDmeBJpFddWNoDeQ=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20250424012533-3644b91a4a5c h1:0LTfgCXv6gk3PubhFMQwRHgo510hxeyacOHuv9ADebA=

--- a/x/challenge/keeper/challenge.go
+++ b/x/challenge/keeper/challenge.go
@@ -56,6 +56,12 @@ func (k Keeper) RemoveChallengeUntil(ctx sdk.Context, height uint64) {
 	}
 }
 
+// RemoveChallenge removes a specific challenge from the store
+func (k Keeper) RemoveChallenge(ctx sdk.Context, challengeId uint64) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.ChallengeKeyPrefix)
+	store.Delete(getChallengeKeyBytes(challengeId))
+}
+
 // ExistsChallenge check whether there exists ongoing challenge for an id
 func (k Keeper) ExistsChallenge(ctx sdk.Context, challengeId uint64) bool {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.ChallengeKeyPrefix)

--- a/x/challenge/keeper/msg_server_attest.go
+++ b/x/challenge/keeper/msg_server_attest.go
@@ -136,6 +136,8 @@ func (k msgServer) Attest(goCtx context.Context, msg *types.MsgAttest) (*types.M
 		if err != nil {
 			return nil, err
 		}
+		// prevent heartbeat attestation replay (SRC-816)
+		k.RemoveChallenge(ctx, msg.ChallengeId)
 	}
 	k.AppendAttestedChallenge(ctx, &types.AttestedChallenge{
 		Id:     msg.ChallengeId,

--- a/x/challenge/keeper/msg_server_attest.go
+++ b/x/challenge/keeper/msg_server_attest.go
@@ -136,8 +136,9 @@ func (k msgServer) Attest(goCtx context.Context, msg *types.MsgAttest) (*types.M
 		if err != nil {
 			return nil, err
 		}
-		// prevent heartbeat attestation replay (SRC-816)
-		k.RemoveChallenge(ctx, msg.ChallengeId)
+		if ctx.IsUpgraded(upgradetypes.Sahel) {
+			k.RemoveChallenge(ctx, msg.ChallengeId)
+		}
 	}
 	k.AppendAttestedChallenge(ctx, &types.AttestedChallenge{
 		Id:     msg.ChallengeId,

--- a/x/payment/keeper/stream_record.go
+++ b/x/payment/keeper/stream_record.go
@@ -138,6 +138,9 @@ func (k Keeper) UpdateFrozenStreamRecord(ctx sdk.Context, streamRecord *types.St
 	if !change.FrozenRateChange.IsZero() {
 		streamRecord.FrozenNetflowRate = streamRecord.FrozenNetflowRate.Add(change.FrozenRateChange)
 	}
+	if !change.StaticBalanceChange.IsZero() {
+		streamRecord.StaticBalance = streamRecord.StaticBalance.Add(change.StaticBalanceChange)
+	}
 	return nil
 }
 

--- a/x/payment/keeper/stream_record.go
+++ b/x/payment/keeper/stream_record.go
@@ -138,8 +138,10 @@ func (k Keeper) UpdateFrozenStreamRecord(ctx sdk.Context, streamRecord *types.St
 	if !change.FrozenRateChange.IsZero() {
 		streamRecord.FrozenNetflowRate = streamRecord.FrozenNetflowRate.Add(change.FrozenRateChange)
 	}
-	if !change.StaticBalanceChange.IsZero() {
-		streamRecord.StaticBalance = streamRecord.StaticBalance.Add(change.StaticBalanceChange)
+	if ctx.IsUpgraded(upgradetypes.Sahel) {
+		if !change.StaticBalanceChange.IsZero() {
+			streamRecord.StaticBalance = streamRecord.StaticBalance.Add(change.StaticBalanceChange)
+		}
 	}
 	return nil
 }

--- a/x/storage/keeper/keeper.go
+++ b/x/storage/keeper/keeper.go
@@ -1236,19 +1236,21 @@ func (k Keeper) CopyObject(
 			operator.String(), srcObjectInfo.BucketName, srcObjectInfo.ObjectName)
 	}
 
-	// check destination bucket write permission
-	verifyOpts := &permtypes.VerifyOptions{WantedSize: &srcObjectInfo.PayloadSize}
-	effect = k.VerifyBucketPermission(ctx, dstBucketInfo, operator, permtypes.ACTION_CREATE_OBJECT, verifyOpts)
-	if effect != permtypes.EFFECT_ALLOW {
-		return sdkmath.ZeroUint(), types.ErrAccessDenied.Wrapf("The operator("+
-			"%s) has no CreateObject permission of the destination bucket(%s)",
-			operator.String(), dstBucketInfo.BucketName)
-	}
+	if ctx.IsUpgraded(upgradetypes.Sahel) {
+		// check destination bucket write permission
+		verifyOpts := &permtypes.VerifyOptions{WantedSize: &srcObjectInfo.PayloadSize}
+		effect = k.VerifyBucketPermission(ctx, dstBucketInfo, operator, permtypes.ACTION_CREATE_OBJECT, verifyOpts)
+		if effect != permtypes.EFFECT_ALLOW {
+			return sdkmath.ZeroUint(), types.ErrAccessDenied.Wrapf("The operator("+
+				"%s) has no CreateObject permission of the destination bucket(%s)",
+				operator.String(), dstBucketInfo.BucketName)
+		}
 
-	// check destination object name does not already exist
-	dstObjectKey := types.GetObjectKey(dstBucketName, dstObjectName)
-	if store.Has(dstObjectKey) {
-		return sdkmath.ZeroUint(), types.ErrObjectAlreadyExists
+		// check destination object name does not already exist
+		dstObjectKey := types.GetObjectKey(dstBucketName, dstObjectName)
+		if store.Has(dstObjectKey) {
+			return sdkmath.ZeroUint(), types.ErrObjectAlreadyExists
+		}
 	}
 
 	if !ctx.IsUpgraded(upgradetypes.Serengeti) {
@@ -2272,8 +2274,10 @@ func (k Keeper) CompleteMigrateBucket(ctx sdk.Context, operator sdk.AccAddress, 
 	if !found {
 		return virtualgroupmoduletypes.ErrGVGFamilyNotExist
 	}
-	if finalFamily.PrimarySpId != dstSP.Id {
-		return types.ErrMigrationBucketFailed.Wrapf("final family primary SP %d does not match destination SP %d", finalFamily.PrimarySpId, dstSP.Id)
+	if ctx.IsUpgraded(upgradetypes.Sahel) {
+		if finalFamily.PrimarySpId != dstSP.Id {
+			return types.ErrMigrationBucketFailed.Wrapf("final family primary SP %d does not match destination SP %d", finalFamily.PrimarySpId, dstSP.Id)
+		}
 	}
 
 	srcGvgFamily, found := k.virtualGroupKeeper.GetGVGFamily(ctx, bucketInfo.GlobalVirtualGroupFamilyId)

--- a/x/storage/keeper/keeper.go
+++ b/x/storage/keeper/keeper.go
@@ -2253,9 +2253,12 @@ func (k Keeper) CompleteMigrateBucket(ctx sdk.Context, operator sdk.AccAddress, 
 		return types.ErrMigrationBucketFailed.Wrapf("dst sp info not match")
 	}
 
-	_, found = k.virtualGroupKeeper.GetGVGFamily(ctx, gvgFamilyID)
+	finalFamily, found := k.virtualGroupKeeper.GetGVGFamily(ctx, gvgFamilyID)
 	if !found {
 		return virtualgroupmoduletypes.ErrGVGFamilyNotExist
+	}
+	if finalFamily.PrimarySpId != dstSP.Id {
+		return types.ErrMigrationBucketFailed.Wrapf("final family primary SP %d does not match destination SP %d", finalFamily.PrimarySpId, dstSP.Id)
 	}
 
 	srcGvgFamily, found := k.virtualGroupKeeper.GetGVGFamily(ctx, bucketInfo.GlobalVirtualGroupFamilyId)
@@ -2290,7 +2293,7 @@ func (k Keeper) CompleteMigrateBucket(ctx sdk.Context, operator sdk.AccAddress, 
 	}
 
 	// rebinding gvg and lvg
-	err = k.RebindingVirtualGroup(ctx, bucketInfo, internalBucketInfo, gvgMappings)
+	err = k.RebindingVirtualGroup(ctx, bucketInfo, internalBucketInfo, gvgMappings, gvgFamilyID, dstSP.Id)
 	if err != nil {
 		return types.ErrMigrationBucketFailed.Wrapf("err: %s", err)
 	}

--- a/x/storage/keeper/keeper.go
+++ b/x/storage/keeper/keeper.go
@@ -1413,6 +1413,16 @@ func (k Keeper) DiscontinueObject(ctx sdk.Context, operator sdk.AccAddress, buck
 		if !ctx.IsUpgraded(upgradetypes.Hulunbeier) {
 			return errors.Wrapf(types.ErrAccessDenied, "only primary sp is allowed to do discontinue objects")
 		}
+		if ctx.IsUpgraded(upgradetypes.Sahel) {
+			// SECURITY (SRC-947): a pending swap-in reservation must NOT grant discontinue authority.
+			// Any in-service SP can ReserveSwapIn against an exiting primary SP with no deposit and no
+			// migration progress, and SwapInInfo carries no "completed" marker; the Hulunbeier branch
+			// below treated a bare reservation as authorization, letting a malicious successor
+			// permanently DiscontinueObject arbitrary objects in the target family. From Sahel on,
+			// only the current on-chain family primary SP may discontinue; a successor earns this right
+			// only after CompleteSwapIn makes it the family primary (covered by the equality above).
+			return errors.Wrapf(types.ErrAccessDenied, "only the current primary sp of the bucket's family is allowed to discontinue objects")
+		}
 		swapInInfo, found := k.virtualGroupKeeper.GetSwapInInfo(ctx, bucketInfo.GlobalVirtualGroupFamilyId, virtualgroupmoduletypes.NoSpecifiedGVGId)
 		if !found || swapInInfo.TargetSpId != spInState.Id || swapInInfo.SuccessorSpId != sp.Id {
 			return errors.Wrapf(types.ErrAccessDenied, "the sp is not allowed to do discontinue objects")

--- a/x/storage/keeper/keeper.go
+++ b/x/storage/keeper/keeper.go
@@ -1236,6 +1236,21 @@ func (k Keeper) CopyObject(
 			operator.String(), srcObjectInfo.BucketName, srcObjectInfo.ObjectName)
 	}
 
+	// check destination bucket write permission
+	verifyOpts := &permtypes.VerifyOptions{WantedSize: &srcObjectInfo.PayloadSize}
+	effect = k.VerifyBucketPermission(ctx, dstBucketInfo, operator, permtypes.ACTION_CREATE_OBJECT, verifyOpts)
+	if effect != permtypes.EFFECT_ALLOW {
+		return sdkmath.ZeroUint(), types.ErrAccessDenied.Wrapf("The operator("+
+			"%s) has no CreateObject permission of the destination bucket(%s)",
+			operator.String(), dstBucketInfo.BucketName)
+	}
+
+	// check destination object name does not already exist
+	dstObjectKey := types.GetObjectKey(dstBucketName, dstObjectName)
+	if store.Has(dstObjectKey) {
+		return sdkmath.ZeroUint(), types.ErrObjectAlreadyExists
+	}
+
 	if !ctx.IsUpgraded(upgradetypes.Serengeti) {
 		if opts.PrimarySpApproval.ExpiredHeight < uint64(ctx.BlockHeight()) {
 			return sdkmath.ZeroUint(), errors.Wrapf(types.ErrInvalidApproval, "The approval of sp is expired.")

--- a/x/storage/keeper/keeper_test.go
+++ b/x/storage/keeper/keeper_test.go
@@ -1,8 +1,53 @@
 package keeper_test
 
 import (
+	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	"github.com/golang/mock/gomock"
+
 	"github.com/bnb-chain/greenfield/testutil/sample"
+	sptypes "github.com/bnb-chain/greenfield/x/sp/types"
+	"github.com/bnb-chain/greenfield/x/storage/types"
+	vgtypes "github.com/bnb-chain/greenfield/x/virtualgroup/types"
 )
+
+// TestDiscontinueObjectRejectsPendingSwapInSuccessor is a regression test for SRC-947:
+// from the Sahel upgrade on, a pending swap-in reservation must NOT grant discontinue
+// authority. Only the current on-chain family primary SP may discontinue objects.
+func (s *TestSuite) TestDiscontinueObjectRejectsPendingSwapInSuccessor() {
+	// Sahel-gated fix; Hulunbeier gates the vulnerable reservation-as-authorization branch.
+	ctx := sdk.NewContext(s.ctx.MultiStore(), s.ctx.BlockHeader(), false, func(_ sdk.Context, name string) bool {
+		return name == upgradetypes.Hulunbeier || name == upgradetypes.Sahel
+	}, s.ctx.Logger())
+
+	// Attacker SP: in-service, resolves from the gc address, but is NOT the family primary.
+	gcAddr := sample.RandAccAddress()
+	attackerSP := &sptypes.StorageProvider{Id: 200, Status: sptypes.STATUS_IN_SERVICE, GcAddress: gcAddr.String()}
+	s.spKeeper.EXPECT().GetStorageProviderByGcAddr(gomock.Any(), gomock.Any()).Return(attackerSP, true).AnyTimes()
+
+	bucketInfo := &types.BucketInfo{
+		Owner:                      sample.RandAccAddress().String(),
+		BucketName:                 "src947-bucket",
+		Id:                         sdkmath.NewUint(1),
+		BucketStatus:               types.BUCKET_STATUS_CREATED,
+		GlobalVirtualGroupFamilyId: 5,
+	}
+	s.storageKeeper.StoreBucketInfo(s.ctx, bucketInfo)
+
+	// The family's real primary SP is a different SP (Id 100).
+	s.virtualGroupKeeper.EXPECT().GetGVGFamily(gomock.Any(), bucketInfo.GlobalVirtualGroupFamilyId).
+		Return(&vgtypes.GlobalVirtualGroupFamily{Id: 5, PrimarySpId: 100}, true).AnyTimes()
+	s.spKeeper.EXPECT().MustGetStorageProvider(gomock.Any(), uint32(100)).
+		Return(&sptypes.StorageProvider{Id: 100, Status: sptypes.STATUS_IN_SERVICE}).AnyTimes()
+
+	// Even with a matching pending swap-in reservation, the non-primary successor must be denied.
+	s.virtualGroupKeeper.EXPECT().GetSwapInInfo(gomock.Any(), bucketInfo.GlobalVirtualGroupFamilyId, vgtypes.NoSpecifiedGVGId).
+		Return(&vgtypes.SwapInInfo{TargetSpId: 100, SuccessorSpId: attackerSP.Id}, true).AnyTimes()
+
+	err := s.storageKeeper.DiscontinueObject(ctx, gcAddr, bucketInfo.BucketName, []sdkmath.Uint{sdkmath.NewUint(1)}, "attack")
+	s.Require().ErrorIs(err, types.ErrAccessDenied)
+}
 
 func (s *TestSuite) TestClearDiscontinueBucketCount() {
 	acc1 := sample.RandAccAddress()

--- a/x/storage/keeper/virtualgroup.go
+++ b/x/storage/keeper/virtualgroup.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	"github.com/prysmaticlabs/prysm/v5/crypto/bls"
 
 	gnfdtypes "github.com/bnb-chain/greenfield/types"
@@ -72,11 +73,13 @@ func (k Keeper) RebindingVirtualGroup(ctx sdk.Context, bucketInfo *types.BucketI
 		if !found {
 			return types.ErrVirtualGroupOperateFailed.Wrapf("dst global virtual group not found in blockchain state. ID: %d", dstGVGID)
 		}
-		if dstGVG.FamilyId != gvgFamilyID {
-			return types.ErrMigrationBucketFailed.Wrapf("destination GVG %d belongs to family %d, expected %d", dstGVGID, dstGVG.FamilyId, gvgFamilyID)
-		}
-		if dstGVG.PrimarySpId != dstSPId {
-			return types.ErrMigrationBucketFailed.Wrapf("destination GVG %d primary SP is %d, expected %d", dstGVGID, dstGVG.PrimarySpId, dstSPId)
+		if ctx.IsUpgraded(upgradetypes.Sahel) {
+			if dstGVG.FamilyId != gvgFamilyID {
+				return types.ErrMigrationBucketFailed.Wrapf("destination GVG %d belongs to family %d, expected %d", dstGVGID, dstGVG.FamilyId, gvgFamilyID)
+			}
+			if dstGVG.PrimarySpId != dstSPId {
+				return types.ErrMigrationBucketFailed.Wrapf("destination GVG %d primary SP is %d, expected %d", dstGVGID, dstGVG.PrimarySpId, dstSPId)
+			}
 		}
 
 		srcGVG, found := k.virtualGroupKeeper.GetGVG(ctx, lvg.GlobalVirtualGroupId)

--- a/x/storage/keeper/virtualgroup.go
+++ b/x/storage/keeper/virtualgroup.go
@@ -56,7 +56,7 @@ func (k Keeper) DeleteObjectFromVirtualGroup(ctx sdk.Context, bucketInfo *types.
 	return nil
 }
 
-func (k Keeper) RebindingVirtualGroup(ctx sdk.Context, bucketInfo *types.BucketInfo, internalBucketInfo *types.InternalBucketInfo, gvgMappings []*types.GVGMapping) error {
+func (k Keeper) RebindingVirtualGroup(ctx sdk.Context, bucketInfo *types.BucketInfo, internalBucketInfo *types.InternalBucketInfo, gvgMappings []*types.GVGMapping, gvgFamilyID uint32, dstSPId uint32) error {
 	gvgsMap := make(map[uint32]uint32)
 	for _, mapping := range gvgMappings {
 		gvgsMap[mapping.SrcGlobalVirtualGroupId] = mapping.DstGlobalVirtualGroupId
@@ -71,6 +71,12 @@ func (k Keeper) RebindingVirtualGroup(ctx sdk.Context, bucketInfo *types.BucketI
 		dstGVG, found := k.virtualGroupKeeper.GetGVG(ctx, dstGVGID)
 		if !found {
 			return types.ErrVirtualGroupOperateFailed.Wrapf("dst global virtual group not found in blockchain state. ID: %d", dstGVGID)
+		}
+		if dstGVG.FamilyId != gvgFamilyID {
+			return types.ErrMigrationBucketFailed.Wrapf("destination GVG %d belongs to family %d, expected %d", dstGVGID, dstGVG.FamilyId, gvgFamilyID)
+		}
+		if dstGVG.PrimarySpId != dstSPId {
+			return types.ErrMigrationBucketFailed.Wrapf("destination GVG %d primary SP is %d, expected %d", dstGVGID, dstGVG.PrimarySpId, dstSPId)
 		}
 
 		srcGVG, found := k.virtualGroupKeeper.GetGVG(ctx, lvg.GlobalVirtualGroupId)

--- a/x/virtualgroup/keeper/msg_server.go
+++ b/x/virtualgroup/keeper/msg_server.go
@@ -344,8 +344,7 @@ func (k msgServer) SwapOut(goCtx context.Context, msg *types.MsgSwapOut) (*types
 		return nil, err
 	}
 
-	// TODO: replace upgradetypes.Cerrado with the next hardfork constant once defined in greenfield-cosmos-sdk
-	if ctx.IsUpgraded(upgradetypes.Cerrado) {
+	if ctx.IsUpgraded(upgradetypes.Sahel) {
 		if msg.GlobalVirtualGroupFamilyId != types.NoSpecifiedFamilyId {
 			family, found := k.GetGVGFamily(ctx, msg.GlobalVirtualGroupFamilyId)
 			if !found {

--- a/x/virtualgroup/keeper/msg_server.go
+++ b/x/virtualgroup/keeper/msg_server.go
@@ -344,6 +344,29 @@ func (k msgServer) SwapOut(goCtx context.Context, msg *types.MsgSwapOut) (*types
 		return nil, err
 	}
 
+	// TODO: replace upgradetypes.Cerrado with the next hardfork constant once defined in greenfield-cosmos-sdk
+	if ctx.IsUpgraded(upgradetypes.Cerrado) {
+		if msg.GlobalVirtualGroupFamilyId != types.NoSpecifiedFamilyId {
+			family, found := k.GetGVGFamily(ctx, msg.GlobalVirtualGroupFamilyId)
+			if !found {
+				return nil, types.ErrGVGFamilyNotExist
+			}
+			if family.PrimarySpId != sp.Id {
+				return nil, types.ErrSwapOutFailed.Wrapf("sp (ID: %d) does not own family (ID: %d)", sp.Id, msg.GlobalVirtualGroupFamilyId)
+			}
+		} else {
+			for _, gvgID := range msg.GlobalVirtualGroupIds {
+				gvg, found := k.GetGVG(ctx, gvgID)
+				if !found {
+					return nil, types.ErrGVGNotExist
+				}
+				if !gvg.ContainsSecondarySP(sp.Id) {
+					return nil, types.ErrSwapOutFailed.Wrapf("sp (ID: %d) is not a secondary SP of GVG (ID: %d)", sp.Id, gvgID)
+				}
+			}
+		}
+	}
+
 	err = k.SetSwapOutInfo(ctx, msg.GlobalVirtualGroupFamilyId, msg.GlobalVirtualGroupIds, sp.Id, successorSP.Id)
 	if err != nil {
 		return nil, err

--- a/x/virtualgroup/types/types.go
+++ b/x/virtualgroup/types/types.go
@@ -41,6 +41,15 @@ func (f *GlobalVirtualGroupFamily) MustRemoveGVG(gvgID uint32) {
 	}
 }
 
+func (g *GlobalVirtualGroup) ContainsSecondarySP(spID uint32) bool {
+	for _, id := range g.SecondarySpIds {
+		if id == spID {
+			return true
+		}
+	}
+	return false
+}
+
 func (g *GlobalVirtualGroupsBindingOnBucket) AppendGVGAndLVG(gvgID, lvgID uint32) {
 	g.GlobalVirtualGroupIds = append(g.GlobalVirtualGroupIds, gvgID)
 	g.LocalVirtualGroupIds = append(g.LocalVirtualGroupIds, lvgID)


### PR DESCRIPTION

### Description

## Summary

`DiscontinueObject` treats a **pending swap-in reservation** as authorization: any in-service SP
that has called `ReserveSwapIn` against an exiting primary SP is allowed to discontinue objects in
the target family, without having completed the migration or become the family primary. Because
`ReserveSwapIn` requires no deposit and `SwapInInfo` carries no "completed" marker, a malicious but
otherwise ordinary registered SP can, whenever any primary SP is exiting, permanently delete
arbitrary users' objects in that family. (SRC-947)


### Rationale

Risk (SRC-947): Unauthorized, irreversible destruction of arbitrary user data.

Any registered, in-service storage provider can permanently delete other users' objects whenever some primary SP is in an exiting state, by abusing the discontinue authorization:

Trigger — The attacker SP calls ReserveSwapIn against a family whose primary SP is GRACEFUL_EXITING/FORCED_EXITING. This is permissionless among SPs and requires no deposit.
Abuse — With that bare reservation, the attacker immediately calls DiscontinueObject on arbitrary CREATED/SEALED objects in the target family. The chain accepts it because it treats the pending reservation as authorization.
Destruction — Discontinued objects enter the deletion queue and are permanently removed by end-block ForceDeleteObject after DiscontinueConfirmPeriod (default 7 days). DiscontinueObjectMax defaults to MaxUint64, so the volume is effectively unbounded, and the bucket owner has no way to cancel or recover a discontinued object.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...
